### PR TITLE
fix: Resolve pandas compatibility issues in tests and Excel export

### DIFF
--- a/shopify_tool/analysis.py
+++ b/shopify_tool/analysis.py
@@ -154,8 +154,9 @@ def _clean_and_prepare_data(
     # This handles float artifacts (5170.0 → "5170"), whitespace, and leading zeros
     # Skip normalization for NO_SKU placeholder
     from .csv_utils import normalize_sku
-    # First, ensure SKU column is string type to avoid dtype errors
-    if orders_clean_df["SKU"].dtype != object and not str(orders_clean_df["SKU"].dtype).startswith('string'):
+    # First, ensure SKU column is string type to avoid dtype errors (pandas 2.x uses 'str')
+    dtype_str = str(orders_clean_df["SKU"].dtype)
+    if orders_clean_df["SKU"].dtype != object and dtype_str != 'str' and not dtype_str.startswith('string'):
         orders_clean_df["SKU"] = orders_clean_df["SKU"].astype(str)
     orders_clean_df.loc[orders_clean_df["Has_SKU"], "SKU"] = \
         orders_clean_df.loc[orders_clean_df["Has_SKU"], "SKU"].apply(normalize_sku)

--- a/shopify_tool/analysis.py
+++ b/shopify_tool/analysis.py
@@ -154,6 +154,9 @@ def _clean_and_prepare_data(
     # This handles float artifacts (5170.0 → "5170"), whitespace, and leading zeros
     # Skip normalization for NO_SKU placeholder
     from .csv_utils import normalize_sku
+    # First, ensure SKU column is string type to avoid dtype errors
+    if orders_clean_df["SKU"].dtype != object and not str(orders_clean_df["SKU"].dtype).startswith('string'):
+        orders_clean_df["SKU"] = orders_clean_df["SKU"].astype(str)
     orders_clean_df.loc[orders_clean_df["Has_SKU"], "SKU"] = \
         orders_clean_df.loc[orders_clean_df["Has_SKU"], "SKU"].apply(normalize_sku)
 

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -753,7 +753,9 @@ def _save_results_and_reports(
         worksheet = writer.sheets["fulfillment_analysis"]
         highlight_format = workbook.add_format({"bg_color": "#FFC7CE", "font_color": "#9C0006"})
         for idx, col in enumerate(final_df):
-            max_len = max((final_df[col].astype(str).map(len).max(), len(str(col)))) + 2
+            # Convert to string and handle NaN values before calculating length
+            col_strings = final_df[col].astype(str).fillna('')
+            max_len = max((col_strings.str.len().max(), len(str(col)))) + 2
             worksheet.set_column(idx, idx, max_len)
         for row_num, status in enumerate(final_df["Order_Fulfillment_Status"]):
             if status == "Not Fulfillable":

--- a/tests/test_csv_merge.py
+++ b/tests/test_csv_merge.py
@@ -60,8 +60,8 @@ def test_merge_with_dtype(tmp_path):
         dtype_dict={"SKU": str}
     )
 
-    # SKU should be string, not float
-    assert merged["SKU"].dtype == object
+    # SKU should be string, not float (pandas 2.x uses StringDtype)
+    assert merged["SKU"].dtype == object or str(merged["SKU"].dtype).startswith('string')
     assert merged["SKU"].iloc[0] == "5170"  # Not "5170.0"
 
 

--- a/tests/test_csv_merge.py
+++ b/tests/test_csv_merge.py
@@ -60,8 +60,9 @@ def test_merge_with_dtype(tmp_path):
         dtype_dict={"SKU": str}
     )
 
-    # SKU should be string, not float (pandas 2.x uses StringDtype)
-    assert merged["SKU"].dtype == object or str(merged["SKU"].dtype).startswith('string')
+    # SKU should be string, not float (pandas 2.x uses StringDtype which shows as 'str')
+    dtype_str = str(merged["SKU"].dtype)
+    assert merged["SKU"].dtype == object or dtype_str == 'str' or dtype_str.startswith('string')
     assert merged["SKU"].iloc[0] == "5170"  # Not "5170.0"
 
 

--- a/tests/test_sku_normalization.py
+++ b/tests/test_sku_normalization.py
@@ -129,9 +129,10 @@ class TestSkuDtypeForcing:
         sku_str = str(df_broken["SKU"].iloc[0])
         assert sku_str in ["5170", "5170.0"], f"Unexpected SKU format: {sku_str}"
 
-        # With dtype=str (fixed - pandas 2.x uses StringDtype)
+        # With dtype=str (fixed - pandas 2.x uses StringDtype which shows as 'str')
         df_fixed = pd.read_csv(io.StringIO(csv_content), dtype={"SKU": str})
-        assert df_fixed["SKU"].dtype == object or str(df_fixed["SKU"].dtype).startswith('string')
+        dtype_str = str(df_fixed["SKU"].dtype)
+        assert df_fixed["SKU"].dtype == object or dtype_str == 'str' or dtype_str.startswith('string')
         assert df_fixed["SKU"].iloc[0] == "5170"
 
     def test_csv_load_mixed_sku_types(self):

--- a/tests/test_sku_normalization.py
+++ b/tests/test_sku_normalization.py
@@ -129,9 +129,9 @@ class TestSkuDtypeForcing:
         sku_str = str(df_broken["SKU"].iloc[0])
         assert sku_str in ["5170", "5170.0"], f"Unexpected SKU format: {sku_str}"
 
-        # With dtype=str (fixed)
+        # With dtype=str (fixed - pandas 2.x uses StringDtype)
         df_fixed = pd.read_csv(io.StringIO(csv_content), dtype={"SKU": str})
-        assert df_fixed["SKU"].dtype == object
+        assert df_fixed["SKU"].dtype == object or str(df_fixed["SKU"].dtype).startswith('string')
         assert df_fixed["SKU"].iloc[0] == "5170"
 
     def test_csv_load_mixed_sku_types(self):


### PR DESCRIPTION
Bug Fixes:
- Fix Excel column width calculation error with NaN values (core.py:756)
  - Changed from .map(len) to .str.len() with fillna to handle NaN floats
  - Prevents "TypeError: object of type 'float' has no len()" error

- Fix SKU dtype assignment error in analysis.py:157
  - Ensure SKU column is converted to string type before normalization
  - Prevents "TypeError: Invalid value for dtype 'int64'" when assigning strings

- Update dtype assertions for pandas 2.x compatibility
  - Pandas 2.x uses StringDtype instead of object dtype for string columns
  - Updated tests to accept both object and string[python] dtypes
  - Affects: test_csv_merge.py, test_sku_normalization.py

These issues were pre-existing bugs revealed by the test suite, not introduced by the documentation update commit (29a7f35).