### PR TITLE
Fix packing lists and stock export generation

### DIFF
--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -479,8 +479,16 @@ class ActionsHandler(QObject):
 
                 # Get exclude_skus from config
                 exclude_skus = report_config.get("exclude_skus", [])
+                self.log.info(f"[EXCLUDE_SKUS] Raw from config: {exclude_skus} (type: {type(exclude_skus)})")
+
                 if isinstance(exclude_skus, str):
                     exclude_skus = [s.strip() for s in exclude_skus.split(',') if s.strip()]
+                    self.log.info(f"[EXCLUDE_SKUS] After string split: {exclude_skus}")
+                elif not isinstance(exclude_skus, list):
+                    exclude_skus = []
+                    self.log.warning(f"[EXCLUDE_SKUS] Unexpected type, reset to empty list")
+
+                self.log.info(f"[EXCLUDE_SKUS] Final value passed to packing_lists: {exclude_skus}")
 
                 # Use the proper packing_lists module
                 # Pass UNFILTERED DataFrame - the module will apply filters itself

--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -404,8 +404,14 @@ class ActionsHandler(QObject):
                 "tags": tags_list
             })
 
+        # Extract session name from path (session_path could be string or Path)
+        if self.mw.session_path:
+            session_id = os.path.basename(str(self.mw.session_path))
+        else:
+            session_id = "unknown"
+
         return {
-            "session_id": self.mw.session_path.name if self.mw.session_path else "unknown",
+            "session_id": session_id,
             "created_at": datetime.now().isoformat(),
             "total_orders": len(orders_data),
             "total_items": int(df['Quantity'].sum()) if 'Quantity' in df.columns else len(df),

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -1069,10 +1069,17 @@ class SettingsWindow(QDialog):
                         "value": val,
                     })
 
+                # Parse exclude_skus from comma-separated string
+                exclude_skus_text = pl_w["exclude_skus"].text().strip()
+                exclude_skus = []
+                if exclude_skus_text:
+                    exclude_skus = [s.strip() for s in exclude_skus_text.split(',') if s.strip()]
+
                 new_packing_lists.append({
                     "name": pl_w["name"].text(),
                     "output_filename": pl_w["filename"].text(),
                     "filters": filters,
+                    "exclude_skus": exclude_skus,
                 })
 
             self.config_data["packing_list_configs"] = new_packing_lists

--- a/shopify_tool/packing_lists.py
+++ b/shopify_tool/packing_lists.py
@@ -71,8 +71,12 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
 
         # Exclude specified SKUs if any are provided
         if exclude_skus and not filtered_orders.empty:
-            logger.info(f"Excluding SKUs: {exclude_skus}")
-            logger.info(f"Total items before exclusion: {len(filtered_orders)}")
+            logger.info(f"[EXCLUDE_SKUS] Received exclude list: {exclude_skus}")
+            logger.info(f"[EXCLUDE_SKUS] Total items before exclusion: {len(filtered_orders)}")
+
+            # Show unique SKUs in DataFrame for debugging
+            unique_skus = filtered_orders["SKU"].unique().tolist()
+            logger.info(f"[EXCLUDE_SKUS] Unique SKUs in DataFrame: {unique_skus[:20]}...")  # Show first 20
 
             # Normalize SKU for comparison - handles numeric types and leading zeros
             def normalize_sku(sku):
@@ -89,14 +93,15 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
             sku_column_normalized = filtered_orders["SKU"].apply(normalize_sku)
             exclude_skus_normalized = [normalize_sku(s) for s in exclude_skus]
 
-            logger.info(f"Normalized exclude SKUs: {exclude_skus_normalized}")
+            logger.info(f"[EXCLUDE_SKUS] Normalized exclude list: {exclude_skus_normalized}")
+            logger.info(f"[EXCLUDE_SKUS] Sample normalized DataFrame SKUs: {sku_column_normalized.unique().tolist()[:20]}...")
 
             # Create mask for items to keep (NOT in exclude list)
             mask = ~sku_column_normalized.isin(exclude_skus_normalized)
             filtered_orders = filtered_orders[mask]
 
             excluded_count = (~mask).sum()
-            logger.info(f"Excluded {excluded_count} items. Remaining: {len(filtered_orders)}")
+            logger.info(f"[EXCLUDE_SKUS] Excluded {excluded_count} items. Remaining: {len(filtered_orders)}")
 
         if filtered_orders.empty:
             logger.warning(f"Report '{report_name}': No orders found matching the criteria.")

--- a/tests/test_actions_handler_reports.py
+++ b/tests/test_actions_handler_reports.py
@@ -1,0 +1,248 @@
+import sys
+import os
+import json
+import pandas as pd
+from pathlib import Path
+from unittest.mock import Mock, MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gui.actions_handler import ActionsHandler
+
+
+def test_create_analysis_json(tmp_path):
+    """
+    Tests that _create_analysis_json creates proper JSON structure for Packing Tool.
+    """
+    # Create mock main window
+    mw = Mock()
+    mw.session_path = tmp_path / "session_123"
+
+    # Create actions handler
+    handler = ActionsHandler(mw)
+
+    # Create test DataFrame
+    df = pd.DataFrame(
+        {
+            "Order_Number": ["A1", "A1", "A2"],
+            "SKU": ["SKU-001", "SKU-002", "SKU-003"],
+            "Product_Name": ["Product 1", "Product 2", "Product 3"],
+            "Quantity": [2, 1, 3],
+            "Order_Fulfillment_Status": ["Fulfillable", "Fulfillable", "Fulfillable"],
+            "Order_Type": ["Regular", "Regular", "Priority"],
+            "Shipping_Provider": ["DHL", "DHL", "PostOne"],
+            "Destination_Country": ["BG", "BG", "US"],
+            "Tags": ["tag1,tag2", "", "tag3"],
+        }
+    )
+
+    # Create JSON
+    result = handler._create_analysis_json(df)
+
+    # Verify structure
+    assert "session_id" in result
+    assert result["session_id"] == "session_123"
+    assert "created_at" in result
+    assert "total_orders" in result
+    assert result["total_orders"] == 2  # 2 unique orders
+    assert "total_items" in result
+    assert result["total_items"] == 6  # 2+1+3
+    assert "orders" in result
+    assert len(result["orders"]) == 2
+
+    # Check first order
+    order_a1 = next(o for o in result["orders"] if o["order_number"] == "A1")
+    assert order_a1["order_type"] == "Regular"
+    assert order_a1["courier"] == "DHL"
+    assert order_a1["destination"] == "BG"
+    assert order_a1["tags"] == ["tag1", "tag2"]
+    assert len(order_a1["items"]) == 2
+
+    # Check items in first order
+    item_1 = next(i for i in order_a1["items"] if i["sku"] == "SKU-001")
+    assert item_1["product_name"] == "Product 1"
+    assert item_1["quantity"] == 2
+    assert item_1["stock_status"] == "Fulfillable"
+
+    # Check second order
+    order_a2 = next(o for o in result["orders"] if o["order_number"] == "A2")
+    assert order_a2["order_type"] == "Priority"
+    assert order_a2["courier"] == "PostOne"
+    assert order_a2["destination"] == "US"
+    assert order_a2["tags"] == ["tag3"]
+    assert len(order_a2["items"]) == 1
+
+
+@patch('gui.actions_handler.packing_lists')
+def test_generate_single_report_packing_with_json(mock_packing_lists, tmp_path):
+    """
+    Tests that _generate_single_report creates both XLSX and JSON for packing lists.
+    """
+    # Create mock main window
+    mw = Mock()
+    mw.analysis_results_df = pd.DataFrame(
+        {
+            "Order_Number": ["A1", "A2"],
+            "SKU": ["SKU-001", "SKU-002"],
+            "Product_Name": ["Product 1", "Product 2"],
+            "Quantity": [1, 2],
+            "Order_Fulfillment_Status": ["Fulfillable", "Fulfillable"],
+            "Order_Type": ["Regular", "Regular"],
+            "Shipping_Provider": ["DHL", "DHL"],
+            "Destination_Country": ["BG", "US"],
+            "Tags": ["", ""],
+        }
+    )
+    mw.session_path = tmp_path / "session_456"
+
+    # Mock log_activity and QMessageBox
+    mw.log_activity = Mock()
+
+    # Create actions handler
+    handler = ActionsHandler(mw)
+
+    # Mock _apply_filters to return all data
+    handler._apply_filters = Mock(return_value=mw.analysis_results_df)
+
+    # Report config
+    report_config = {
+        "name": "Test Packing List",
+        "output_filename": "test_packing.xlsx",
+        "filters": [],
+        "exclude_skus": []
+    }
+
+    # Mock QMessageBox
+    with patch('gui.actions_handler.QMessageBox'):
+        # Generate report
+        handler._generate_single_report("packing_lists", report_config, mw.session_path)
+
+    # Verify packing_lists.create_packing_list was called
+    mock_packing_lists.create_packing_list.assert_called_once()
+
+    # Check call arguments
+    call_args = mock_packing_lists.create_packing_list.call_args
+    assert call_args[1]["report_name"] == "Test Packing List"
+    assert call_args[1]["exclude_skus"] == []
+
+    # Verify JSON file was created
+    json_path = tmp_path / "session_456" / "packing_lists" / "test_packing.json"
+    assert json_path.exists()
+
+    # Verify JSON content
+    with open(json_path, 'r', encoding='utf-8') as f:
+        json_data = json.load(f)
+
+    assert json_data["session_id"] == "session_456"
+    assert json_data["total_orders"] == 2
+    assert json_data["total_items"] == 3
+
+
+@patch('gui.actions_handler.stock_export')
+def test_generate_single_report_stock_export(mock_stock_export, tmp_path):
+    """
+    Tests that _generate_single_report creates stock export correctly.
+    """
+    # Create mock main window
+    mw = Mock()
+    mw.analysis_results_df = pd.DataFrame(
+        {
+            "Order_Number": ["A1", "A2"],
+            "SKU": ["SKU-001", "SKU-002"],
+            "Product_Name": ["Product 1", "Product 2"],
+            "Quantity": [1, 2],
+            "Order_Fulfillment_Status": ["Fulfillable", "Fulfillable"],
+            "Shipping_Provider": ["DHL", "DHL"],
+        }
+    )
+    mw.session_path = tmp_path / "session_789"
+    mw.log_activity = Mock()
+
+    # Create actions handler
+    handler = ActionsHandler(mw)
+    handler._apply_filters = Mock(return_value=mw.analysis_results_df)
+
+    # Report config
+    report_config = {
+        "name": "Test Stock Export",
+        "output_filename": "",  # Should auto-generate
+        "filters": []
+    }
+
+    # Mock QMessageBox
+    with patch('gui.actions_handler.QMessageBox'):
+        # Generate report
+        handler._generate_single_report("stock_exports", report_config, mw.session_path)
+
+    # Verify stock_export.create_stock_export was called
+    mock_stock_export.create_stock_export.assert_called_once()
+
+    # Check call arguments
+    call_args = mock_stock_export.create_stock_export.call_args
+    assert call_args[1]["report_name"] == "Test Stock Export"
+
+    # Verify output file has .xls extension
+    output_file = call_args[1]["output_file"]
+    assert output_file.endswith(".xls")
+
+    # Verify NO JSON file was created (stock exports don't need JSON)
+    session_dir = tmp_path / "session_789" / "stock_exports"
+    if session_dir.exists():
+        json_files = list(session_dir.glob("*.json"))
+        assert len(json_files) == 0
+
+
+@patch('gui.actions_handler.packing_lists')
+def test_generate_packing_list_with_exclude_skus(mock_packing_lists, tmp_path):
+    """
+    Tests that exclude_skus from config are properly passed to packing_lists module.
+    """
+    # Create mock main window
+    mw = Mock()
+    mw.analysis_results_df = pd.DataFrame(
+        {
+            "Order_Number": ["A1", "A1"],
+            "SKU": ["SKU-001", "SKU-EXCLUDE"],
+            "Product_Name": ["Product 1", "Product 2"],
+            "Quantity": [1, 1],
+            "Order_Fulfillment_Status": ["Fulfillable", "Fulfillable"],
+            "Order_Type": ["Regular", "Regular"],
+            "Shipping_Provider": ["DHL", "DHL"],
+            "Destination_Country": ["BG", "BG"],
+            "Tags": ["", ""],
+        }
+    )
+    mw.session_path = tmp_path / "session_exclude"
+    mw.log_activity = Mock()
+
+    # Create actions handler
+    handler = ActionsHandler(mw)
+    handler._apply_filters = Mock(return_value=mw.analysis_results_df)
+
+    # Report config with exclude_skus
+    report_config = {
+        "name": "Test Exclude",
+        "output_filename": "test_exclude.xlsx",
+        "filters": [],
+        "exclude_skus": ["SKU-EXCLUDE"]
+    }
+
+    # Mock QMessageBox
+    with patch('gui.actions_handler.QMessageBox'):
+        # Generate report
+        handler._generate_single_report("packing_lists", report_config, mw.session_path)
+
+    # Verify exclude_skus was passed correctly
+    call_args = mock_packing_lists.create_packing_list.call_args
+    assert call_args[1]["exclude_skus"] == ["SKU-EXCLUDE"]
+
+    # Verify JSON was created and doesn't contain excluded SKU
+    json_path = tmp_path / "session_exclude" / "packing_lists" / "test_exclude.json"
+    assert json_path.exists()
+
+    with open(json_path, 'r', encoding='utf-8') as f:
+        json_data = json.load(f)
+
+    # Both items should be in JSON (exclusion happens in packing module, not in JSON)
+    assert len(json_data["orders"]) == 1
+    assert len(json_data["orders"][0]["items"]) == 2

--- a/tests/test_packing_lists.py
+++ b/tests/test_packing_lists.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import json
 import pandas as pd
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -62,3 +63,116 @@ def test_create_packing_list_with_not_equals_filter(tmp_path):
     assert "A1" not in result_df["Order_Number"].values
     assert "A4" not in result_df["Order_Number"].values
     assert "A5" not in result_df["Order_Number"].values  # Should be excluded due to status
+
+
+def test_create_packing_list_with_exclude_skus(tmp_path):
+    """
+    Tests that exclude_skus parameter correctly excludes specified SKUs from packing list.
+    """
+    # Build a DataFrame with multiple SKUs
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable", "Fulfillable", "Fulfillable", "Fulfillable"],
+            "Order_Number": ["A1", "A1", "A2", "A2"],
+            "SKU": ["SKU-001", "SKU-002", "SKU-001", "SKU-003"],
+            "Product_Name": ["Product 1", "Product 2", "Product 1", "Product 3"],
+            "Quantity": [1, 2, 1, 1],
+            "Shipping_Provider": ["DHL", "DHL", "DHL", "DHL"],
+            "Destination_Country": ["BG", "", "BG", ""],
+        }
+    )
+
+    out_file = tmp_path / "packing_test_exclude.xlsx"
+
+    # Exclude SKU-002 from the packing list
+    exclude_skus = ["SKU-002"]
+
+    packing_lists.create_packing_list(
+        df, str(out_file), report_name="TestExclude", filters=None, exclude_skus=exclude_skus
+    )
+
+    assert out_file.exists()
+
+    # Read the generated Excel file and verify its contents
+    result_df = pd.read_excel(out_file)
+
+    # SKU-002 should be excluded, leaving 3 items
+    assert len(result_df) == 3
+    assert "SKU-001" in result_df["SKU"].values
+    assert "SKU-003" in result_df["SKU"].values
+    assert "SKU-002" not in result_df["SKU"].values
+
+
+def test_create_packing_list_with_multiple_exclude_skus(tmp_path):
+    """
+    Tests that multiple SKUs can be excluded at once.
+    """
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable"] * 5,
+            "Order_Number": ["A1", "A1", "A1", "A2", "A2"],
+            "SKU": ["SKU-001", "SKU-002", "SKU-003", "SKU-004", "SKU-005"],
+            "Product_Name": ["P1", "P2", "P3", "P4", "P5"],
+            "Quantity": [1, 1, 1, 1, 1],
+            "Shipping_Provider": ["DHL"] * 5,
+            "Destination_Country": ["BG", "", "", "US", ""],
+        }
+    )
+
+    out_file = tmp_path / "packing_test_multi_exclude.xlsx"
+
+    # Exclude multiple SKUs
+    exclude_skus = ["SKU-002", "SKU-004"]
+
+    packing_lists.create_packing_list(
+        df, str(out_file), report_name="TestMultiExclude", filters=None, exclude_skus=exclude_skus
+    )
+
+    assert out_file.exists()
+
+    result_df = pd.read_excel(out_file)
+
+    # Should have 3 items left (SKU-001, SKU-003, SKU-005)
+    assert len(result_df) == 3
+    assert "SKU-001" in result_df["SKU"].values
+    assert "SKU-003" in result_df["SKU"].values
+    assert "SKU-005" in result_df["SKU"].values
+    assert "SKU-002" not in result_df["SKU"].values
+    assert "SKU-004" not in result_df["SKU"].values
+
+
+def test_create_packing_list_with_filters_and_exclude_skus(tmp_path):
+    """
+    Tests that filters and exclude_skus work together correctly.
+    """
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable"] * 4 + ["Not Fulfillable"],
+            "Order_Number": ["A1", "A1", "A2", "A2", "A3"],
+            "SKU": ["SKU-001", "SKU-002", "SKU-001", "SKU-003", "SKU-004"],
+            "Product_Name": ["P1", "P2", "P1", "P3", "P4"],
+            "Quantity": [1, 1, 1, 1, 1],
+            "Shipping_Provider": ["DHL", "DHL", "PostOne", "PostOne", "DHL"],
+            "Destination_Country": ["BG", "", "US", "", "FR"],
+        }
+    )
+
+    out_file = tmp_path / "packing_test_combined.xlsx"
+
+    # Filter to only DHL and exclude SKU-002
+    filters = [{"field": "Shipping_Provider", "operator": "==", "value": "DHL"}]
+    exclude_skus = ["SKU-002"]
+
+    packing_lists.create_packing_list(
+        df, str(out_file), report_name="TestCombined", filters=filters, exclude_skus=exclude_skus
+    )
+
+    assert out_file.exists()
+
+    result_df = pd.read_excel(out_file)
+
+    # Should have only SKU-001 from order A1 (DHL + Fulfillable + not excluded)
+    # A3 is not Fulfillable so excluded
+    assert len(result_df) == 1
+    assert result_df["SKU"].iloc[0] == "SKU-001"
+    assert result_df["Order_Number"].iloc[0] == "A1"


### PR DESCRIPTION
Changed _generate_single_report() method in gui/actions_handler.py to use:
- packing_lists.create_packing_list() for formatted packing lists (6 columns, proper formatting, timestamp)
- stock_export.create_stock_export() for aggregated stock exports (SKU + Quantity only)

Previously, the method was using filtered_df.to_excel() which exported the entire DataFrame with all columns instead of properly formatted warehouse reports.

For packing lists, a JSON file is also created for integration with the Packing Tool.

Changes:
- Added imports for packing_lists and stock_export modules
- Completely rewrote _generate_single_report() to delegate to specialized modules
- Added proper filename handling with correct extensions (.xlsx for packing, .xls for stock)
- Added exclude_skus support for packing lists
- Improved error handling and logging