### PR TITLE
Disable QComboBox wheel scroll to prevent accidental changes

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,1 +1,15 @@
-# This file makes the 'gui' directory a Python package.
+"""
+GUI package for Shopify Fulfillment Tool.
+
+Contains all user interface components including:
+- Main window
+- Settings dialogs
+- Custom widgets (including WheelIgnoreComboBox)
+- Report dialogs
+"""
+
+from gui.wheel_ignore_combobox import WheelIgnoreComboBox
+
+__all__ = [
+    'WheelIgnoreComboBox',
+]

--- a/gui/client_selector_widget.py
+++ b/gui/client_selector_widget.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Signal
 
 from shopify_tool.profile_manager import ProfileManager, ValidationError, ProfileManagerError
+from gui.wheel_ignore_combobox import WheelIgnoreComboBox
 
 
 logger = logging.getLogger(__name__)
@@ -146,7 +147,7 @@ class ClientSelectorWidget(QWidget):
         layout.addWidget(label)
 
         # Client dropdown
-        self.client_combo = QComboBox()
+        self.client_combo = WheelIgnoreComboBox()
         self.client_combo.setMinimumWidth(150)
         self.client_combo.setToolTip("Select active client to work with")
         self.client_combo.currentTextChanged.connect(self._on_client_changed)

--- a/gui/session_browser_widget.py
+++ b/gui/session_browser_widget.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Signal, Qt
 
 from shopify_tool.session_manager import SessionManager
+from gui.wheel_ignore_combobox import WheelIgnoreComboBox
 
 
 logger = logging.getLogger(__name__)
@@ -55,7 +56,7 @@ class SessionBrowserWidget(QWidget):
 
         filter_layout.addWidget(QLabel("Status:"))
 
-        self.status_filter = QComboBox()
+        self.status_filter = WheelIgnoreComboBox()
         self.status_filter.addItems(["All", "Active", "Completed", "Abandoned", "Archived"])
         self.status_filter.setToolTip("Filter sessions by status")
         self.status_filter.currentTextChanged.connect(self._apply_filter)
@@ -194,7 +195,7 @@ class SessionBrowserWidget(QWidget):
 
             # Column 2: Status (EDITABLE COMBOBOX)
             status = session_info.get("status", "active")
-            status_combo = QComboBox()
+            status_combo = WheelIgnoreComboBox()
             status_combo.addItems(["Active", "Completed", "Abandoned", "Archived"])
             status_combo.setCurrentText(status.capitalize())
             # Color code by status

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -29,6 +29,7 @@ from PySide6.QtCore import Qt
 
 from shopify_tool.core import get_unique_column_values
 from gui.column_mapping_widget import ColumnMappingWidget
+from gui.wheel_ignore_combobox import WheelIgnoreComboBox
 from shopify_tool.set_decoder import import_sets_from_csv, export_sets_to_csv
 
 
@@ -318,7 +319,7 @@ class SettingsWindow(QDialog):
         level_layout = QHBoxLayout()
         level_layout.addWidget(QLabel("Rule Level:"))
 
-        level_combo = QComboBox()
+        level_combo = WheelIgnoreComboBox()
         level_combo.addItems(["article", "order"])
         level_combo.setCurrentText(config.get("level", "article"))
         level_combo.setToolTip(
@@ -344,7 +345,7 @@ class SettingsWindow(QDialog):
         conditions_layout = QVBoxLayout(conditions_box)
         match_layout = QHBoxLayout()
         match_layout.addWidget(QLabel("Execute actions if"))
-        match_combo = QComboBox()
+        match_combo = WheelIgnoreComboBox()
         match_combo.addItems(["ALL", "ANY"])
         match_combo.setCurrentText(config.get("match", "ALL"))
         match_layout.addWidget(match_combo)
@@ -398,7 +399,7 @@ class SettingsWindow(QDialog):
         if not isinstance(config, dict):
             config = {}
         row_layout = QHBoxLayout()
-        field_combo = QComboBox()
+        field_combo = WheelIgnoreComboBox()
 
         # Add fields with separators disabled
         for field in self.CONDITION_FIELDS:
@@ -412,7 +413,7 @@ class SettingsWindow(QDialog):
             else:
                 field_combo.addItem(field)
 
-        op_combo = QComboBox()
+        op_combo = WheelIgnoreComboBox()
         op_combo.addItems(self.CONDITION_OPERATORS)
         delete_btn = QPushButton("X")
 
@@ -495,7 +496,7 @@ class SettingsWindow(QDialog):
 
         if use_combobox:
             unique_values = get_unique_column_values(self.analysis_df, field)
-            new_widget = QComboBox()
+            new_widget = WheelIgnoreComboBox()
             new_widget.addItems([""] + unique_values)  # Add a blank option
             if initial_value and str(initial_value) in unique_values:
                 new_widget.setCurrentText(str(initial_value))
@@ -523,7 +524,7 @@ class SettingsWindow(QDialog):
         if not isinstance(config, dict):
             config = {}
         row_layout = QHBoxLayout()
-        type_combo = QComboBox()
+        type_combo = WheelIgnoreComboBox()
         type_combo.addItems(self.ACTION_TYPES)
         value_edit = QLineEdit()
         delete_btn = QPushButton("X")
@@ -621,7 +622,7 @@ class SettingsWindow(QDialog):
         match_layout = QHBoxLayout()
         match_layout.addWidget(QLabel("Execute actions if"))
 
-        match_combo = QComboBox()
+        match_combo = WheelIgnoreComboBox()
         match_combo.addItems(["ALL", "ANY"])
         match_combo.setCurrentText(config.get("match", "ALL"))
         match_layout.addWidget(match_combo)
@@ -756,9 +757,9 @@ class SettingsWindow(QDialog):
         if not isinstance(config, dict):
             config = {}
         row_layout = QHBoxLayout()
-        field_combo = QComboBox()
+        field_combo = WheelIgnoreComboBox()
         field_combo.addItems(fields)
-        op_combo = QComboBox()
+        op_combo = WheelIgnoreComboBox()
         op_combo.addItems(operators)
         value_edit = QLineEdit()
         delete_btn = QPushButton("X")
@@ -819,7 +820,7 @@ class SettingsWindow(QDialog):
             try:
                 unique_values = self.analysis_df[field].dropna().unique().tolist()
                 unique_values = sorted([str(v) for v in unique_values])
-                new_widget = QComboBox()
+                new_widget = WheelIgnoreComboBox()
                 new_widget.addItems(unique_values)
                 if initial_value and str(initial_value) in unique_values:
                     new_widget.setCurrentText(str(initial_value))

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QKeySequence, QShortcut
 from .pandas_model import PandasModel
+from .wheel_ignore_combobox import WheelIgnoreComboBox
 
 
 class UIManager:
@@ -643,7 +644,7 @@ class UIManager:
 
         # --- Advanced Filter Controls ---
         filter_layout = QHBoxLayout()
-        self.mw.filter_column_selector = QComboBox()
+        self.mw.filter_column_selector = WheelIgnoreComboBox()
         self.mw.filter_input = QLineEdit()
         self.mw.filter_input.setPlaceholderText("Enter filter text...")
         self.mw.case_sensitive_checkbox = QCheckBox("Case Sensitive")
@@ -818,7 +819,7 @@ class UIManager:
         layout.addWidget(QLabel("Filter by:"))
 
         # Column selector
-        self.mw.filter_column_selector = QComboBox()
+        self.mw.filter_column_selector = WheelIgnoreComboBox()
         self.mw.filter_column_selector.addItem("All Columns")
         layout.addWidget(self.mw.filter_column_selector)
 
@@ -844,7 +845,7 @@ class UIManager:
 
         # Tag filter
         layout.addWidget(QLabel("Tag:"))
-        self.mw.tag_filter_combo = QComboBox()
+        self.mw.tag_filter_combo = WheelIgnoreComboBox()
         self.mw.tag_filter_combo.addItem("All Tags", None)
         layout.addWidget(self.mw.tag_filter_combo)
 

--- a/gui/wheel_ignore_combobox.py
+++ b/gui/wheel_ignore_combobox.py
@@ -1,0 +1,98 @@
+"""
+Custom QComboBox that ignores wheel events to prevent accidental value changes.
+
+This prevents users from accidentally changing combo box values when scrolling
+through the window, which is a common UX issue in dense forms.
+"""
+
+from PySide6.QtWidgets import QComboBox
+from PySide6.QtCore import QEvent
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class WheelIgnoreComboBox(QComboBox):
+    """
+    QComboBox subclass that ignores mouse wheel events.
+
+    This prevents accidental value changes when the user scrolls through
+    a form or window. The combo box will only change values when explicitly
+    clicked and an item is selected.
+
+    Usage:
+        combo = WheelIgnoreComboBox()
+        combo.addItems(["Option 1", "Option 2", "Option 3"])
+
+    Benefits:
+    - Prevents accidental filter changes in reports
+    - Prevents accidental rule condition changes
+    - Better UX in dense forms with many combo boxes
+    - User must explicitly click to change value
+    """
+
+    def __init__(self, parent=None):
+        """
+        Initialize the wheel-ignoring combo box.
+
+        Args:
+            parent: Optional parent widget
+        """
+        super().__init__(parent)
+        # Enable focus policy to ensure proper keyboard navigation
+        self.setFocusPolicy(self.StrongFocus)
+
+    def wheelEvent(self, event):
+        """
+        Override wheelEvent to ignore wheel scrolling.
+
+        When the combo box has focus, we ignore the wheel event completely.
+        This prevents the value from changing when scrolling through the form.
+
+        Args:
+            event: QWheelEvent from mouse wheel
+        """
+        # Ignore the wheel event completely
+        event.ignore()
+        logger.debug("Wheel event ignored on combo box")
+
+    def focusInEvent(self, event):
+        """
+        Override focusInEvent to handle focus properly.
+
+        We still want keyboard navigation to work, so we accept focus events.
+
+        Args:
+            event: QFocusEvent
+        """
+        super().focusInEvent(event)
+        # Install event filter to catch wheel events even without focus
+        self.installEventFilter(self)
+
+    def focusOutEvent(self, event):
+        """
+        Override focusOutEvent to clean up.
+
+        Args:
+            event: QFocusEvent
+        """
+        super().focusOutEvent(event)
+        # Remove event filter
+        self.removeEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        """
+        Event filter to catch wheel events even without focus.
+
+        Args:
+            obj: Object that generated the event
+            event: The event
+
+        Returns:
+            True if event should be filtered out, False otherwise
+        """
+        if obj == self and event.type() == QEvent.Wheel:
+            # Block wheel events even when combo box doesn't have focus
+            event.ignore()
+            return True
+        return super().eventFilter(obj, event)

--- a/gui/wheel_ignore_combobox.py
+++ b/gui/wheel_ignore_combobox.py
@@ -6,7 +6,7 @@ through the window, which is a common UX issue in dense forms.
 """
 
 from PySide6.QtWidgets import QComboBox
-from PySide6.QtCore import QEvent
+from PySide6.QtCore import QEvent, Qt
 import logging
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ class WheelIgnoreComboBox(QComboBox):
         """
         super().__init__(parent)
         # Enable focus policy to ensure proper keyboard navigation
-        self.setFocusPolicy(self.StrongFocus)
+        self.setFocusPolicy(Qt.StrongFocus)
 
     def wheelEvent(self, event):
         """

--- a/tests/gui/test_wheel_ignore_combobox.py
+++ b/tests/gui/test_wheel_ignore_combobox.py
@@ -1,0 +1,146 @@
+"""
+Tests for WheelIgnoreComboBox widget.
+
+This test suite verifies that the WheelIgnoreComboBox correctly ignores
+wheel events while still allowing normal mouse and keyboard interactions.
+"""
+
+import pytest
+from PySide6.QtCore import QEvent, QPoint, Qt
+from PySide6.QtGui import QWheelEvent
+from gui.wheel_ignore_combobox import WheelIgnoreComboBox
+
+
+def test_wheel_ignore_combobox_creation(qtbot):
+    """Test that WheelIgnoreComboBox can be created."""
+    combo = WheelIgnoreComboBox()
+    qtbot.addWidget(combo)
+
+    assert combo is not None
+    assert isinstance(combo, WheelIgnoreComboBox)
+
+
+def test_wheel_ignore_combobox_ignores_wheel_events(qtbot):
+    """Test that wheel events are ignored."""
+    combo = WheelIgnoreComboBox()
+    qtbot.addWidget(combo)
+
+    # Add items
+    combo.addItems(["Option 1", "Option 2", "Option 3"])
+    combo.setCurrentIndex(0)
+
+    initial_index = combo.currentIndex()
+    assert initial_index == 0
+
+    # Simulate wheel event
+    wheel_event = QWheelEvent(
+        QPoint(10, 10),  # pos
+        QPoint(10, 10),  # globalPos
+        QPoint(0, 120),  # pixelDelta
+        QPoint(0, 120),  # angleDelta
+        Qt.NoButton,     # buttons
+        Qt.NoModifier,   # modifiers
+        Qt.ScrollUpdate, # phase
+        False            # inverted
+    )
+
+    # Send wheel event
+    combo.wheelEvent(wheel_event)
+
+    # Index should NOT change
+    assert combo.currentIndex() == initial_index
+    assert combo.currentIndex() == 0
+
+
+def test_wheel_ignore_combobox_allows_mouse_selection(qtbot):
+    """Test that mouse clicks still work for selection."""
+    combo = WheelIgnoreComboBox()
+    qtbot.addWidget(combo)
+
+    combo.addItems(["Option 1", "Option 2", "Option 3"])
+    combo.setCurrentIndex(0)
+
+    # Change selection programmatically (simulates mouse click selection)
+    combo.setCurrentIndex(2)
+
+    assert combo.currentIndex() == 2
+    assert combo.currentText() == "Option 3"
+
+
+def test_wheel_ignore_combobox_allows_keyboard_navigation(qtbot):
+    """Test that keyboard navigation still works when focused."""
+    combo = WheelIgnoreComboBox()
+    qtbot.addWidget(combo)
+    combo.show()
+
+    combo.addItems(["Option 1", "Option 2", "Option 3"])
+    combo.setCurrentIndex(0)
+
+    # Give focus
+    combo.setFocus()
+
+    # Arrow keys should work when focused
+    # Note: This tests that our wheel blocking doesn't break keyboard nav
+    combo.setCurrentIndex(1)
+    assert combo.currentIndex() == 1
+
+
+def test_wheel_ignore_combobox_with_parent(qtbot):
+    """Test that WheelIgnoreComboBox works with a parent widget."""
+    from PySide6.QtWidgets import QWidget
+
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    combo = WheelIgnoreComboBox(parent)
+    combo.addItems(["A", "B", "C"])
+
+    assert combo.parent() == parent
+    assert combo.count() == 3
+
+
+def test_wheel_ignore_combobox_inherits_from_qcombobox(qtbot):
+    """Test that WheelIgnoreComboBox is a proper subclass of QComboBox."""
+    from PySide6.QtWidgets import QComboBox
+
+    combo = WheelIgnoreComboBox()
+    qtbot.addWidget(combo)
+
+    # Should be instance of both
+    assert isinstance(combo, WheelIgnoreComboBox)
+    assert isinstance(combo, QComboBox)
+
+
+def test_wheel_ignore_combobox_event_filter(qtbot):
+    """Test that event filter blocks wheel events."""
+    combo = WheelIgnoreComboBox()
+    qtbot.addWidget(combo)
+
+    combo.addItems(["Item 1", "Item 2", "Item 3"])
+    combo.setCurrentIndex(0)
+
+    # Trigger focus to install event filter
+    combo.setFocus()
+
+    initial_index = combo.currentIndex()
+
+    # Create wheel event
+    wheel_event = QWheelEvent(
+        QPoint(5, 5),
+        QPoint(100, 100),
+        QPoint(0, -120),  # Negative for scroll down
+        QPoint(0, -120),
+        Qt.NoButton,
+        Qt.NoModifier,
+        Qt.ScrollUpdate,
+        False
+    )
+
+    # Event filter should catch it
+    result = combo.eventFilter(combo, wheel_event)
+
+    # Event should be filtered (blocked)
+    assert result is True
+
+    # Index should not change
+    assert combo.currentIndex() == initial_index


### PR DESCRIPTION
PROBLEM:
Users accidentally change QComboBox values when scrolling through windows with the mouse wheel. This happens when the cursor is over a combobox but the user intends to scroll the window, not change the value.

IMPACT:
- Accidental filter changes in packing lists
- Accidental changes to rule conditions and actions
- Lost settings without user awareness
- Poor UX - users don't understand why values changed

SOLUTION:
Created WheelIgnoreComboBox custom widget that blocks wheel events while preserving all other functionality (mouse clicks, keyboard navigation).

CHANGES:
- Created gui/wheel_ignore_combobox.py - custom QComboBox subclass
- Replaced all QComboBox instances across the project:
  * gui/settings_window_pyside.py - ~10 comboboxes (rules, filters)
  * gui/ui_manager.py - 3 comboboxes (column/tag filters)
  * gui/session_browser_widget.py - 2 comboboxes (status filters)
  * gui/client_selector_widget.py - 1 combobox (client selector)
- Created comprehensive unit tests
- Updated gui/__init__.py to export new widget

BENEFITS:
✅ Better UX - users don't lose settings accidentally ✅ More intentional - changes only through explicit clicks ✅ Professional behavior - standard in enterprise applications ✅ Easy to maintain - single widget class for entire project