### PR TITLE
Add order-level rules to Rule Engine

### DIFF
--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -322,12 +322,17 @@ class SettingsWindow(QDialog):
         level_combo.setCurrentText(config.get("level", "article"))
         level_combo.setToolTip(
             "article: Apply to each item (row) individually\n"
-            "  → Use article-level fields (SKU, Product_Name, etc.)\n\n"
-            "order: Evaluate entire order and apply to first row only\n"
+            "  → Use article-level fields (SKU, Product_Name, etc.)\n"
+            "  → All actions apply to matching rows\n\n"
+            "order: Evaluate entire order based on aggregate data\n"
             "  → Use order-level fields:\n"
             "     • item_count - number of rows in order\n"
             "     • total_quantity - sum of all quantities\n"
-            "     • has_sku - check if order contains specific SKU"
+            "     • has_sku - check if order contains specific SKU\n"
+            "  → Actions behavior:\n"
+            "     • ADD_TAG - applies to ALL rows (for filtering)\n"
+            "     • ADD_ORDER_TAG - applies to first row only (for counting)\n"
+            "     • SET_PACKAGING_TAG - applies to first row only (for counting)"
         )
         level_layout.addWidget(level_combo)
         level_layout.addStretch()


### PR DESCRIPTION
Added support for both article-level (row-by-row) and order-level (entire order) rules to enable packaging logic and order-wide decisions.

## Changes

### Rule Engine (shopify_tool/rules.py)
- Added new comparison operators: `is greater than or equal`, `is less than or equal`
- Implemented operator functions: `_op_greater_than_or_equal()`, `_op_less_than_or_equal()`
- Added ORDER_LEVEL_FIELDS: `item_count`, `total_quantity`, `has_sku`
- Implemented order-level condition evaluation: `_evaluate_order_conditions()`
- Added calculation methods:
  - `_calculate_item_count()`: Counts unique items (rows) in order
  - `_calculate_total_quantity()`: Sums all quantities in order
  - `_check_has_sku()`: Checks if order contains specific SKU
- Updated `apply()` to handle both article and order-level rules
- Added new action types:
  - `SET_PACKAGING_TAG`: Sets packaging tag (overwrites existing)
  - `ADD_ORDER_TAG`: Adds tag to Status_Note for order-level tagging
- Updated `_prepare_df_for_actions()` to create Packaging_Tags column

### Settings UI (gui/settings_window_pyside.py)
- Added level selector (article/order) to rule configuration UI
- Updated CONDITION_FIELDS to include order-level fields
- Updated CONDITION_OPERATORS to include new comparison operators
- Updated ACTION_TYPES to include SET_PACKAGING_TAG and ADD_ORDER_TAG
- Modified `add_rule_widget()` to display level selector with tooltips
- Updated `save_settings()` to persist level field in rule configs

### Tests (tests/test_rules.py)
- Added comprehensive test suite for order-level rules:
  - `test_order_level_item_count()`: Tests item count conditions
  - `test_order_level_has_sku()`: Tests SKU presence detection
  - `test_order_level_total_quantity()`: Tests quantity summation
  - `test_order_and_article_level_rules_together()`: Tests mixed rule types
  - `test_new_operators_greater_than_or_equal()`: Tests >= operator
  - `test_new_operators_less_than_or_equal()`: Tests <= operator
  - `test_order_level_backwards_compatibility()`: Tests default behavior
  - `test_set_packaging_tag_action()`: Tests packaging tag action
  - `test_add_order_tag_action()`: Tests order-level tagging

## Backwards Compatibility
- Rules without "level" field default to "article" (existing behavior)
- All existing rules continue to work unchanged

## Use Cases
- Packaging logic: Determine bag/box type based on order contents
- Order-level tagging: Tag orders based on aggregate criteria
- Quantity-based rules: Apply logic based on total order quantity
- SKU detection: Check if specific SKUs are present in order