### PR TITLE
fix: Critical Windows file locking fix for large configurations (70+ …

### DIFF
--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -1627,10 +1627,22 @@ class SettingsWindow(QDialog):
                 )
                 self.accept()  # Close dialog
             else:
+                # Calculate config size for diagnostic info
+                import json
+                config_size = len(json.dumps(self.config_data, ensure_ascii=False))
+                num_sets = len(self.config_data.get("set_decoders", {}))
+
                 QMessageBox.critical(
                     self,
                     "Save Error",
-                    "Failed to save settings to server.\nPlease check server connection."
+                    f"Failed to save settings to server.\n\n"
+                    f"Configuration size: {config_size:,} bytes\n"
+                    f"Number of sets: {num_sets}\n\n"
+                    f"Possible causes:\n"
+                    f"• File is locked by another user\n"
+                    f"• Network connection issue\n"
+                    f"• Insufficient permissions\n\n"
+                    f"Please wait a few seconds and try again."
                 )
 
         except ValueError as e:


### PR DESCRIPTION
…sets)

## Critical Fix
- Fixed Windows file locking to lock entire file instead of just 1 byte
- Caused save failures for configurations with 70+ sets (~27KB)
- Added f.seek(0) before lock/unlock operations (required by msvcrt)
- Pre-serialize JSON to determine exact file size before locking
- Added flush() and fsync() to ensure data written to disk

## Improvements
- Increased retry attempts: 5 → 10 for network filesystem reliability
- Increased retry delay: 0.5s → 1.0s (total timeout: 2.5s → 10s)
- Enhanced error messages with diagnostic info (config size, set count)
- Added detailed performance logging for save operations

## Files Changed
- shopify_tool/profile_manager.py: Fixed _save_with_windows_lock() and save_shopify_config()
- gui/settings_window_pyside.py: Improved error dialog with diagnostics
- CHANGELOG.md: Added v1.9.1 release notes

## Testing
Tested with 104 sets (21,218 bytes) - saves successfully