### PR TITLE
fix: Prevent barcode font loading error with monkey patch

### DIFF
--- a/shopify_tool/barcode_processor.py
+++ b/shopify_tool/barcode_processor.py
@@ -38,6 +38,14 @@ from reportlab.lib.pagesizes import mm
 
 logger = logging.getLogger(__name__)
 
+# Monkey patch ImageWriter to disable text rendering and font loading
+# This prevents "cannot open resource" errors when fonts are not available
+def _noop_paint_text(self, *args, **kwargs):
+    """No-op replacement for _paint_text to avoid font loading."""
+    pass
+
+ImageWriter._paint_text = _noop_paint_text
+
 
 # === LABEL SPECIFICATIONS ===
 # Optimized for Citizen CL-E300 thermal printer
@@ -250,6 +258,8 @@ def generate_barcode_label(
             'dpi': dpi,
             'quiet_zone': 0,         # No quiet zone (we add manually)
             'write_text': False,     # We add text manually
+            'text': '',              # Empty text to avoid font loading
+            'font_size': 0,          # Zero font size to skip font initialization
         })
 
         barcode_instance = barcode_class(safe_order_number, writer=writer)


### PR DESCRIPTION
Fixed OSError "cannot open resource" during barcode generation. The python-barcode library was trying to load system fonts even with write_text=False, causing failures on systems without proper font setup.

Solution:
- Monkey patch ImageWriter._paint_text to no-op function
- Added font_size: 0 and text: '' options
- This prevents font loading entirely while still generating barcodes

Fixes barcode generation errors where all 81 orders failed with OSError.