### PR TITLE
Implement auto-save for DataFrame modifications

### DIFF
--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -659,6 +659,8 @@ class ActionsHandler(QObject):
         if success:
             self.mw.analysis_results_df = updated_df
             self.data_changed.emit()
+            # Auto-save session state after modification
+            self.mw.save_session_state()
             new_status = updated_df.loc[updated_df["Order_Number"] == order_number, "Order_Fulfillment_Status"].iloc[0]
             self.mw.log_activity("Manual Edit", f"Order {order_number} status changed to '{new_status}'.")
             self.log.info(f"Order {order_number} status changed to '{new_status}'.")
@@ -689,6 +691,8 @@ class ActionsHandler(QObject):
                     new_notes = current_notes
                 self.mw.analysis_results_df.loc[index, "Status_Note"] = new_notes
             self.data_changed.emit()
+            # Auto-save session state after modification
+            self.mw.save_session_state()
             self.mw.log_activity("Manual Tag", f"Added note '{tag_to_add}' to order {order_number}.")
 
     def remove_item_from_order(self, order_number, sku):
@@ -716,6 +720,8 @@ class ActionsHandler(QObject):
 
             self.mw.analysis_results_df = self.mw.analysis_results_df[~mask].reset_index(drop=True)
             self.data_changed.emit()
+            # Auto-save session state after modification
+            self.mw.save_session_state()
             self.mw.log_activity("Data Edit", f"Removed item {sku} from order {order_number}.")
 
     def remove_entire_order(self, order_number):
@@ -738,6 +744,8 @@ class ActionsHandler(QObject):
 
             self.mw.analysis_results_df = self.mw.analysis_results_df[order_mask].reset_index(drop=True)
             self.data_changed.emit()
+            # Auto-save session state after modification
+            self.mw.save_session_state()
             self.mw.log_activity("Data Edit", f"Removed order {order_number}.")
 
     def show_add_product_dialog(self):

--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -938,7 +938,10 @@ class ActionsHandler(QObject):
         # Step 8: Emit data changed signal
         self.data_changed.emit()
 
-        # Step 9: Show success message
+        # Step 9: Auto-save session state after modification
+        self.mw.save_session_state()
+
+        # Step 10: Show success message
         QMessageBox.information(
             self.mw,
             "Product Added",

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -551,6 +551,36 @@ def run_full_analysis(
                     worksheet.set_row(row_num + 1, None, highlight_format)
         logger.info(f"Excel report saved to '{output_file_path}'")
 
+        # Save initial state files (current_state.pkl, current_state.xlsx, analysis_stats.json)
+        # This allows modifications to be tracked from the start
+        if use_session_mode:
+            try:
+                logger.info("Saving initial session state files...")
+
+                # Define file paths
+                current_state_pkl = Path(analysis_dir) / "current_state.pkl"
+                current_state_xlsx = Path(analysis_dir) / "current_state.xlsx"
+                stats_json = Path(analysis_dir) / "analysis_stats.json"
+
+                # Save DataFrame to pickle (fast loading)
+                logger.info(f"Saving current_state.pkl: {current_state_pkl}")
+                final_df.to_pickle(current_state_pkl)
+
+                # Save DataFrame to Excel (backup, human-readable)
+                logger.info(f"Saving current_state.xlsx: {current_state_xlsx}")
+                final_df.to_excel(current_state_xlsx, index=False)
+
+                # Save statistics to JSON
+                logger.info(f"Saving analysis_stats.json: {stats_json}")
+                with open(stats_json, 'w', encoding='utf-8') as f:
+                    json.dump(stats, f, indent=2, ensure_ascii=False)
+
+                logger.info("Initial session state files saved successfully")
+
+            except Exception as e:
+                logger.error(f"Failed to save initial session state: {e}", exc_info=True)
+                # Continue with the workflow even if initial state save fails
+
         # 3.5. Session mode: Export analysis_data.json and update session_info
         if use_session_mode:
             try:


### PR DESCRIPTION
## Changes

### 1. Added save_session_state() method (gui/main_window_pyside.py)
- Saves current DataFrame state after every modification
- Creates three files in session/analysis/:
  * current_state.pkl (fast, primary format)
  * current_state.xlsx (backup, human-readable)
  * analysis_stats.json (statistics dictionary)
- Graceful error handling - logs errors without blocking UI

### 2. Enhanced _load_session_analysis() (gui/main_window_pyside.py)
- Priority loading: pkl > xlsx > original analysis_report.xlsx
- Fallback mechanism if pickle corrupted
- Loads statistics from JSON if available
- Backward compatible with old sessions

### 3. Auto-save after modifications (gui/actions_handler.py) Added save_session_state() calls after:
- toggle_fulfillment_status_for_order()
- add_tag_manually()
- remove_item_from_order()
- remove_entire_order()

### 4. Save initial state (shopify_tool/core.py)
- run_full_analysis() now saves initial current_state files
- Ensures state tracking from analysis start
- Only in session mode, not legacy mode

## Benefits
- User modifications persist across session reloads
- Fast loading with pickle, reliable fallback with Excel
- Prepares infrastructure for future undo functionality
- No impact on legacy code paths

## Testing
- All files compile without syntax errors
- Backward compatible with existing sessions
- Graceful degradation if files missing/corrupted