### PR TITLE
feat(ui): Implement dynamic value dropdowns in Rule Engine

### DIFF
--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -287,6 +287,26 @@ def create_packing_list_report(analysis_df, report_config):
         return False, error_message
 
 
+def get_unique_column_values(df, column_name):
+    """Extracts unique, sorted, non-null values from a DataFrame column.
+
+    Args:
+        df (pd.DataFrame): The DataFrame to extract values from.
+        column_name (str): The name of the column to get unique values from.
+
+    Returns:
+        list[str]: A sorted list of unique string-converted values, or an
+                   empty list if the column doesn't exist or an error occurs.
+    """
+    if df.empty or column_name not in df.columns:
+        return []
+    try:
+        unique_values = df[column_name].dropna().unique().tolist()
+        return sorted([str(v) for v in unique_values])
+    except Exception:
+        return []
+
+
 def create_stock_export_report(analysis_df, report_config, templates_path, output_path):
     """Generates a stock export report from a template.
 


### PR DESCRIPTION
Refactored the Rule Engine UI in the settings window to be more intuitive and less error-prone. Replaced the manual text input for condition values with dynamic, data-aware QComboBoxes.

Key changes:
- In `gui/settings_window_pyside.py`:
  - Modified `add_condition_row` to support dynamic value widgets.
  - Added a new handler, `_on_rule_condition_changed`, to create a QComboBox populated with unique values from the selected column when the operator is 'equals' or 'does not equal'.
  - The UI falls back to a QLineEdit for other operators like 'contains'.
  - The value widget is hidden for operators like 'is_empty'.
  - Updated `save_settings` to correctly retrieve values from either widget type, ensuring backend compatibility.
- In `shopify_tool/core.py`:
  - Added a new helper function, `get_unique_column_values`, to centralize the logic for fetching unique values from a DataFrame column.

This change significantly improves the user experience for creating rules by preventing typos and guiding the user with valid options.