### PR TITLE
Fix Settings Window configuration loading on startup

### DIFF
--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import json
 import pandas as pd
 from PySide6.QtWidgets import (
@@ -595,7 +596,7 @@ class SettingsWindow(QDialog):
         self.packing_lists_layout.setAlignment(Qt.AlignTop)
         scroll_area.setWidget(scroll_content)
         self.tab_widget.addTab(tab, "Packing Lists")
-        for pl_config in self.config_data.get("packing_lists", []):
+        for pl_config in self.config_data.get("packing_list_configs", []):
             self.add_packing_list_widget(pl_config)
 
     def add_packing_list_widget(self, config=None):
@@ -755,7 +756,7 @@ class SettingsWindow(QDialog):
         self.stock_exports_layout.setAlignment(Qt.AlignTop)
         scroll_area.setWidget(scroll_content)
         self.tab_widget.addTab(tab, "Stock Exports")
-        for se_config in self.config_data.get("stock_exports", []):
+        for se_config in self.config_data.get("stock_export_configs", []):
             self.add_stock_export_widget(se_config)
 
     def add_stock_export_widget(self, config=None):


### PR DESCRIPTION
PROBLEM:
Settings Window was not loading existing packing list and stock export configurations because it was looking for wrong config keys.

CHANGES:
- Fixed create_packing_lists_tab(): changed "packing_lists" to "packing_list_configs"
- Fixed create_stock_exports_tab(): changed "stock_exports" to "stock_export_configs"
- Added import os for future path handling

These keys now match what's used in __init__() and save_settings(), ensuring configurations are properly loaded when opening Settings Window.

IMPACT:
Users will now see their saved packing lists and stock exports when reopening Settings Window, instead of seeing an empty configuration.