### PR TITLE
Fix NoneType error when switching clients

### DIFF
--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -287,11 +287,18 @@ class UIManager:
                 enables them based on the current application state.
         """
         self.mw.run_analysis_button.setEnabled(not is_busy)
-        is_data_loaded = not self.mw.analysis_results_df.empty
+
+        # FIX: Check that DataFrame is not None before calling .empty
+        is_data_loaded = (
+            self.mw.analysis_results_df is not None
+            and not self.mw.analysis_results_df.empty
+        )
+
         self.mw.packing_list_button.setEnabled(not is_busy and is_data_loaded)
         self.mw.stock_export_button.setEnabled(not is_busy and is_data_loaded)
         self.mw.report_builder_button.setEnabled(not is_busy and is_data_loaded)
-        self.log.debug(f"UI busy state set to: {is_busy}")
+
+        self.log.debug(f"UI busy state set to: {is_busy}, data_loaded: {is_data_loaded}")
 
     def update_results_table(self, data_df):
         """Populates the main results table with new data from a DataFrame.


### PR DESCRIPTION
…t_ui_busy()

CRITICAL FIX #1: Added None check before accessing DataFrame.empty property

Problem:
- When switching clients, set_ui_busy() would crash with AttributeError
- analysis_results_df could be None, but code called .empty without checking

Solution:
- Added explicit None check before accessing .empty property
- Enhanced logging to track both busy state and data_loaded status
- Ensures proper button enable/disable behavior during client switching

Impact:
- Prevents crash when switching between clients (TEST → RPTN)
- Report buttons now correctly update based on actual data availability
- More robust state management for UI elements

File: gui/ui_manager.py:278-301