### PR TITLE
Add Warehouse Names and Manual Product Dialog

### DIFF
--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -764,7 +764,7 @@ class ActionsHandler(QObject):
         ]
 
         if existing_rows.empty:
-            logger.error(f"Order {product_data['order_number']} not found")
+            self.log.error(f"Order {product_data['order_number']} not found")
             QMessageBox.warning(
                 self.mw,
                 "Order Not Found",
@@ -798,7 +798,7 @@ class ActionsHandler(QObject):
             ignore_index=True
         )
 
-        logger.info(f"Added product {product_data['sku']} to order {product_data['order_number']}")
+        self.log.info(f"Added product {product_data['sku']} to order {product_data['order_number']}")
 
         # Save to session
         self._save_manual_addition(product_data)
@@ -827,7 +827,7 @@ class ActionsHandler(QObject):
         from datetime import datetime
 
         if not hasattr(self.mw, 'session_path') or not self.mw.session_path:
-            logger.warning("No active session, manual addition not saved")
+            self.log.warning("No active session, manual addition not saved")
             return
 
         # Path to manual_additions.json
@@ -839,7 +839,7 @@ class ActionsHandler(QObject):
                 with open(additions_file, 'r', encoding='utf-8') as f:
                     additions = json.load(f)
             except Exception as e:
-                logger.error(f"Error loading manual additions: {e}")
+                self.log.error(f"Error loading manual additions: {e}")
                 additions = []
         else:
             additions = []
@@ -857,6 +857,6 @@ class ActionsHandler(QObject):
         try:
             with open(additions_file, 'w', encoding='utf-8') as f:
                 json.dump(additions, f, indent=2, ensure_ascii=False)
-            logger.info(f"Saved manual addition to {additions_file}")
+            self.log.info(f"Saved manual addition to {additions_file}")
         except Exception as e:
-            logger.error(f"Error saving manual additions: {e}")
+            self.log.error(f"Error saving manual additions: {e}")

--- a/gui/add_product_dialog.py
+++ b/gui/add_product_dialog.py
@@ -1,0 +1,345 @@
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout,
+    QComboBox, QSpinBox, QLabel, QPushButton,
+    QGroupBox, QMessageBox, QWidget
+)
+from PySide6.QtCore import Qt
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AddProductDialog(QDialog):
+    """
+    Dialog for manually adding product to order.
+
+    Usage:
+        dialog = AddProductDialog(
+            parent=main_window,
+            orders_df=analysis_df,
+            stock_df=stock_df
+        )
+
+        if dialog.exec() == QDialog.Accepted:
+            result = dialog.get_result()
+            # result = {
+            #     "order_number": "1001",
+            #     "sku": "SKU-HAT",
+            #     "product_name": "Зимова шапка",
+            #     "quantity": 2
+            # }
+    """
+
+    def __init__(self, parent, orders_df, stock_df):
+        super().__init__(parent)
+
+        self.orders_df = orders_df
+        self.stock_df = stock_df
+        self.result = None
+
+        self.setup_ui()
+        self.populate_orders()
+        self.populate_products()
+
+    def setup_ui(self):
+        """Setup dialog UI components."""
+        self.setWindowTitle("Add Product to Order")
+        self.setModal(True)
+        self.resize(500, 600)
+
+        layout = QVBoxLayout(self)
+
+        # Section 1: Order Selection
+        layout.addWidget(self._create_order_section())
+
+        # Section 2: Product Selection
+        layout.addWidget(self._create_product_section())
+
+        # Section 3: Quantity
+        layout.addWidget(self._create_quantity_section())
+
+        # Section 4: Info/Warning Box
+        self.warning_box = self._create_warning_box()
+        self.warning_box.setVisible(False)
+        layout.addWidget(self.warning_box)
+
+        self.info_box = self._create_info_box()
+        layout.addWidget(self.info_box)
+
+        # Section 5: Buttons
+        layout.addWidget(self._create_buttons())
+
+    def _create_order_section(self):
+        """Create order selection section."""
+        group = QGroupBox("ORDER SELECTION")
+        layout = QVBoxLayout(group)
+
+        layout.addWidget(QLabel("Select the order to add product to:"))
+
+        self.order_combo = QComboBox()
+        self.order_combo.setPlaceholderText("Select order...")
+        layout.addWidget(self.order_combo)
+
+        return group
+
+    def _create_product_section(self):
+        """Create product selection section."""
+        group = QGroupBox("PRODUCT SELECTION")
+        layout = QVBoxLayout(group)
+
+        layout.addWidget(QLabel("Select product to add:"))
+
+        self.product_combo = QComboBox()
+        self.product_combo.setPlaceholderText("Select product from stock...")
+        self.product_combo.currentIndexChanged.connect(self._on_product_changed)
+        layout.addWidget(self.product_combo)
+
+        return group
+
+    def _create_quantity_section(self):
+        """Create quantity input section."""
+        group = QGroupBox("QUANTITY")
+        layout = QVBoxLayout(group)
+
+        layout.addWidget(QLabel("Quantity to add:"))
+
+        self.quantity_spin = QSpinBox()
+        self.quantity_spin.setMinimum(1)
+        self.quantity_spin.setMaximum(9999)
+        self.quantity_spin.setValue(1)
+        layout.addWidget(self.quantity_spin)
+
+        return group
+
+    def _create_warning_box(self):
+        """Create warning box for low/zero stock."""
+        label = QLabel()
+        label.setWordWrap(True)
+        label.setStyleSheet("""
+            QLabel {
+                background-color: #FFEBEE;
+                border: 2px solid #F44336;
+                border-radius: 5px;
+                padding: 10px;
+            }
+        """)
+        return label
+
+    def _create_info_box(self):
+        """Create info box."""
+        text = (
+            "ℹ️ INFO\n\n"
+            "• Product will be added with Source: 'Manual'\n"
+            "• Order fulfillment status will be marked 'Pending'\n"
+            "• Re-run analysis to update fulfillment\n"
+            "• Manual addition will be saved in session"
+        )
+
+        label = QLabel(text)
+        label.setWordWrap(True)
+        label.setStyleSheet("""
+            QLabel {
+                background-color: #E3F2FD;
+                border: 2px solid #2196F3;
+                border-radius: 5px;
+                padding: 10px;
+            }
+        """)
+        return label
+
+    def _create_buttons(self):
+        """Create Cancel/Add buttons."""
+        widget = QWidget()
+        layout = QHBoxLayout(widget)
+        layout.addStretch()
+
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        layout.addWidget(cancel_btn)
+
+        self.add_btn = QPushButton("Add Product")
+        self.add_btn.clicked.connect(self._on_add_clicked)
+        self.add_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #2196F3;
+                color: white;
+                padding: 8px 16px;
+            }
+            QPushButton:hover {
+                background-color: #1976D2;
+            }
+        """)
+        layout.addWidget(self.add_btn)
+
+        return widget
+
+    def populate_orders(self):
+        """Populate order dropdown from analysis DataFrame."""
+        if self.orders_df is None or self.orders_df.empty:
+            logger.warning("No orders available")
+            return
+
+        # Group by Order_Number, count items, get fulfillment status
+        orders_grouped = self.orders_df.groupby("Order_Number").agg({
+            "SKU": "count",  # item count
+            "Order_Fulfillment_Status": "first"  # status
+        }).reset_index()
+
+        for _, row in orders_grouped.iterrows():
+            order_num = row["Order_Number"]
+            item_count = row["SKU"]
+            status = row["Order_Fulfillment_Status"]
+
+            # Format display text
+            display_text = f"{order_num} ({item_count} items, {status})"
+
+            # Add to combo with order_num as user data
+            self.order_combo.addItem(display_text, userData=order_num)
+
+    def populate_products(self):
+        """Populate product dropdown from stock DataFrame."""
+        if self.stock_df is None or self.stock_df.empty:
+            logger.warning("No stock data available")
+            return
+
+        if "Product_Name" not in self.stock_df.columns:
+            logger.warning("Stock file has no Product_Name column")
+            # Fall back to showing just SKU
+            for _, row in self.stock_df.iterrows():
+                sku = row["SKU"]
+                stock = row.get("Stock", 0)
+                display_text = f"{sku} ({stock} in stock)"
+                user_data = {
+                    "sku": sku,
+                    "name": sku,  # Use SKU as name if no Product_Name
+                    "stock": stock
+                }
+                self.product_combo.addItem(display_text, userData=user_data)
+            return
+
+        for _, row in self.stock_df.iterrows():
+            sku = row["SKU"]
+            name = row.get("Product_Name", "")
+            stock = row.get("Stock", 0)
+
+            # Format display text
+            display_text = f"{sku} - {name} ({stock} in stock)"
+
+            # Store full data as userData
+            user_data = {
+                "sku": sku,
+                "name": name,
+                "stock": stock
+            }
+
+            self.product_combo.addItem(display_text, userData=user_data)
+
+    def _on_product_changed(self, index):
+        """Handle product selection change."""
+        if index < 0:
+            return
+
+        product_data = self.product_combo.itemData(index)
+        if not product_data:
+            return
+
+        stock = product_data.get("stock", 0)
+
+        # Show warning if low/zero stock
+        if stock == 0:
+            warning_text = (
+                "⚠️ WARNING\n\n"
+                f"Selected product {product_data['sku']} has 0 stock available!\n"
+                "Adding this product may affect order fulfillment.\n\n"
+                "Do you want to continue?"
+            )
+            self.warning_box.setText(warning_text)
+            self.warning_box.setVisible(True)
+            self.warning_box.setStyleSheet("""
+                QLabel {
+                    background-color: #FFEBEE;
+                    border: 2px solid #F44336;
+                    border-radius: 5px;
+                    padding: 10px;
+                }
+            """)
+        elif stock < 5:
+            warning_text = (
+                "⚠️ WARNING\n\n"
+                f"Selected product {product_data['sku']} has low stock ({stock} units).\n"
+                "Consider checking availability."
+            )
+            self.warning_box.setText(warning_text)
+            self.warning_box.setVisible(True)
+            self.warning_box.setStyleSheet("""
+                QLabel {
+                    background-color: #FFF8E1;
+                    border: 2px solid #FFC107;
+                    border-radius: 5px;
+                    padding: 10px;
+                }
+            """)
+        else:
+            self.warning_box.setVisible(False)
+
+    def _on_add_clicked(self):
+        """Handle Add Product button click."""
+        # Validate inputs
+        if not self._validate():
+            return
+
+        # Get selected values
+        order_number = self.order_combo.currentData()
+        product_data = self.product_combo.currentData()
+        quantity = self.quantity_spin.value()
+
+        # Store result
+        self.result = {
+            "order_number": order_number,
+            "sku": product_data["sku"],
+            "product_name": product_data["name"],
+            "quantity": quantity
+        }
+
+        logger.info(f"Adding product: {self.result}")
+
+        # Close dialog with accepted
+        self.accept()
+
+    def _validate(self):
+        """Validate user inputs."""
+        # Check order selected
+        if self.order_combo.currentIndex() < 0:
+            QMessageBox.warning(
+                self,
+                "Validation Error",
+                "Please select an order."
+            )
+            self.order_combo.setFocus()
+            return False
+
+        # Check product selected
+        if self.product_combo.currentIndex() < 0:
+            QMessageBox.warning(
+                self,
+                "Validation Error",
+                "Please select a product."
+            )
+            self.product_combo.setFocus()
+            return False
+
+        # Check quantity
+        if self.quantity_spin.value() < 1:
+            QMessageBox.warning(
+                self,
+                "Validation Error",
+                "Quantity must be at least 1."
+            )
+            self.quantity_spin.setFocus()
+            return False
+
+        return True
+
+    def get_result(self):
+        """Get dialog result after accept."""
+        return self.result

--- a/gui/file_handler.py
+++ b/gui/file_handler.py
@@ -189,7 +189,16 @@ class FileHandler:
             stock_df = pd.read_csv(filepath, delimiter=delimiter, encoding='utf-8-sig', dtype=dtype_dict)
             self.log.info(f"Loaded stock CSV with delimiter '{delimiter}': {len(stock_df)} rows")
 
-            # Store stock_df in MainWindow for later use (e.g., manual product addition dialog)
+            # Apply column mappings to stock_df before storing
+            # This ensures that the stored stock_df has internal column names (SKU, Product_Name, Stock)
+            # which is what AddProductDialog expects
+            stock_rename_map = {csv_col: internal_col for csv_col, internal_col in stock_mappings.items()
+                                if csv_col in stock_df.columns and csv_col != internal_col}
+            if stock_rename_map:
+                stock_df = stock_df.rename(columns=stock_rename_map)
+                self.log.info(f"Applied column mappings to stock_df: {stock_rename_map}")
+
+            # Store mapped stock_df in MainWindow for later use (e.g., manual product addition dialog)
             self.mw.stock_df = stock_df
 
         except Exception as e:

--- a/gui/file_handler.py
+++ b/gui/file_handler.py
@@ -189,6 +189,9 @@ class FileHandler:
             stock_df = pd.read_csv(filepath, delimiter=delimiter, encoding='utf-8-sig', dtype=dtype_dict)
             self.log.info(f"Loaded stock CSV with delimiter '{delimiter}': {len(stock_df)} rows")
 
+            # Store stock_df in MainWindow for later use (e.g., manual product addition dialog)
+            self.mw.stock_df = stock_df
+
         except Exception as e:
             self.log.error(f"Failed to load stock CSV: {e}")
             QMessageBox.critical(

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -376,6 +376,15 @@ class MainWindow(QMainWindow):
 
                     self.stock_df = pd.read_csv(stock_file, delimiter=stock_delimiter, encoding='utf-8-sig', dtype=dtype_dict)
                     logging.info(f"Loaded stock file from session: {len(self.stock_df)} rows")
+
+                    # Apply column mappings to stock_df before storing
+                    # This ensures that the stored stock_df has internal column names (SKU, Product_Name, Stock)
+                    # which is what AddProductDialog expects
+                    stock_rename_map = {csv_col: internal_col for csv_col, internal_col in stock_mappings.items()
+                                        if csv_col in self.stock_df.columns and csv_col != internal_col}
+                    if stock_rename_map:
+                        self.stock_df = self.stock_df.rename(columns=stock_rename_map)
+                        logging.info(f"Applied column mappings to stock_df from session: {stock_rename_map}")
                 except Exception as e:
                     logging.warning(f"Failed to load stock file from session: {e}")
                     self.stock_df = None

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -221,6 +221,7 @@ class MainWindow(QMainWindow):
 
         # Main actions
         self.run_analysis_button.clicked.connect(self.actions_handler.run_analysis)
+        self.add_product_button.clicked.connect(self.actions_handler.show_add_product_dialog)
         self.settings_button.clicked.connect(self.actions_handler.open_settings_window)
 
         # Reports
@@ -394,6 +395,8 @@ class MainWindow(QMainWindow):
                         self.packing_list_button.setEnabled(True)
                     if hasattr(self, 'stock_export_button'):
                         self.stock_export_button.setEnabled(True)
+                    if hasattr(self, 'add_product_button'):
+                        self.add_product_button.setEnabled(True)
 
                     self.log_activity("Session", f"Loaded session: {session_name}")
                     QMessageBox.information(
@@ -457,6 +460,14 @@ class MainWindow(QMainWindow):
                 self.analysis_stats = recalculate_statistics(self.analysis_results_df)
                 self.ui_manager.update_results_table(self.analysis_results_df)
                 self.update_statistics_tab()
+
+                # Enable action buttons that require analysis data
+                if hasattr(self, 'packing_list_button'):
+                    self.packing_list_button.setEnabled(True)
+                if hasattr(self, 'stock_export_button'):
+                    self.stock_export_button.setEnabled(True)
+                if hasattr(self, 'add_product_button'):
+                    self.add_product_button.setEnabled(True)
             except Exception as e:
                 logging.error(f"Failed to recalculate statistics: {e}", exc_info=True)
                 self.analysis_stats = None
@@ -466,6 +477,14 @@ class MainWindow(QMainWindow):
             self.analysis_stats = None
             self._clear_statistics_view()
             self.ui_manager.update_results_table(pd.DataFrame())
+
+            # Disable action buttons that require analysis data
+            if hasattr(self, 'packing_list_button'):
+                self.packing_list_button.setEnabled(False)
+            if hasattr(self, 'stock_export_button'):
+                self.stock_export_button.setEnabled(False)
+            if hasattr(self, 'add_product_button'):
+                self.add_product_button.setEnabled(False)
 
         # Populate filter dropdown
         self.filter_column_selector.clear()

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -339,11 +339,17 @@ class UIManager:
         self.mw.run_analysis_button.setEnabled(False)
         self.mw.run_analysis_button.setToolTip("Start the fulfillment analysis based on the loaded files.")
 
+        self.mw.add_product_button = QPushButton("➕ Add Product to Order")
+        self.mw.add_product_button.setMinimumHeight(60)
+        self.mw.add_product_button.setEnabled(False)  # Enabled after successful analysis
+        self.mw.add_product_button.setToolTip("Manually add a product to an existing order")
+
         self.mw.settings_button = QPushButton("Open Client Settings")
         self.mw.settings_button.setToolTip("Open the settings window for the active client.")
         self.mw.settings_button.setEnabled(False)  # Enabled when client is selected
 
         actions_layout.addWidget(self.mw.run_analysis_button, 1)
+        actions_layout.addWidget(self.mw.add_product_button, 1)
         actions_layout.addWidget(self.mw.settings_button)
         main_layout.addLayout(actions_layout)
 

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -372,6 +372,16 @@ def run_full_analysis(
             logger.info(f"Reading stock file from normalized path: {stock_file_path}")
             stock_df = pd.read_csv(stock_file_path, delimiter=stock_delimiter, encoding='utf-8-sig', dtype=stock_dtype)
             logger.info(f"Stock data loaded: {len(stock_df)} rows, {len(stock_df.columns)} columns")
+
+            # Apply column mappings to stock_df immediately after loading
+            # This ensures stock_df has internal column names (SKU, Product_Name, Stock)
+            # which is needed for manual additions loading later
+            stock_mappings = column_mappings.get("stock", {})
+            stock_rename_map = {csv_col: internal_col for csv_col, internal_col in stock_mappings.items()
+                                if csv_col in stock_df.columns and csv_col != internal_col}
+            if stock_rename_map:
+                stock_df = stock_df.rename(columns=stock_rename_map)
+                logger.debug(f"Applied column mappings to stock_df: {stock_rename_map}")
         except pd.errors.ParserError as e:
             error_msg = (
                 f"Failed to parse stock file. The file may have incorrect delimiter.\n"

--- a/shopify_tool/packing_lists.py
+++ b/shopify_tool/packing_lists.py
@@ -102,8 +102,9 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
         logger.info(f"Found {filtered_orders['Order_Number'].nunique()} orders for the report.")
 
         # Fill NaN values to avoid issues during processing
-        for col in ["Destination_Country", "Product_Name", "SKU"]:
-            filtered_orders[col] = filtered_orders[col].fillna("")
+        for col in ["Destination_Country", "Product_Name", "Warehouse_Name", "SKU"]:
+            if col in filtered_orders.columns:
+                filtered_orders[col] = filtered_orders[col].fillna("")
 
         # Sort the list for optimal packing order
         provider_map = {"DHL": 0, "PostOne": 1, "DPD": 2}
@@ -116,11 +117,12 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
         )
 
         # Define the columns for the final print list
+        # Use Warehouse_Name (from stock file) for warehouse picking instead of Product_Name (from Shopify)
         columns_for_print = [
             "Destination_Country",
             "Order_Number",
             "SKU",
-            "Product_Name",
+            "Warehouse_Name",  # Changed from Product_Name - shows stock/warehouse product names
             "Quantity",
             "Shipping_Provider",
         ]
@@ -130,7 +132,7 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
         output_filename = os.path.basename(output_file)
 
         # Rename columns to embed metadata into the header
-        rename_map = {"Shipping_Provider": generation_timestamp, "Product_Name": output_filename}
+        rename_map = {"Shipping_Provider": generation_timestamp, "Warehouse_Name": output_filename}
         print_list = print_list.rename(columns=rename_map)
 
         logger.info("Creating Excel file...")
@@ -193,7 +195,7 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
                 original_col_name = columns_for_print[i]
                 if original_col_name == "Destination_Country":
                     max_len = 5
-                elif original_col_name == "Product_Name":
+                elif original_col_name == "Warehouse_Name":
                     max_len = min(max_len, 45)
                 elif original_col_name == "SKU":
                     max_len = min(max_len, 25)


### PR DESCRIPTION
## Phase 1: Warehouse_Name Column
- Add Warehouse_Name column in analysis.py to preserve stock file product names
- Map SKU to warehouse product names from stock file (e.g., Bulgarian names)
- Product_Name column still contains Shopify/order names
- Warehouse_Name used in packing lists for warehouse picking
- Add Source column to distinguish between 'Order' and 'Manual' entries

## Phase 2: Manual Product Addition UI
- Create AddProductDialog (gui/add_product_dialog.py)
  - Order selection dropdown with item count and status
  - Product selection dropdown from stock with stock levels
  - Quantity input spinbox
  - Low/zero stock warnings
  - Info box with instructions
- Add "Add Product to Order" button to MainWindow
- Enable button after successful analysis

## Phase 3: Manual Product Addition Logic
- Add show_add_product_dialog() in actions_handler.py
- Add _add_product_to_dataframe() to handle product addition
- Add _save_manual_addition() to persist additions in session
- Manual additions saved to manual_additions.json
- Marked with Source='Manual' and Status='Pending'
- UI refreshes after addition

## Benefits
- Warehouse sees correct product names from stock file
- Set components show actual component names (not set name)
- Manual product additions tracked and persistent
- Clear separation between order and manual entries
- Supports Cyrillic and other non-ASCII characters

Implements: Phase 1, 2, and 3 from warehouse-name-manual-products prompt