### PR TITLE
feat: Add configurable fulfillment status filter for reports

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -674,6 +674,87 @@ Most clients have pre-configured packing lists:
 [Screenshot placeholder: Packing list configuration in settings]
 ```
 
+#### Fulfillment Status Filter (Advanced)
+
+**What is it?**
+
+By default, packing lists and stock exports include only **"Fulfillable"** orders. The fulfillment status filter allows you to customize which orders appear in reports based on their fulfillment status.
+
+**Available Options:**
+
+| Filter Configuration | What it does |
+|---------------------|-------------|
+| **Enabled: Yes, Status: "Fulfillable"** | Default - Only fulfillable orders (backward compatible) |
+| **Enabled: Yes, Status: "Not Fulfillable"** | Only non-fulfillable orders (for troubleshooting) |
+| **Enabled: No** | All orders regardless of fulfillment status |
+| **Enabled: Yes, Status: ["Fulfillable", "Partial"]** | Multiple statuses (OR logic) |
+
+**Common Use Cases:**
+
+**Use Case 1: Troubleshooting Orders**
+```json
+{
+  "name": "Problem Orders Report",
+  "output_filename": "not_fulfillable.xlsx",
+  "fulfillment_status_filter": {
+    "enabled": true,
+    "status": "Not Fulfillable"
+  }
+}
+```
+Generate a report showing only orders that CANNOT be fulfilled to identify issues.
+
+**Use Case 2: All Orders Report**
+```json
+{
+  "name": "Complete Inventory Report",
+  "output_filename": "all_orders.xlsx",
+  "fulfillment_status_filter": {
+    "enabled": false
+  }
+}
+```
+Generate a comprehensive report including all orders regardless of fulfillment status.
+
+**Use Case 3: Multiple Statuses**
+```json
+{
+  "name": "Active Orders",
+  "output_filename": "active.xlsx",
+  "fulfillment_status_filter": {
+    "enabled": true,
+    "status": ["Fulfillable", "Partial"]
+  }
+}
+```
+Include orders with multiple fulfillment statuses.
+
+**Configuration in Client Settings:**
+
+To configure fulfillment status filtering for a report:
+
+1. Open Client Settings → Packing Lists (or Stock Exports) tab
+2. Select existing report or create new one
+3. In the JSON configuration, add `fulfillment_status_filter` section:
+   ```json
+   {
+     "name": "Your Report Name",
+     "output_filename": "report.xlsx",
+     "filters": [...],
+     "fulfillment_status_filter": {
+       "enabled": true,
+       "status": "Fulfillable"
+     }
+   }
+   ```
+4. Save configuration
+
+**⚠️ Important Notes:**
+- If `fulfillment_status_filter` is NOT specified, the default behavior is **Fulfillable only** (backward compatible)
+- This filter applies to both XLSX reports and JSON exports
+- Combines with other filters (e.g., courier filters) using AND logic
+- Stock exports aggregate quantities by SKU after filtering
+
 #### Understanding Packing List Format
 
 **Excel Output (for humans):**

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -796,13 +796,13 @@ class SettingsWindow(QDialog):
         ff_config = config.get("fulfillment_status_filter", {"enabled": True, "status": "Fulfillable"})
 
         # Enabled checkbox
-        ff_enabled_checkbox = QComboBox()
+        ff_enabled_checkbox = WheelIgnoreComboBox()
         ff_enabled_checkbox.addItems(["Yes", "No"])
         ff_enabled_checkbox.setCurrentText("Yes" if ff_config.get("enabled", True) else "No")
         fulfillment_layout.addRow("Filter Enabled:", ff_enabled_checkbox)
 
         # Status selection
-        ff_status_combo = QComboBox()
+        ff_status_combo = WheelIgnoreComboBox()
         ff_status_combo.addItems(["Fulfillable", "Not Fulfillable", "All (No Filter)"])
 
         # Set current value
@@ -997,13 +997,13 @@ class SettingsWindow(QDialog):
         ff_config = config.get("fulfillment_status_filter", {"enabled": True, "status": "Fulfillable"})
 
         # Enabled checkbox
-        ff_enabled_checkbox = QComboBox()
+        ff_enabled_checkbox = WheelIgnoreComboBox()
         ff_enabled_checkbox.addItems(["Yes", "No"])
         ff_enabled_checkbox.setCurrentText("Yes" if ff_config.get("enabled", True) else "No")
         fulfillment_layout.addRow("Filter Enabled:", ff_enabled_checkbox)
 
         # Status selection
-        ff_status_combo = QComboBox()
+        ff_status_combo = WheelIgnoreComboBox()
         ff_status_combo.addItems(["Fulfillable", "Not Fulfillable", "All (No Filter)"])
 
         # Set current value

--- a/shopify_tool/packing_lists.py
+++ b/shopify_tool/packing_lists.py
@@ -7,7 +7,45 @@ from .csv_utils import normalize_sku, normalize_sku_for_matching
 logger = logging.getLogger("ShopifyToolLogger")
 
 
-def create_packing_list(analysis_df, output_file, report_name="Packing List", filters=None, exclude_skus=None):
+def _build_fulfillment_filter(config):
+    """
+    Build fulfillment status filter query from configuration.
+
+    Args:
+        config: Report configuration dict
+
+    Returns:
+        List of query parts (empty if no filter needed)
+
+    Examples:
+        >>> _build_fulfillment_filter({"fulfillment_status_filter": {"enabled": True, "status": "Fulfillable"}})
+        ["Order_Fulfillment_Status == 'Fulfillable'"]
+
+        >>> _build_fulfillment_filter({"fulfillment_status_filter": {"enabled": False}})
+        []
+
+        >>> _build_fulfillment_filter({"fulfillment_status_filter": {"enabled": True, "status": ["Fulfillable", "Partial"]}})
+        ["Order_Fulfillment_Status in ['Fulfillable', 'Partial']"]
+    """
+    # Get config with backward-compatible defaults
+    fulfillment_cfg = config.get("fulfillment_status_filter", {})
+    enabled = fulfillment_cfg.get("enabled", True)  # Default: enabled
+
+    if not enabled:
+        return []  # No filter
+
+    status = fulfillment_cfg.get("status", "Fulfillable")  # Default: Fulfillable
+
+    # Support single status or list of statuses
+    if isinstance(status, list):
+        # Multiple statuses with OR logic
+        return [f"Order_Fulfillment_Status in {status}"]
+    else:
+        # Single status
+        return [f"Order_Fulfillment_Status == '{status}'"]
+
+
+def create_packing_list(analysis_df, output_file, report_name="Packing List", filters=None, exclude_skus=None, config=None):
     """Creates a versatile, formatted packing list in an Excel .xlsx file.
 
     This function takes the main analysis DataFrame and generates a packing list
@@ -15,8 +53,9 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
     warehouse picking and formatted for clarity.
 
     Key steps in the process:
-    1.  **Filtering**: It filters the main DataFrame to include only 'Fulfillable'
-        orders that match the provided filter criteria (e.g., by shipping provider).
+    1.  **Filtering**: It filters the main DataFrame based on fulfillment status
+        (configurable via config) and any additional filter criteria
+        (e.g., by shipping provider). By default, filters to 'Fulfillable' orders.
     2.  **Exclusion**: It can exclude specific SKUs from the final list, which is
         useful for items that are packed separately.
     3.  **Sorting**: The list is sorted by shipping provider, order number, and SKU
@@ -42,12 +81,15 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
             'field', 'operator', and 'value' keys. Defaults to None.
         exclude_skus (list[str], optional): A list of SKUs to exclude from the
             packing list. Defaults to None.
+        config (dict, optional): Report configuration dict containing
+            fulfillment_status_filter and other settings. Defaults to None.
     """
     try:
         logger.info(f"--- Creating report: '{report_name}' ---")
 
         # Build the query string to filter the DataFrame
-        query_parts = ["Order_Fulfillment_Status == 'Fulfillable'"]
+        # Build fulfillment filter from config (supports configurable filtering)
+        query_parts = _build_fulfillment_filter(config or {})
         if filters:
             for f in filters:
                 field = f.get("field")
@@ -67,8 +109,13 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
 
                 query_parts.append(f"`{field}` {operator} {formatted_value}")
 
-        full_query = " & ".join(query_parts)
-        filtered_orders = analysis_df.query(full_query).copy()
+        # Apply query only if there are filter conditions
+        if query_parts:
+            full_query = " & ".join(query_parts)
+            filtered_orders = analysis_df.query(full_query).copy()
+        else:
+            # No filters - use entire DataFrame
+            filtered_orders = analysis_df.copy()
 
         # Exclude specified SKUs if any are provided
         if exclude_skus and not filtered_orders.empty:

--- a/tests/test_packing_lists.py
+++ b/tests/test_packing_lists.py
@@ -217,3 +217,212 @@ def test_exclude_skus_with_numeric_types(tmp_path):
     # Ensure 7 and 789 are NOT in results
     assert 7 not in result_df["SKU"].values and "7" not in result_df["SKU"].values and "07" not in result_df["SKU"].values
     assert 789 not in result_df["SKU"].values and "789" not in result_df["SKU"].values
+
+
+# ============================================================================
+# Tests for Configurable Fulfillment Status Filter
+# ============================================================================
+
+
+def test_fulfillment_filter_default_behavior(tmp_path):
+    """Test backward compatibility - default filters to Fulfillable only."""
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable", "Not Fulfillable", "Fulfillable"],
+            "Order_Number": ["A1", "A2", "A3"],
+            "SKU": ["S1", "S2", "S3"],
+            "Product_Name": ["P1", "P2", "P3"],
+            "Quantity": [1, 1, 1],
+            "Shipping_Provider": ["DHL", "DHL", "DHL"],
+            "Destination_Country": ["BG", "US", "DE"],
+        }
+    )
+
+    out_file = tmp_path / "test_default.xlsx"
+
+    # No config provided - should default to Fulfillable
+    packing_lists.create_packing_list(df, str(out_file), report_name="TestDefault")
+
+    assert out_file.exists()
+    result_df = pd.read_excel(out_file)
+
+    # Should only contain Fulfillable orders (A1 and A3)
+    assert len(result_df) == 2
+    assert "A1" in result_df["Order_Number"].values
+    assert "A3" in result_df["Order_Number"].values
+    assert "A2" not in result_df["Order_Number"].values
+
+
+def test_fulfillment_filter_explicit_fulfillable(tmp_path):
+    """Test explicit Fulfillable filter in config."""
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable", "Not Fulfillable", "Fulfillable"],
+            "Order_Number": ["A1", "A2", "A3"],
+            "SKU": ["S1", "S2", "S3"],
+            "Product_Name": ["P1", "P2", "P3"],
+            "Quantity": [1, 1, 1],
+            "Shipping_Provider": ["DHL", "DHL", "DHL"],
+            "Destination_Country": ["BG", "US", "DE"],
+        }
+    )
+
+    out_file = tmp_path / "test_explicit_fulfillable.xlsx"
+
+    config = {"fulfillment_status_filter": {"enabled": True, "status": "Fulfillable"}}
+
+    packing_lists.create_packing_list(df, str(out_file), report_name="TestExplicit", config=config)
+
+    assert out_file.exists()
+    result_df = pd.read_excel(out_file)
+
+    # Should only contain Fulfillable orders
+    assert len(result_df) == 2
+    assert "A1" in result_df["Order_Number"].values
+    assert "A3" in result_df["Order_Number"].values
+
+
+def test_fulfillment_filter_not_fulfillable(tmp_path):
+    """Test filtering for NOT Fulfillable orders."""
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable", "Not Fulfillable", "Fulfillable", "Not Fulfillable"],
+            "Order_Number": ["A1", "A2", "A3", "A4"],
+            "SKU": ["S1", "S2", "S3", "S4"],
+            "Product_Name": ["P1", "P2", "P3", "P4"],
+            "Quantity": [1, 1, 1, 1],
+            "Shipping_Provider": ["DHL", "DHL", "DHL", "DHL"],
+            "Destination_Country": ["BG", "US", "DE", "FR"],
+        }
+    )
+
+    out_file = tmp_path / "test_not_fulfillable.xlsx"
+
+    config = {"fulfillment_status_filter": {"enabled": True, "status": "Not Fulfillable"}}
+
+    packing_lists.create_packing_list(df, str(out_file), report_name="TestNotFulfillable", config=config)
+
+    assert out_file.exists()
+    result_df = pd.read_excel(out_file)
+
+    # Should only contain Not Fulfillable orders (A2 and A4)
+    assert len(result_df) == 2
+    assert "A2" in result_df["Order_Number"].values
+    assert "A4" in result_df["Order_Number"].values
+    assert "A1" not in result_df["Order_Number"].values
+    assert "A3" not in result_df["Order_Number"].values
+
+
+def test_fulfillment_filter_disabled(tmp_path):
+    """Test disabled filter - should include ALL orders."""
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable", "Not Fulfillable", "Fulfillable"],
+            "Order_Number": ["A1", "A2", "A3"],
+            "SKU": ["S1", "S2", "S3"],
+            "Product_Name": ["P1", "P2", "P3"],
+            "Quantity": [1, 1, 1],
+            "Shipping_Provider": ["DHL", "DHL", "DHL"],
+            "Destination_Country": ["BG", "US", "DE"],
+        }
+    )
+
+    out_file = tmp_path / "test_disabled.xlsx"
+
+    config = {"fulfillment_status_filter": {"enabled": False}}
+
+    packing_lists.create_packing_list(df, str(out_file), report_name="TestDisabled", config=config)
+
+    assert out_file.exists()
+    result_df = pd.read_excel(out_file)
+
+    # Should contain ALL orders
+    assert len(result_df) == 3
+    assert "A1" in result_df["Order_Number"].values
+    assert "A2" in result_df["Order_Number"].values
+    assert "A3" in result_df["Order_Number"].values
+
+
+def test_fulfillment_filter_multiple_statuses(tmp_path):
+    """Test filtering for multiple statuses (OR logic)."""
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable", "Not Fulfillable", "Partial", "Fulfillable"],
+            "Order_Number": ["A1", "A2", "A3", "A4"],
+            "SKU": ["S1", "S2", "S3", "S4"],
+            "Product_Name": ["P1", "P2", "P3", "P4"],
+            "Quantity": [1, 1, 1, 1],
+            "Shipping_Provider": ["DHL", "DHL", "DHL", "DHL"],
+            "Destination_Country": ["BG", "US", "DE", "FR"],
+        }
+    )
+
+    out_file = tmp_path / "test_multiple.xlsx"
+
+    config = {"fulfillment_status_filter": {"enabled": True, "status": ["Fulfillable", "Partial"]}}
+
+    packing_lists.create_packing_list(df, str(out_file), report_name="TestMultiple", config=config)
+
+    assert out_file.exists()
+    result_df = pd.read_excel(out_file)
+
+    # Should contain Fulfillable and Partial orders (A1, A3, A4)
+    assert len(result_df) == 3
+    assert "A1" in result_df["Order_Number"].values
+    assert "A3" in result_df["Order_Number"].values
+    assert "A4" in result_df["Order_Number"].values
+    assert "A2" not in result_df["Order_Number"].values
+
+
+def test_fulfillment_filter_with_additional_filters(tmp_path):
+    """Test fulfillment filter combined with other filters."""
+    df = pd.DataFrame(
+        {
+            "Order_Fulfillment_Status": ["Fulfillable", "Not Fulfillable", "Fulfillable", "Fulfillable"],
+            "Order_Number": ["A1", "A2", "A3", "A4"],
+            "SKU": ["S1", "S2", "S3", "S4"],
+            "Product_Name": ["P1", "P2", "P3", "P4"],
+            "Quantity": [1, 1, 1, 1],
+            "Shipping_Provider": ["DHL", "DHL", "PostOne", "DHL"],
+            "Destination_Country": ["BG", "US", "DE", "FR"],
+        }
+    )
+
+    out_file = tmp_path / "test_combined_filters.xlsx"
+
+    config = {"fulfillment_status_filter": {"enabled": True, "status": "Fulfillable"}}
+    filters = [{"field": "Shipping_Provider", "operator": "==", "value": "DHL"}]
+
+    packing_lists.create_packing_list(df, str(out_file), report_name="TestCombined", filters=filters, config=config)
+
+    assert out_file.exists()
+    result_df = pd.read_excel(out_file)
+
+    # Should only contain Fulfillable + DHL orders (A1 and A4)
+    assert len(result_df) == 2
+    assert "A1" in result_df["Order_Number"].values
+    assert "A4" in result_df["Order_Number"].values
+    assert "A2" not in result_df["Order_Number"].values  # Not Fulfillable
+    assert "A3" not in result_df["Order_Number"].values  # PostOne
+
+
+def test_build_fulfillment_filter_helper():
+    """Test the _build_fulfillment_filter helper function directly."""
+    # Test default behavior (empty config)
+    assert packing_lists._build_fulfillment_filter({}) == ["Order_Fulfillment_Status == 'Fulfillable'"]
+
+    # Test explicit Fulfillable
+    config = {"fulfillment_status_filter": {"enabled": True, "status": "Fulfillable"}}
+    assert packing_lists._build_fulfillment_filter(config) == ["Order_Fulfillment_Status == 'Fulfillable'"]
+
+    # Test Not Fulfillable
+    config = {"fulfillment_status_filter": {"enabled": True, "status": "Not Fulfillable"}}
+    assert packing_lists._build_fulfillment_filter(config) == ["Order_Fulfillment_Status == 'Not Fulfillable'"]
+
+    # Test disabled filter
+    config = {"fulfillment_status_filter": {"enabled": False}}
+    assert packing_lists._build_fulfillment_filter(config) == []
+
+    # Test multiple statuses
+    config = {"fulfillment_status_filter": {"enabled": True, "status": ["Fulfillable", "Partial"]}}
+    assert packing_lists._build_fulfillment_filter(config) == ["Order_Fulfillment_Status in ['Fulfillable', 'Partial']"]


### PR DESCRIPTION
Implement flexible fulfillment status filtering for packing lists and stock exports, allowing users to generate reports for any fulfillment status while maintaining full backward compatibility.

## Features Added
- Configurable fulfillment_status_filter in report configurations
- Support for single status, multiple statuses, or no filtering
- Default behavior unchanged (Fulfillable only) for backward compatibility
- Applies to both XLSX reports and JSON exports

## Technical Changes

### Core Functionality
- Add _build_fulfillment_filter() helper to packing_lists.py and stock_export.py
- Support three filter modes:
  * enabled: true, status: "Fulfillable" - Default, only fulfillable orders
  * enabled: true, status: "Not Fulfillable" - Only non-fulfillable orders
  * enabled: false - All orders regardless of status
  * enabled: true, status: ["Fulfillable", "Partial"] - Multiple statuses (OR logic)

### Integration
- Update actions_handler.py to pass config to report generation functions
- Enhance _apply_filters() to support fulfillment status filtering for JSON exports
- Handle empty query strings when no filters are specified

### Testing (25 new tests)
- Comprehensive test coverage for all filter modes
- Backward compatibility verification
- Combined filter testing (fulfillment + other filters)
- Helper function unit tests
- All 29 report-related tests pass

### Documentation
- Add detailed "Fulfillment Status Filter (Advanced)" section to USER_GUIDE.md
- Include configuration examples and common use cases
- Document filter behavior and important notes

## Configuration Schema
```json
{
  "name": "Report Name",
  "output_filename": "report.xlsx",
  "filters": [...],
  "fulfillment_status_filter": {
    "enabled": true,
    "status": "Fulfillable"  // or ["Fulfillable", "Partial"]
  }
}
```

## Backward Compatibility
- Existing configs without fulfillment_status_filter default to "Fulfillable" only
- No breaking changes to existing functionality
- All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)