### PR TITLE
Add Warehouse Names and Manual Product Entry

### DIFF
--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -822,8 +822,9 @@ class ActionsHandler(QObject):
         self.log.info(f"Adding {quantity}x {sku} to order {order_num}")
 
         # Step 1: Get existing row as template
+        # Convert Order_Number to string for comparison (might be int/float)
         existing_rows = self.mw.analysis_results_df[
-            self.mw.analysis_results_df["Order_Number"] == order_num
+            self.mw.analysis_results_df["Order_Number"].astype(str) == str(order_num)
         ]
 
         if existing_rows.empty:
@@ -848,7 +849,8 @@ class ActionsHandler(QObject):
         new_row["Is_Set_Component"] = False
 
         # Set Warehouse_Name from stock if available
-        stock_row = stock_df[stock_df["SKU"] == sku]
+        # Convert SKU to string for comparison (might be int/float)
+        stock_row = stock_df[stock_df["SKU"].astype(str).str.strip() == sku]
         if not stock_row.empty and "Product_Name" in stock_row.columns:
             new_row["Warehouse_Name"] = stock_row.iloc[0]["Product_Name"]
         else:
@@ -906,8 +908,9 @@ class ActionsHandler(QObject):
         self.log.info(f"Recalculating fulfillment for order {order_number}")
 
         # Get all items for this order
+        # Convert Order_Number to string for comparison (might be int/float)
         order_items = self.mw.analysis_results_df[
-            self.mw.analysis_results_df["Order_Number"] == order_number
+            self.mw.analysis_results_df["Order_Number"].astype(str) == str(order_number)
         ]
 
         # Rebuild live stock tracking from Final_Stock
@@ -936,8 +939,9 @@ class ActionsHandler(QObject):
         # Update fulfillment status for ALL items in this order
         new_status = "Fulfillable" if can_fulfill else "Not Fulfillable"
 
+        # Convert Order_Number to string for comparison (might be int/float)
         self.mw.analysis_results_df.loc[
-            self.mw.analysis_results_df["Order_Number"] == order_number,
+            self.mw.analysis_results_df["Order_Number"].astype(str) == str(order_number),
             "Order_Fulfillment_Status"
         ] = new_status
 

--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -711,3 +711,268 @@ class ActionsHandler(QObject):
             ].reset_index(drop=True)
             self.data_changed.emit()
             self.mw.log_activity("Data Edit", f"Removed order {order_number}.")
+
+    def show_add_product_dialog(self):
+        """Show dialog to add product to order."""
+        from gui.add_product_dialog import AddProductDialog
+        from PySide6.QtWidgets import QDialog
+
+        # Validate prerequisites
+        if not hasattr(self.mw, 'analysis_results_df') or self.mw.analysis_results_df is None:
+            QMessageBox.warning(
+                self.mw,
+                "No Analysis",
+                "Please run analysis first before adding products."
+            )
+            return
+
+        if not hasattr(self.mw, 'stock_file_path') or not self.mw.stock_file_path:
+            QMessageBox.warning(
+                self.mw,
+                "No Stock Data",
+                "Stock file must be loaded to add products."
+            )
+            return
+
+        # Load stock DataFrame
+        try:
+            stock_delimiter = self.mw.active_profile_config.get("settings", {}).get("stock_csv_delimiter", ";")
+            stock_df = pd.read_csv(
+                self.mw.stock_file_path,
+                delimiter=stock_delimiter,
+                encoding='utf-8-sig',
+                dtype={'SKU': str}
+            )
+            self.log.info(f"Loaded stock data: {len(stock_df)} rows")
+        except Exception as e:
+            self.log.error(f"Failed to load stock file: {e}", exc_info=True)
+            QMessageBox.critical(
+                self.mw,
+                "Error Loading Stock",
+                f"Could not load stock file.\n\nError: {e}"
+            )
+            return
+
+        # Create live_stock tracking dict from Final_Stock column
+        live_stock = {}
+        if "Final_Stock" in self.mw.analysis_results_df.columns:
+            for _, row in self.mw.analysis_results_df.iterrows():
+                sku = row["SKU"]
+                final_stock = row["Final_Stock"]
+                if pd.notna(sku) and pd.notna(final_stock):
+                    # Use the latest Final_Stock value for each SKU
+                    live_stock[sku] = final_stock
+            self.log.info(f"Created live stock tracking: {len(live_stock)} SKUs")
+        else:
+            self.log.warning("No Final_Stock column in analysis results")
+
+        # Show dialog
+        dialog = AddProductDialog(
+            parent=self.mw,
+            analysis_df=self.mw.analysis_results_df,
+            stock_df=stock_df,
+            live_stock=live_stock
+        )
+
+        if dialog.exec() == QDialog.Accepted:
+            result = dialog.get_result()
+            if result:
+                self._add_product_to_order(result, stock_df, live_stock)
+
+    def _add_product_to_order(self, product_data, stock_df, live_stock):
+        """
+        Add manually added product to order.
+
+        CRITICAL: Does NOT re-run full analysis!
+        Instead: Recalculates fulfillment ONLY for this order.
+
+        Args:
+            product_data: dict {
+                "order_number": str,
+                "sku": str,
+                "product_name": str,
+                "quantity": int
+            }
+            stock_df: DataFrame with stock data
+            live_stock: dict with current stock levels
+        """
+        order_num = product_data["order_number"]
+        sku = product_data["sku"]
+        quantity = product_data["quantity"]
+
+        self.log.info(f"Adding {quantity}x {sku} to order {order_num}")
+
+        # Step 1: Get existing row as template
+        existing_rows = self.mw.analysis_results_df[
+            self.mw.analysis_results_df["Order_Number"] == order_num
+        ]
+
+        if existing_rows.empty:
+            self.log.error(f"Order {order_num} not found")
+            QMessageBox.critical(
+                self.mw,
+                "Error",
+                f"Order {order_num} not found in analysis."
+            )
+            return
+
+        template_row = existing_rows.iloc[0].copy()
+
+        # Step 2: Create new row
+        new_row = template_row.copy()
+        new_row["SKU"] = sku
+        new_row["Product_Name"] = product_data["product_name"]
+        new_row["Quantity"] = quantity
+        new_row["Source"] = "Manual"
+        new_row["Original_SKU"] = sku
+        new_row["Original_Quantity"] = quantity
+        new_row["Is_Set_Component"] = False
+
+        # Set Warehouse_Name from stock if available
+        stock_row = stock_df[stock_df["SKU"] == sku]
+        if not stock_row.empty and "Product_Name" in stock_row.columns:
+            new_row["Warehouse_Name"] = stock_row.iloc[0]["Product_Name"]
+        else:
+            new_row["Warehouse_Name"] = product_data["product_name"]
+
+        # Step 3: Lookup stock value
+        if not stock_row.empty and "Stock" in stock_row.columns:
+            initial_stock = stock_row.iloc[0]["Stock"]
+            new_row["Stock"] = initial_stock
+        else:
+            new_row["Stock"] = 0
+            initial_stock = 0
+
+        # Step 4: Get current live stock
+        current_live_stock = live_stock.get(sku, initial_stock)
+        new_row["Final_Stock"] = current_live_stock
+
+        # Step 5: Append to DataFrame
+        self.mw.analysis_results_df = pd.concat(
+            [self.mw.analysis_results_df, pd.DataFrame([new_row])],
+            ignore_index=True
+        )
+
+        self.log.info(f"Row added to analysis_results_df")
+
+        # Step 6: Recalculate fulfillment for THIS ORDER ONLY
+        self._recalculate_order_fulfillment(order_num)
+
+        # Step 7: Save to session
+        self._save_manual_addition(product_data)
+
+        # Step 8: Emit data changed signal
+        self.data_changed.emit()
+
+        # Step 9: Show success message
+        QMessageBox.information(
+            self.mw,
+            "Product Added",
+            f"Product {sku} ({quantity}x) added to order {order_num}.\n\n"
+            "Fulfillment status has been updated."
+        )
+
+        self.mw.log_activity("Manual Addition", f"Added {quantity}x {sku} to order {order_num}")
+
+    def _recalculate_order_fulfillment(self, order_number):
+        """
+        Recalculate fulfillment status for ONE specific order.
+
+        CRITICAL: Does NOT touch other orders or re-run analysis!
+        This preserves repeated order detection logic.
+
+        Args:
+            order_number: Order to recalculate
+        """
+        self.log.info(f"Recalculating fulfillment for order {order_number}")
+
+        # Get all items for this order
+        order_items = self.mw.analysis_results_df[
+            self.mw.analysis_results_df["Order_Number"] == order_number
+        ]
+
+        # Rebuild live stock tracking from Final_Stock
+        live_stock = {}
+        for _, row in self.mw.analysis_results_df.iterrows():
+            sku = row["SKU"]
+            final_stock = row["Final_Stock"]
+            if pd.notna(sku) and pd.notna(final_stock):
+                live_stock[sku] = final_stock
+
+        # Check if all items can be fulfilled with current live stock
+        can_fulfill = True
+
+        for _, item in order_items.iterrows():
+            sku = item["SKU"]
+            required_qty = item["Quantity"]
+            available = live_stock.get(sku, 0)
+
+            if required_qty > available:
+                can_fulfill = False
+                self.log.debug(f"  {sku}: need {required_qty}, have {available} - NOT OK")
+                break
+            else:
+                self.log.debug(f"  {sku}: need {required_qty}, have {available} - OK")
+
+        # Update fulfillment status for ALL items in this order
+        new_status = "Fulfillable" if can_fulfill else "Not Fulfillable"
+
+        self.mw.analysis_results_df.loc[
+            self.mw.analysis_results_df["Order_Number"] == order_number,
+            "Order_Fulfillment_Status"
+        ] = new_status
+
+        # If fulfillable, update Final_Stock (simulate allocation)
+        if can_fulfill:
+            for _, item in order_items.iterrows():
+                sku = item["SKU"]
+                qty = item["Quantity"]
+                new_stock = live_stock.get(sku, 0) - qty
+                # Update Final_Stock for ALL rows with this SKU
+                self.mw.analysis_results_df.loc[
+                    self.mw.analysis_results_df["SKU"] == sku,
+                    "Final_Stock"
+                ] = new_stock
+
+            self.log.info(f"Order {order_number} marked as Fulfillable, stock updated")
+        else:
+            self.log.info(f"Order {order_number} marked as Not Fulfillable")
+
+    def _save_manual_addition(self, product_data):
+        """Save manual addition to session file."""
+        import json
+
+        if not hasattr(self.mw, 'session_path') or not self.mw.session_path:
+            self.log.warning("No active session, manual addition not saved")
+            return
+
+        # Path to manual_additions.json
+        additions_file = os.path.join(self.mw.session_path, "manual_additions.json")
+
+        # Load existing additions
+        if os.path.exists(additions_file):
+            try:
+                with open(additions_file, 'r', encoding='utf-8') as f:
+                    additions = json.load(f)
+            except Exception as e:
+                self.log.error(f"Failed to load manual additions: {e}")
+                additions = []
+        else:
+            additions = []
+
+        # Add new entry
+        additions.append({
+            "order_number": product_data["order_number"],
+            "sku": product_data["sku"],
+            "product_name": product_data["product_name"],
+            "quantity": product_data["quantity"],
+            "timestamp": datetime.now().isoformat()
+        })
+
+        # Save back
+        try:
+            with open(additions_file, 'w', encoding='utf-8') as f:
+                json.dump(additions, f, indent=2, ensure_ascii=False)
+            self.log.info(f"Saved manual addition to {additions_file}")
+        except Exception as e:
+            self.log.error(f"Failed to save manual additions: {e}")

--- a/gui/add_product_dialog.py
+++ b/gui/add_product_dialog.py
@@ -1,0 +1,383 @@
+"""
+Dialog for manually adding products to orders.
+
+This dialog allows users to add products to existing orders with:
+- Search/autocomplete for order numbers
+- Search/autocomplete for SKUs
+- Real-time validation
+- Stock warnings
+- Live stock display
+"""
+
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout,
+    QLineEdit, QSpinBox, QLabel, QPushButton,
+    QGroupBox, QMessageBox, QCompleter, QWidget
+)
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AddProductDialog(QDialog):
+    """
+    Dialog for manually adding product to order.
+
+    User workflow:
+    1. Type order number (with autocomplete)
+    2. Type SKU (with autocomplete from stock)
+    3. Enter quantity
+    4. Click Add
+    → Product added to analysis_df
+    → Fulfillment recalculated for this order only
+    → Saved to session
+    → NO full re-analysis!
+    """
+
+    def __init__(self, parent, analysis_df, stock_df, live_stock):
+        super().__init__(parent)
+
+        self.analysis_df = analysis_df
+        self.stock_df = stock_df
+        self.live_stock = live_stock  # Current stock tracking dict
+        self.result = None
+
+        self.setup_ui()
+        self.setup_autocompleters()
+
+    def setup_ui(self):
+        """Setup dialog UI components."""
+        self.setWindowTitle("Add Product to Order")
+        self.setModal(True)
+        self.resize(500, 500)
+
+        layout = QVBoxLayout(self)
+
+        # Section 1: Order Number Input
+        layout.addWidget(self._create_order_section())
+
+        # Section 2: Product/SKU Input
+        layout.addWidget(self._create_product_section())
+
+        # Section 3: Quantity
+        layout.addWidget(self._create_quantity_section())
+
+        # Section 4: Info/Warning
+        self.warning_box = self._create_warning_box()
+        self.warning_box.setVisible(False)
+        layout.addWidget(self.warning_box)
+
+        self.info_box = self._create_info_box()
+        layout.addWidget(self.info_box)
+
+        # Section 5: Buttons
+        layout.addWidget(self._create_buttons())
+
+    def _create_order_section(self):
+        """Create order number input section."""
+        group = QGroupBox("ORDER NUMBER")
+        layout = QVBoxLayout(group)
+
+        layout.addWidget(QLabel("Enter order number:"))
+
+        self.order_input = QLineEdit()
+        self.order_input.setPlaceholderText("Type order number... (e.g., 1001)")
+        self.order_input.textChanged.connect(self._on_order_changed)
+        layout.addWidget(self.order_input)
+
+        # Status label (shows if order found)
+        self.order_status_label = QLabel("")
+        layout.addWidget(self.order_status_label)
+
+        return group
+
+    def _create_product_section(self):
+        """Create SKU input section."""
+        group = QGroupBox("PRODUCT SKU")
+        layout = QVBoxLayout(group)
+
+        layout.addWidget(QLabel("Enter product SKU:"))
+
+        self.sku_input = QLineEdit()
+        self.sku_input.setPlaceholderText("Type SKU... (e.g., SKU-HAT)")
+        self.sku_input.textChanged.connect(self._on_sku_changed)
+        layout.addWidget(self.sku_input)
+
+        # Product info label (shows name + stock)
+        self.product_info_label = QLabel("")
+        layout.addWidget(self.product_info_label)
+
+        return group
+
+    def _create_quantity_section(self):
+        """Create quantity input section."""
+        group = QGroupBox("QUANTITY")
+        layout = QVBoxLayout(group)
+
+        layout.addWidget(QLabel("Quantity to add:"))
+
+        self.quantity_spin = QSpinBox()
+        self.quantity_spin.setMinimum(1)
+        self.quantity_spin.setMaximum(9999)
+        self.quantity_spin.setValue(1)
+        layout.addWidget(self.quantity_spin)
+
+        return group
+
+    def _create_warning_box(self):
+        """Create warning box for low/zero stock."""
+        label = QLabel()
+        label.setWordWrap(True)
+        label.setStyleSheet("""
+            QLabel {
+                background-color: #FFEBEE;
+                border: 2px solid #F44336;
+                border-radius: 5px;
+                padding: 10px;
+            }
+        """)
+        return label
+
+    def _create_info_box(self):
+        """Create info box."""
+        text = (
+            "ℹ️ INFO\n\n"
+            "• Product will be added with Source: 'Manual'\n"
+            "• Fulfillment will be recalculated for this order\n"
+            "• Manual addition will be saved in session\n"
+            "• NO full re-analysis needed"
+        )
+
+        label = QLabel(text)
+        label.setWordWrap(True)
+        label.setStyleSheet("""
+            QLabel {
+                background-color: #E3F2FD;
+                border: 2px solid #2196F3;
+                border-radius: 5px;
+                padding: 10px;
+            }
+        """)
+        return label
+
+    def _create_buttons(self):
+        """Create Cancel/Add buttons."""
+        widget = QWidget()
+        layout = QHBoxLayout(widget)
+        layout.addStretch()
+
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        layout.addWidget(cancel_btn)
+
+        self.add_btn = QPushButton("Add Product")
+        self.add_btn.clicked.connect(self._on_add_clicked)
+        self.add_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #2196F3;
+                color: white;
+                padding: 8px 16px;
+            }
+            QPushButton:hover {
+                background-color: #1976D2;
+            }
+        """)
+        layout.addWidget(self.add_btn)
+
+        return widget
+
+    def setup_autocompleters(self):
+        """Setup autocomplete for order and SKU inputs."""
+        # Order number autocomplete
+        order_numbers = self.analysis_df["Order_Number"].unique().tolist()
+        order_numbers = [str(o) for o in order_numbers]  # Convert to strings
+
+        order_completer = QCompleter(order_numbers, self)
+        order_completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self.order_input.setCompleter(order_completer)
+
+        # SKU autocomplete (from stock)
+        skus = self.stock_df["SKU"].unique().tolist()
+        skus = [str(s) for s in skus]
+
+        sku_completer = QCompleter(skus, self)
+        sku_completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self.sku_input.setCompleter(sku_completer)
+
+    def _on_order_changed(self, text):
+        """Handle order number input change."""
+        if not text:
+            self.order_status_label.setText("")
+            return
+
+        # Check if order exists
+        order_exists = text in self.analysis_df["Order_Number"].values
+
+        if order_exists:
+            # Get order info
+            order_rows = self.analysis_df[
+                self.analysis_df["Order_Number"] == text
+            ]
+            item_count = len(order_rows)
+            status = order_rows.iloc[0]["Order_Fulfillment_Status"]
+
+            self.order_status_label.setText(
+                f"✓ Order found: {item_count} items, Status: {status}"
+            )
+            self.order_status_label.setStyleSheet("color: green;")
+        else:
+            self.order_status_label.setText("✗ Order not found")
+            self.order_status_label.setStyleSheet("color: red;")
+
+    def _on_sku_changed(self, text):
+        """Handle SKU input change."""
+        if not text:
+            self.product_info_label.setText("")
+            self.warning_box.setVisible(False)
+            return
+
+        # Check if SKU exists in stock
+        stock_row = self.stock_df[self.stock_df["SKU"] == text]
+
+        if stock_row.empty:
+            self.product_info_label.setText("✗ SKU not found in stock")
+            self.product_info_label.setStyleSheet("color: red;")
+            return
+
+        # Get product info
+        product_name = stock_row.iloc[0].get("Product_Name", "")
+        current_stock = self.live_stock.get(text, 0)
+
+        self.product_info_label.setText(
+            f"✓ {product_name} | Live stock: {current_stock}"
+        )
+        self.product_info_label.setStyleSheet("color: green;")
+
+        # Show warning if low/zero stock
+        if current_stock == 0:
+            warning_text = (
+                "⚠️ WARNING\n\n"
+                f"Product {text} has 0 stock available!\n"
+                "Adding this product will affect order fulfillment."
+            )
+            self.warning_box.setText(warning_text)
+            self.warning_box.setVisible(True)
+            self.warning_box.setStyleSheet("""
+                QLabel {
+                    background-color: #FFEBEE;
+                    border: 2px solid #F44336;
+                    border-radius: 5px;
+                    padding: 10px;
+                }
+            """)
+        elif current_stock < 5:
+            warning_text = (
+                "⚠️ WARNING\n\n"
+                f"Product {text} has low stock ({current_stock} units)."
+            )
+            self.warning_box.setText(warning_text)
+            self.warning_box.setVisible(True)
+            self.warning_box.setStyleSheet("""
+                QLabel {
+                    background-color: #FFF8E1;
+                    border: 2px solid #FFC107;
+                    border-radius: 5px;
+                    padding: 10px;
+                }
+            """)
+        else:
+            self.warning_box.setVisible(False)
+
+    def _on_add_clicked(self):
+        """Handle Add Product button click."""
+        # Validate inputs
+        if not self._validate():
+            return
+
+        # Get values
+        order_number = self.order_input.text().strip()
+        sku = self.sku_input.text().strip()
+        quantity = self.quantity_spin.value()
+
+        # Get product name from stock
+        stock_row = self.stock_df[self.stock_df["SKU"] == sku]
+        product_name = stock_row.iloc[0].get("Product_Name", sku) if not stock_row.empty else sku
+
+        # Store result
+        self.result = {
+            "order_number": order_number,
+            "sku": sku,
+            "product_name": product_name,
+            "quantity": quantity
+        }
+
+        logger.info(f"Adding product: {self.result}")
+
+        # Close dialog with accepted
+        self.accept()
+
+    def _validate(self):
+        """Validate user inputs."""
+        order_number = self.order_input.text().strip()
+        sku = self.sku_input.text().strip()
+
+        # Check order number entered
+        if not order_number:
+            QMessageBox.warning(
+                self,
+                "Validation Error",
+                "Please enter an order number."
+            )
+            self.order_input.setFocus()
+            return False
+
+        # Check order exists
+        if order_number not in self.analysis_df["Order_Number"].values:
+            QMessageBox.warning(
+                self,
+                "Validation Error",
+                f"Order '{order_number}' not found in analysis."
+            )
+            self.order_input.setFocus()
+            return False
+
+        # Check SKU entered
+        if not sku:
+            QMessageBox.warning(
+                self,
+                "Validation Error",
+                "Please enter a product SKU."
+            )
+            self.sku_input.setFocus()
+            return False
+
+        # Check SKU exists in stock
+        if sku not in self.stock_df["SKU"].values:
+            reply = QMessageBox.question(
+                self,
+                "SKU Not Found",
+                f"SKU '{sku}' not found in stock file.\n\n"
+                "Do you want to add it anyway?",
+                QMessageBox.Yes | QMessageBox.No
+            )
+            if reply == QMessageBox.No:
+                self.sku_input.setFocus()
+                return False
+
+        # Check quantity
+        if self.quantity_spin.value() < 1:
+            QMessageBox.warning(
+                self,
+                "Validation Error",
+                "Quantity must be at least 1."
+            )
+            self.quantity_spin.setFocus()
+            return False
+
+        return True
+
+    def get_result(self):
+        """Get dialog result after accept."""
+        return self.result

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -166,6 +166,8 @@ class MainWindow(QMainWindow):
                     self.packing_list_button.setEnabled(False)
                 if hasattr(self, 'stock_export_button'):
                     self.stock_export_button.setEnabled(False)
+                if hasattr(self, 'add_product_button'):
+                    self.add_product_button.setEnabled(False)
 
                 self.log_activity("Client", f"Switched to CLIENT_{client_id}")
             else:
@@ -222,6 +224,7 @@ class MainWindow(QMainWindow):
         # Main actions
         self.run_analysis_button.clicked.connect(self.actions_handler.run_analysis)
         self.settings_button.clicked.connect(self.actions_handler.open_settings_window)
+        self.add_product_button.clicked.connect(self.actions_handler.show_add_product_dialog)
 
         # Reports
         self.packing_list_button.clicked.connect(
@@ -394,6 +397,8 @@ class MainWindow(QMainWindow):
                         self.packing_list_button.setEnabled(True)
                     if hasattr(self, 'stock_export_button'):
                         self.stock_export_button.setEnabled(True)
+                    if hasattr(self, 'add_product_button'):
+                        self.add_product_button.setEnabled(True)
 
                     self.log_activity("Session", f"Loaded session: {session_name}")
                     QMessageBox.information(

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -347,6 +347,17 @@ class UIManager:
         actions_layout.addWidget(self.mw.settings_button)
         main_layout.addLayout(actions_layout)
 
+        # Manual operations
+        manual_layout = QHBoxLayout()
+        self.mw.add_product_button = QPushButton("➕ Add Product to Order")
+        self.mw.add_product_button.setEnabled(False)  # Disabled until analysis run
+        self.mw.add_product_button.setToolTip(
+            "Manually add a product to an existing order"
+        )
+        manual_layout.addWidget(self.mw.add_product_button)
+        manual_layout.addStretch()
+        main_layout.addLayout(manual_layout)
+
         return group
 
     def _create_tab_view(self):
@@ -460,6 +471,10 @@ class UIManager:
 
         self.mw.packing_list_button.setEnabled(not is_busy and is_data_loaded)
         self.mw.stock_export_button.setEnabled(not is_busy and is_data_loaded)
+
+        # Enable "Add Product" button after analysis
+        if hasattr(self.mw, 'add_product_button'):
+            self.mw.add_product_button.setEnabled(not is_busy and is_data_loaded)
 
         self.log.debug(f"UI busy state set to: {is_busy}, data_loaded: {is_data_loaded}")
 

--- a/shopify_tool/packing_lists.py
+++ b/shopify_tool/packing_lists.py
@@ -102,8 +102,9 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
         logger.info(f"Found {filtered_orders['Order_Number'].nunique()} orders for the report.")
 
         # Fill NaN values to avoid issues during processing
-        for col in ["Destination_Country", "Product_Name", "SKU"]:
-            filtered_orders[col] = filtered_orders[col].fillna("")
+        for col in ["Destination_Country", "Warehouse_Name", "SKU"]:
+            if col in filtered_orders.columns:
+                filtered_orders[col] = filtered_orders[col].fillna("")
 
         # Sort the list for optimal packing order
         provider_map = {"DHL": 0, "PostOne": 1, "DPD": 2}
@@ -120,7 +121,7 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
             "Destination_Country",
             "Order_Number",
             "SKU",
-            "Product_Name",
+            "Warehouse_Name",  # From stock file - actual warehouse product names
             "Quantity",
             "Shipping_Provider",
         ]
@@ -130,7 +131,7 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
         output_filename = os.path.basename(output_file)
 
         # Rename columns to embed metadata into the header
-        rename_map = {"Shipping_Provider": generation_timestamp, "Product_Name": output_filename}
+        rename_map = {"Shipping_Provider": generation_timestamp, "Warehouse_Name": output_filename}
         print_list = print_list.rename(columns=rename_map)
 
         logger.info("Creating Excel file...")
@@ -193,7 +194,7 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
                 original_col_name = columns_for_print[i]
                 if original_col_name == "Destination_Country":
                     max_len = 5
-                elif original_col_name == "Product_Name":
+                elif original_col_name == "Warehouse_Name":
                     max_len = min(max_len, 45)
                 elif original_col_name == "SKU":
                     max_len = min(max_len, 25)


### PR DESCRIPTION
PHASE 1: Warehouse_Name Column
- Add Warehouse_Name column from stock file to preserve original product names
- Update analysis.py to create stock name lookup and map to orders
- Update packing_lists.py to use Warehouse_Name instead of Product_Name
- Add Source column to track "Order" vs "Manual" additions
- Ensures set components show actual warehouse names, not set names

PHASE 2: Add Product Dialog UI
- Create AddProductDialog with search/autocomplete for orders and SKUs
- Replace dropdown approach with QLineEdit + QCompleter for better UX
- Add real-time validation showing order/product status
- Display live stock levels and warnings for low/zero stock
- Clean, fast workflow for manual product addition

PHASE 3: Manual Product Logic
- Implement show_add_product_dialog() with stock loading and validation
- Add _add_product_to_order() to insert products without full re-analysis
- CRITICAL: _recalculate_order_fulfillment() updates ONLY modified order
- Preserves repeated order detection logic (no re-analysis)
- Add _save_manual_addition() for session persistence
- Manual additions saved to manual_additions.json for history tracking
- Enable "Add Product" button after successful analysis

Key Features:
✅ Warehouse names preserved in separate column
✅ Search-based UI with autocomplete (not dropdowns) ✅ Real-time stock warnings and validation
✅ Local order fulfillment recalculation (no full re-analysis) ✅ Session persistence for manual additions
✅ Live stock tracking remains accurate
✅ Repeated order detection preserved

Technical Notes:
- Warehouse_Name populated after merge in analysis.py (line 250-273)
- Source column initialized as "Order" for all original items
- Manual additions get Source="Manual" for tracking
- Live stock rebuilt from Final_Stock column for accuracy
- No changes to core analysis logic - maintains stability