### PR TITLE
Extend Rule Engine SKU field operators

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -563,6 +563,33 @@ Condition: SKU equals "SHIPPING-PROTECT"
 Action: EXCLUDE_FROM_REPORT
 ```
 
+**Example 4: Identify Packaging Type by SKU Prefix**
+```yaml
+Rule Name: "Box Items Only"
+Level: order
+Condition: has_sku starts with "01-"
+Action: ADD_ORDER_TAG = "BOX_ONLY"
+
+Rule Name: "Bag Items Only"
+Level: order
+Condition: has_sku starts with "02-FACE-"
+Action: ADD_ORDER_TAG = "BAG_ONLY"
+
+Rule Name: "Mixed Packaging"
+Level: order
+Match: ALL
+Conditions:
+  - has_sku starts with "01-"
+  - has_sku starts with "02-"
+Action: ADD_ORDER_TAG = "MIXED"
+```
+
+**Why use order-level rules with has_sku?**
+- **Packaging Detection**: Identify what type of packaging is needed based on SKU patterns
+- **Mixed Orders**: Detect orders that need multiple packaging types
+- **Workflow Automation**: Route orders to appropriate packing stations
+- **Inventory Planning**: Track which product types are selling together
+
 
 #### Managing Rules
 

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -200,29 +200,32 @@ class SettingsWindow(QDialog):
         """Get all available fields for rules from DataFrame + common fields.
 
         Returns a list of field names including:
-        - Common order-level fields (shown first)
-        - Common product fields
-        - Common shipping fields
+        - Order-level fields (shown first)
+        - Common article-level fields
         - All other DataFrame columns (dynamically discovered)
         - Separators (disabled items starting with "---")
         """
         import logging
         logger = logging.getLogger(__name__)
 
-        # Common fields (shown first with separators)
-        common_fields = [
-            "--- COMMON ORDER FIELDS ---",
-            "Order_Number",
-            "Order_Type",
+        # Start with order-level fields (these are ALWAYS available)
+        order_level_fields = [
+            "--- ORDER-LEVEL FIELDS ---",
             "item_count",
             "total_quantity",
-            "--- COMMON PRODUCT FIELDS ---",
+            "has_sku",
+        ]
+
+        # Common article-level fields
+        common_fields = [
+            "--- COMMON ARTICLE FIELDS ---",
+            "Order_Number",
+            "Order_Type",
             "SKU",
             "Product_Name",
             "Quantity",
             "Stock",
             "Final_Stock",
-            "--- COMMON SHIPPING FIELDS ---",
             "Shipping_Provider",
             "Shipping_Method",
             "Destination_Country",
@@ -250,17 +253,17 @@ class SettingsWindow(QDialog):
 
             logger.info(f"[RULE ENGINE] Found {len(custom_columns)} custom columns: {custom_columns}")
 
-            # Combine: common fields first, then separator, then custom
+            # Combine: order-level fields first, then common fields, then separator, then custom
             if custom_columns:
-                return common_fields + [
+                return order_level_fields + common_fields + [
                     "--- OTHER AVAILABLE FIELDS ---"
                 ] + custom_columns
             else:
-                return common_fields
+                return order_level_fields + common_fields
         else:
             logger.warning(f"[RULE ENGINE] No analysis_df available (is None: {self.analysis_df is None})")
 
-        return common_fields  # Fallback to common only
+        return order_level_fields + common_fields  # Fallback to order-level + common only
 
     def create_general_tab(self):
         """Creates the 'General Settings' tab."""


### PR DESCRIPTION
…rators

This commit extends the Rule Engine's has_sku order-level field to support multiple string operators (starts with, contains, ends with, etc.) and fixes missing order-level fields in the UI field selector.

Changes:

1. Extended _check_has_sku() method (shopify_tool/rules.py):
   - Added operator parameter (default "equals" for backward compatibility)
   - Supports 8 operators: equals, does not equal, contains, does not contain, starts with, ends with, is empty, is not empty
   - Uses existing operator functions from module
   - Returns True if ANY SKU in order matches condition

2. Updated _evaluate_order_conditions() (shopify_tool/rules.py):
   - Passes operator parameter to _check_has_sku()
   - Method now applies operator logic instead of ignoring it

3. Fixed UI field selector (gui/settings_window_pyside.py):
   - Reorganized get_available_rule_fields() to show order-level fields first
   - Order-level fields (item_count, total_quantity, has_sku) now appear at top
   - Properly separated from article-level fields with separators

4. Added comprehensive unit tests (tests/test_rules.py):
   - test_order_level_has_sku_starts_with: Tests SKU prefix matching
   - test_order_level_has_sku_mixed_detection: Tests multiple has_sku conditions
   - test_order_level_has_sku_negative_operators: Tests "does not contain"
   - test_ui_field_selector_includes_order_level_fields: Verifies UI changes

5. Updated documentation:
   - docs/FUNCTIONS.md: Added detailed documentation for _check_has_sku()
   - docs/USER_GUIDE.md: Added Example 4 showing packaging detection use case

Use Cases:
- Packaging detection: Identify box vs bag items by SKU prefix
- Mixed order detection: Orders with both box and bag items
- Workflow automation: Route orders to appropriate packing stations
- Negative matching: Orders without specific SKU patterns

Backward Compatibility:
- Default operator is "equals" for existing rules
- Unknown operators fallback to "equals" with warning log
- All existing rules continue to work without changes

Fixes: #176 (Extended SKU operators for order-level rules)
Related: v1.8.1 (Dynamic field discovery)