### PR TITLE
refactor(rules): Remove deprecated action types and simplify UI

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -339,8 +339,8 @@ def __init__(self, rules_config)
             "value": "HighValue"
         },
         {
-            "type": "SET_PRIORITY",
-            "value": "High"
+            "type": "ADD_INTERNAL_TAG",
+            "value": "priority:high"
         }
     ]
 }
@@ -399,12 +399,20 @@ Executes a list of actions on matching rows.
 - `matches` (pd.Series[bool]): Boolean series of rows to modify
 - `actions` (list[dict]): List of action configurations
 
-**Action Types**:
-- `ADD_TAG`: Appends value to Status_Note
+**Active Action Types** (as of v1.9.0):
+- `ADD_TAG`: Appends value to Status_Note column
+- `ADD_ORDER_TAG`: Appends value to Status_Note (order-level only)
+- `ADD_INTERNAL_TAG`: Adds structured tag to Internal_Tags JSON column (recommended for metadata)
 - `SET_STATUS`: Changes Order_Fulfillment_Status
-- `SET_PRIORITY`: Sets Priority field
-- `EXCLUDE_FROM_REPORT`: Marks row as excluded
-- `EXCLUDE_SKU`: Sets quantity to 0 for specific SKU
+
+**Deprecated Action Types** (removed in v1.9.0):
+The following action types have been removed: `SET_PRIORITY`, `EXCLUDE_FROM_REPORT`, `SET_PACKAGING_TAG`, `EXCLUDE_SKU`.
+If encountered, these actions will log a warning and be skipped. Use `ADD_INTERNAL_TAG` for structured metadata instead.
+
+**Migration Examples**:
+- `SET_PRIORITY: "High"` → `ADD_INTERNAL_TAG: "priority:high"`
+- `EXCLUDE_FROM_REPORT` → `ADD_INTERNAL_TAG: "exclude_from_report"`
+- `SET_PACKAGING_TAG: "BOX"` → `ADD_INTERNAL_TAG: "packaging:box"`
 
 ### Operator Functions
 
@@ -1328,8 +1336,7 @@ CONDITION_OPERATORS = [
 ]
 
 ACTION_TYPES = [
-    "ADD_TAG", "SET_STATUS", "SET_PRIORITY",
-    "EXCLUDE_FROM_REPORT", "EXCLUDE_SKU"
+    "ADD_TAG", "ADD_ORDER_TAG", "ADD_INTERNAL_TAG", "SET_STATUS"
 ]
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -360,6 +360,59 @@ def __init__(self, rules_config)
 }
 ```
 
+**Rule Priority System**:
+
+Rules support an optional `priority` field to control execution order:
+
+- **Type**: `int`
+- **Default**: `1000` (if not specified)
+- **Lower values = higher priority** (execute first)
+- **Per-Level**: Article rules and order rules have separate priority sequences
+
+**Example with Priority**:
+```json
+{
+  "rules": [
+    {
+      "name": "Calculate Total First",
+      "priority": 1,
+      "level": "article",
+      "match": "ALL",
+      "conditions": [{"field": "Quantity", "operator": "is greater than", "value": "0"}],
+      "actions": [{
+        "type": "CALCULATE",
+        "operation": "multiply",
+        "field1": "Quantity",
+        "field2": "Unit_Price",
+        "target": "Total_Price"
+      }]
+    },
+    {
+      "name": "Tag Based on Total",
+      "priority": 2,
+      "level": "article",
+      "match": "ALL",
+      "conditions": [{"field": "Total_Price", "operator": "is greater than", "value": "100"}],
+      "actions": [{"type": "ADD_TAG", "value": "HIGH-VALUE"}]
+    }
+  ]
+}
+```
+
+**Execution Order**:
+- Rules are sorted by priority before execution (lower number = executes first)
+- Article rules always execute before order rules (separate phases)
+- Within each level (article/order), rules execute in priority order
+- Rules without `priority` field automatically receive 1000, 1001, 1002... (executed last)
+
+**Priority Gaps**:
+- Priority values like 1, 5, 10, 20 are allowed (no need for sequential numbering)
+- Gaps enable inserting new rules without renumbering existing ones
+
+**Backward Compatibility**:
+- Existing configs without `priority` field continue to work
+- Rules are automatically assigned default priorities preserving their original order
+
 ##### Methods
 
 ###### `apply(df)`

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -1090,7 +1090,7 @@ class MainWindow(QMainWindow):
 
             # Data rows (limit to top 20 for performance)
             for row_idx, sku_data in enumerate(sku_summary[:20], start=1):
-                self.sku_stats_layout.addWidget(QLabel(sku_data.get("SKU", "N/A")), row_idx, 0)
+                self.sku_stats_layout.addWidget(QLabel(str(sku_data.get("SKU", "N/A"))), row_idx, 0)
                 warehouse_name = sku_data.get("Warehouse_Name", "N/A")
                 if warehouse_name == "N/A" or warehouse_name == "" or pd.isna(warehouse_name):
                     warehouse_name = sku_data.get("Product_Name", "N/A")

--- a/gui/rule_test_dialog.py
+++ b/gui/rule_test_dialog.py
@@ -1,0 +1,392 @@
+"""
+Dialog for testing rules against current analysis data.
+
+Allows users to:
+- Preview condition evaluation results
+- See matched rows before actions
+- Preview actions to be applied
+- See DataFrame after actions with change highlighting
+"""
+
+import logging
+import pandas as pd
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton,
+    QGroupBox, QTableWidget, QTableWidgetItem,
+    QLabel, QMessageBox, QScrollArea, QWidget
+)
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
+
+logger = logging.getLogger(__name__)
+
+
+class RuleTestDialog(QDialog):
+    """
+    Dialog for testing a rule against current analysis DataFrame.
+
+    Shows:
+    - Condition evaluation results (matched rows per condition)
+    - Final match count (ALL vs ANY logic)
+    - Preview of matched rows (first 5, max 100 for performance)
+    - Actions to be applied
+    - Preview after actions (highlighting changed cells)
+    """
+
+    def __init__(self, rule_config, analysis_df, parent=None):
+        """
+        Initialize test dialog.
+
+        Args:
+            rule_config (dict): Rule configuration to test
+            analysis_df (pd.DataFrame): Analysis data to test against
+            parent: Parent widget
+        """
+        super().__init__(parent)
+
+        self.rule_config = rule_config
+        self.analysis_df = analysis_df
+
+        # Test results (populated by _run_test)
+        self.test_df = None
+        self.df_before = None
+        self.df_after = None
+        self.matches = None
+        self.matched_count = 0
+
+        self.setWindowTitle(f"Test Rule: {rule_config.get('name', 'Unnamed')}")
+        self.setMinimumSize(1000, 800)
+        self.setModal(True)
+
+        self._init_ui()
+        self._run_test()
+
+    def _init_ui(self):
+        """Create UI sections."""
+        layout = QVBoxLayout(self)
+
+        # Section 1: Conditions Results
+        self.conditions_section = self._create_conditions_section()
+        layout.addWidget(self.conditions_section)
+
+        # Section 2: Matched Rows Preview (BEFORE actions)
+        self.preview_section = self._create_preview_section()
+        layout.addWidget(self.preview_section)
+
+        # Section 3: Actions to be applied
+        self.actions_section = self._create_actions_section()
+        layout.addWidget(self.actions_section)
+
+        # Section 4: After Actions Preview (AFTER actions)
+        self.after_section = self._create_after_actions_section()
+        layout.addWidget(self.after_section)
+
+        # Close button
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.accept)
+        close_btn.setMinimumWidth(100)
+        button_layout.addWidget(close_btn)
+        layout.addLayout(button_layout)
+
+    def _create_conditions_section(self):
+        """Create section showing condition evaluation results."""
+        group = QGroupBox("📋 Condition Evaluation")
+        layout = QVBoxLayout(group)
+
+        # Table: Field | Operator | Value | Matched Rows
+        self.conditions_table = QTableWidget()
+        self.conditions_table.setColumnCount(4)
+        self.conditions_table.setHorizontalHeaderLabels([
+            "Field", "Operator", "Value", "Matched Rows"
+        ])
+        self.conditions_table.setMaximumHeight(200)
+        self.conditions_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.conditions_table.setSelectionMode(QTableWidget.NoSelection)
+
+        layout.addWidget(self.conditions_table)
+
+        # Summary label
+        self.match_summary_label = QLabel()
+        self.match_summary_label.setStyleSheet("font-weight: bold; font-size: 11pt; margin-top: 10px;")
+        layout.addWidget(self.match_summary_label)
+
+        return group
+
+    def _create_preview_section(self):
+        """Create section showing first 5 matched rows (max 100 total)."""
+        group = QGroupBox("🔍 Matched Rows Preview (Before Actions)")
+        layout = QVBoxLayout(group)
+
+        # Info label
+        info_label = QLabel("Showing first 5 matched rows (limited to 100 for performance)")
+        info_label.setStyleSheet("color: gray; font-style: italic; font-size: 9pt;")
+        layout.addWidget(info_label)
+
+        # Preview table
+        self.preview_table = QTableWidget()
+        self.preview_table.setMaximumHeight(250)
+        self.preview_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.preview_table.setAlternatingRowColors(True)
+
+        layout.addWidget(self.preview_table)
+        return group
+
+    def _create_actions_section(self):
+        """Create section showing actions to be applied."""
+        group = QGroupBox("⚙️ Actions to be Applied")
+        layout = QVBoxLayout(group)
+
+        # Actions list label
+        self.actions_label = QLabel()
+        self.actions_label.setWordWrap(True)
+        self.actions_label.setStyleSheet("font-size: 10pt;")
+        layout.addWidget(self.actions_label)
+
+        return group
+
+    def _create_after_actions_section(self):
+        """Create section showing rows after actions applied."""
+        group = QGroupBox("✨ Preview After Actions")
+        layout = QVBoxLayout(group)
+
+        # Preview table
+        self.after_table = QTableWidget()
+        self.after_table.setMaximumHeight(250)
+        self.after_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.after_table.setAlternatingRowColors(True)
+
+        layout.addWidget(self.after_table)
+
+        # Legend for highlights
+        legend = QLabel("🟡 Yellow highlight = Modified by rule actions")
+        legend.setStyleSheet("color: #666; font-size: 9pt; margin-top: 5px;")
+        layout.addWidget(legend)
+
+        return group
+
+    def _run_test(self):
+        """Execute rule test using RuleEngine.apply() on a copy of DataFrame."""
+        from shopify_tool.rules import RuleEngine
+
+        try:
+            # Performance warning for large datasets
+            if len(self.analysis_df) > 1000:
+                logger.warning(f"[RULE TEST] Large dataset ({len(self.analysis_df)} rows), limiting to 100 for performance")
+
+            # Limit to 100 rows for performance
+            self.test_df = self.analysis_df.head(100).copy()
+            logger.info(f"[RULE TEST] Testing rule '{self.rule_config.get('name')}' with {len(self.test_df)} rows")
+
+            # Create single-rule engine
+            engine = RuleEngine([self.rule_config])
+
+            # Save before state
+            self.df_before = self.test_df.copy()
+
+            # Apply rule (modifies test_df in-place)
+            self.df_after = engine.apply(self.test_df)
+
+            # Get matches
+            self.matches = engine._get_matching_rows(self.df_after, self.rule_config)
+            self.matched_count = self.matches.sum()
+
+            logger.info(f"[RULE TEST] Matched {self.matched_count} rows")
+
+            # Populate UI sections
+            self._populate_conditions_table()
+            self._populate_preview_table()
+            self._populate_actions_list()
+            self._populate_after_actions_table()
+
+        except Exception as e:
+            logger.error(f"[RULE TEST] Error testing rule: {e}", exc_info=True)
+            QMessageBox.critical(
+                self,
+                "Test Error",
+                f"Failed to test rule:\n\n{str(e)}\n\nCheck logs for details."
+            )
+
+    def _populate_conditions_table(self):
+        """Populate conditions table with evaluation results."""
+        conditions = self.rule_config.get("conditions", [])
+        self.conditions_table.setRowCount(len(conditions))
+
+        for row_idx, condition in enumerate(conditions):
+            # Field
+            field_item = QTableWidgetItem(condition.get("field", ""))
+            self.conditions_table.setItem(row_idx, 0, field_item)
+
+            # Operator
+            op_item = QTableWidgetItem(condition.get("operator", ""))
+            self.conditions_table.setItem(row_idx, 1, op_item)
+
+            # Value
+            value_item = QTableWidgetItem(str(condition.get("value", "")))
+            self.conditions_table.setItem(row_idx, 2, value_item)
+
+            # Matched rows (placeholder - showing "N/A" as we don't evaluate per-condition)
+            matched_item = QTableWidgetItem("N/A")
+            matched_item.setToolTip("Per-condition match count not available")
+            self.conditions_table.setItem(row_idx, 3, matched_item)
+
+        self.conditions_table.resizeColumnsToContents()
+
+        # Update summary label
+        match_type = self.rule_config.get("match", "ALL")
+        total_rows = len(self.test_df)
+        percentage = (self.matched_count / total_rows * 100) if total_rows > 0 else 0
+
+        summary = f"📊 Final Result ({match_type} conditions): "
+        summary += f"<span style='color: #4CAF50; font-size: 14pt;'>{self.matched_count}</span> rows matched "
+        summary += f"({percentage:.1f}% of {total_rows} total rows)"
+
+        self.match_summary_label.setText(summary)
+
+    def _populate_preview_table(self):
+        """Populate preview table with first 5 matched rows."""
+        if self.matches is None or self.matched_count == 0:
+            self.preview_table.setRowCount(1)
+            self.preview_table.setColumnCount(1)
+            no_match_item = QTableWidgetItem("No rows matched the conditions")
+            no_match_item.setForeground(QColor("#999"))
+            self.preview_table.setItem(0, 0, no_match_item)
+            return
+
+        # Get matched rows (first 5)
+        matched_df = self.df_before[self.matches].head(5)
+
+        # Select relevant columns to display
+        display_cols = self._get_display_columns(matched_df)
+        display_df = matched_df[display_cols]
+
+        self.preview_table.setRowCount(len(display_df))
+        self.preview_table.setColumnCount(len(display_cols))
+        self.preview_table.setHorizontalHeaderLabels(display_cols)
+
+        for row_idx, (_, row) in enumerate(display_df.iterrows()):
+            for col_idx, col_name in enumerate(display_cols):
+                value = row[col_name]
+                item = QTableWidgetItem(str(value))
+                self.preview_table.setItem(row_idx, col_idx, item)
+
+        self.preview_table.resizeColumnsToContents()
+
+        # Show "and X more" if there are more matches
+        if self.matched_count > 5:
+            remaining = self.matched_count - 5
+            logger.info(f"[RULE TEST] Showing 5 of {self.matched_count} matched rows ({remaining} more)")
+
+    def _populate_actions_list(self):
+        """Populate actions list with actions to be applied."""
+        actions = self.rule_config.get("actions", [])
+
+        if not actions:
+            self.actions_label.setText("⚠️ No actions configured for this rule")
+            return
+
+        actions_text = f"<b>{len(actions)} action(s) will be applied to {self.matched_count} matched rows:</b><br><br>"
+
+        for idx, action in enumerate(actions, 1):
+            action_type = action.get("type", "")
+            action_value = action.get("value", "")
+
+            actions_text += f"{idx}. <b>{action_type}</b>"
+
+            if action_value:
+                actions_text += f": <code>{action_value}</code>"
+
+            # Add description based on action type
+            if action_type == "ADD_TAG":
+                actions_text += f" → Appends to Status_Note column"
+            elif action_type == "SET_STATUS":
+                actions_text += f" → Sets Order_Fulfillment_Status"
+            elif action_type == "ADD_INTERNAL_TAG":
+                actions_text += f" → Appends to Internal_Tags (JSON list)"
+            elif action_type == "COPY_FIELD":
+                source = action.get("source", "")
+                target = action.get("target", "")
+                actions_text += f" → Copies '{source}' to '{target}'"
+            elif action_type == "CALCULATE":
+                operation = action.get("operation", "")
+                source = action.get("source", "")
+                target = action.get("target", "")
+                calc_value = action.get("value", "")
+                actions_text += f" → {operation.upper()} {source} by {calc_value}, store in {target}"
+
+            actions_text += "<br>"
+
+        self.actions_label.setText(actions_text)
+
+    def _populate_after_actions_table(self):
+        """Populate after-actions table with changed cells highlighted."""
+        if self.matches is None or self.matched_count == 0:
+            self.after_table.setRowCount(1)
+            self.after_table.setColumnCount(1)
+            no_match_item = QTableWidgetItem("No rows to show")
+            no_match_item.setForeground(QColor("#999"))
+            self.after_table.setItem(0, 0, no_match_item)
+            return
+
+        # Get matched rows before and after (first 5)
+        matched_before = self.df_before[self.matches].head(5)
+        matched_after = self.df_after[self.matches].head(5)
+
+        # Select relevant columns to display
+        display_cols = self._get_display_columns(matched_after)
+
+        self.after_table.setRowCount(len(matched_after))
+        self.after_table.setColumnCount(len(display_cols))
+        self.after_table.setHorizontalHeaderLabels(display_cols)
+
+        for row_idx, (idx_after, row_after) in enumerate(matched_after.iterrows()):
+            row_before = matched_before.loc[idx_after]
+
+            for col_idx, col_name in enumerate(display_cols):
+                value_before = row_before[col_name]
+                value_after = row_after[col_name]
+
+                item = QTableWidgetItem(str(value_after))
+
+                # Highlight changed cells
+                if value_before != value_after and not (pd.isna(value_before) and pd.isna(value_after)):
+                    item.setBackground(QColor("#FFEB3B"))  # Yellow
+                    item.setToolTip(f"Changed from: {value_before}")
+
+                self.after_table.setItem(row_idx, col_idx, item)
+
+        self.after_table.resizeColumnsToContents()
+
+    def _get_display_columns(self, df):
+        """
+        Get relevant columns to display in preview tables.
+
+        Prioritizes important columns and limits total number.
+
+        Args:
+            df: DataFrame to select columns from
+
+        Returns:
+            List of column names to display
+        """
+        priority_cols = [
+            "Order_Number",
+            "SKU",
+            "Order_Fulfillment_Status",
+            "Status_Note",
+            "Total_Price",
+            "Quantity",
+            "Shipping_Provider",
+            "Internal_Tags"
+        ]
+
+        # Select priority columns that exist in DataFrame
+        display_cols = [col for col in priority_cols if col in df.columns]
+
+        # Add other columns if we have space (max 10 total)
+        remaining_cols = [col for col in df.columns if col not in display_cols]
+        if len(display_cols) < 10:
+            display_cols.extend(remaining_cols[:10 - len(display_cols)])
+
+        return display_cols

--- a/gui/rule_validator.py
+++ b/gui/rule_validator.py
@@ -1,0 +1,197 @@
+"""
+Validation module for rule conditions.
+
+Provides real-time validation for different operator types:
+- Regex pattern validation
+- Date format validation
+- Range format validation
+- List format validation
+
+Reuses helpers from shopify_tool.rules for consistency between
+validation and execution.
+"""
+
+import logging
+from typing import Tuple, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def validate_regex(pattern: str) -> Tuple[bool, Optional[str]]:
+    """
+    Validate regex pattern using rule engine's safe compiler.
+
+    Args:
+        pattern: Regex pattern string to validate
+
+    Returns:
+        Tuple of (is_valid, error_message)
+        - is_valid: True if pattern is valid, False otherwise
+        - error_message: None if valid, error description if invalid
+
+    Examples:
+        >>> validate_regex("^SKU-\\d{4}$")
+        (True, None)
+        >>> validate_regex("(unclosed")
+        (False, "Invalid regex syntax")
+    """
+    from shopify_tool.rules import _compile_regex_safe
+
+    if not pattern or not pattern.strip():
+        return (False, "Regex pattern cannot be empty")
+
+    compiled = _compile_regex_safe(pattern)
+    if compiled is None:
+        return (False, "Invalid regex syntax")
+
+    return (True, None)
+
+
+def validate_date(date_str: str) -> Tuple[bool, Optional[str]]:
+    """
+    Validate date string using rule engine's safe parser.
+
+    Supports multiple formats:
+    - ISO: "2024-01-30"
+    - European slash: "30/01/2024"
+    - European dot: "30.01.2024"
+    - Timestamp: "2026-01-14 18:56:50 +0200"
+
+    Args:
+        date_str: Date string to validate
+
+    Returns:
+        Tuple of (is_valid, error_message)
+        - is_valid: True if date is valid, False otherwise
+        - error_message: None if valid, error description if invalid
+
+    Examples:
+        >>> validate_date("2024-01-30")
+        (True, None)
+        >>> validate_date("invalid")
+        (False, "Invalid date format. Use: YYYY-MM-DD, DD/MM/YYYY, or DD.MM.YYYY")
+    """
+    from shopify_tool.rules import _parse_date_safe
+
+    if not date_str or not str(date_str).strip():
+        return (False, "Date cannot be empty")
+
+    parsed = _parse_date_safe(date_str)
+    if parsed is None:
+        return (False, "Invalid date format. Use: YYYY-MM-DD, DD/MM/YYYY, or DD.MM.YYYY")
+
+    return (True, None)
+
+
+def validate_range(range_str: str) -> Tuple[bool, Optional[str], Optional[str]]:
+    """
+    Validate range string using rule engine's parser.
+
+    Format: "start-end" (e.g., "10-100")
+
+    Args:
+        range_str: Range string to validate
+
+    Returns:
+        Tuple of (is_valid, error_message, warning_message)
+        - is_valid: True if range format is valid, False otherwise
+        - error_message: None if valid, error description if invalid
+        - warning_message: Warning if start > end (valid format but suspicious)
+
+    Examples:
+        >>> validate_range("10-100")
+        (True, None, None)
+        >>> validate_range("100-10")
+        (True, None, "Warning: Start (100.0) > End (10.0)")
+        >>> validate_range("invalid")
+        (False, "Invalid format. Use: start-end (e.g., 10-100)", None)
+    """
+    if not range_str or not str(range_str).strip():
+        return (False, "Range cannot be empty", None)
+
+    # Manual parsing to detect reversed ranges
+    try:
+        parts = str(range_str).strip().split("-")
+        if len(parts) != 2:
+            return (False, "Invalid format. Use: start-end (e.g., 10-100)", None)
+
+        start = float(parts[0].strip())
+        end = float(parts[1].strip())
+
+        if start > end:
+            return (True, None, f"Warning: Start ({start}) > End ({end})")
+
+        return (True, None, None)
+
+    except ValueError:
+        return (False, "Invalid format. Use: start-end (e.g., 10-100)", None)
+
+
+def validate_list(list_str: str) -> Tuple[bool, int, Optional[str]]:
+    """
+    Validate and count list items.
+
+    List format: "Value1, Value2, Value3"
+    - Comma-separated values
+    - Spaces are auto-trimmed
+    - Case-insensitive matching (in rule execution)
+
+    Args:
+        list_str: Comma-separated list string
+
+    Returns:
+        Tuple of (is_valid, item_count, error_message)
+        - is_valid: True if list is valid, False otherwise
+        - item_count: Number of non-empty items in list
+        - error_message: None if valid, error description if invalid
+
+    Examples:
+        >>> validate_list("A, B, C")
+        (True, 3, None)
+        >>> validate_list(" A , B ")
+        (True, 2, None)
+        >>> validate_list("")
+        (False, 0, "List cannot be empty")
+    """
+    if not list_str or not str(list_str).strip():
+        return (False, 0, "List cannot be empty")
+
+    # Split, trim, count non-empty items
+    items = [item.strip() for item in str(list_str).split(",") if item.strip()]
+
+    if not items:
+        return (False, 0, "No valid items in list")
+
+    return (True, len(items), None)
+
+
+def validate_numeric(value_str: str) -> Tuple[bool, Optional[str]]:
+    """
+    Validate that a string can be converted to a number.
+
+    Used for numeric operators like "is greater than", "is less than", etc.
+
+    Args:
+        value_str: String to validate as numeric
+
+    Returns:
+        Tuple of (is_valid, error_message)
+        - is_valid: True if can be converted to number, False otherwise
+        - error_message: None if valid, error description if invalid
+
+    Examples:
+        >>> validate_numeric("123")
+        (True, None)
+        >>> validate_numeric("123.45")
+        (True, None)
+        >>> validate_numeric("abc")
+        (False, "Value must be a number")
+    """
+    if not value_str or not str(value_str).strip():
+        return (False, "Value cannot be empty")
+
+    try:
+        float(value_str)
+        return (True, None)
+    except ValueError:
+        return (False, "Value must be a number")

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -96,6 +96,14 @@ class SettingsWindow(QDialog):
         "ends with",
         "is empty",
         "is not empty",
+        "in list",
+        "not in list",
+        "between",
+        "not between",
+        "date before",
+        "date after",
+        "date equals",
+        "matches regex",
     ]
     ACTION_TYPES = [
         "ADD_TAG",
@@ -587,9 +595,23 @@ class SettingsWindow(QDialog):
             if initial_value and str(initial_value) in unique_values:
                 new_widget.setCurrentText(str(initial_value))
         else:
-            # Default to QLineEdit
+            # Default to QLineEdit with smart placeholders
             new_widget = QLineEdit()
-            new_widget.setPlaceholderText("Value")
+
+            # Set operator-specific placeholders
+            placeholder = "Value"  # Default
+
+            if op in ["in list", "not in list"]:
+                placeholder = "Value1, Value2, Value3"
+            elif op in ["between", "not between"]:
+                placeholder = "10-100"
+            elif op in ["date before", "date after", "date equals"]:
+                placeholder = "2024-01-30"
+            elif op == "matches regex":
+                placeholder = "^SKU-\\d{4}$"
+
+            new_widget.setPlaceholderText(placeholder)
+
             if initial_value is not None:
                 new_widget.setText(str(initial_value))
 

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -168,9 +168,6 @@ class SettingsWindow(QDialog):
         self.stock_export_widgets = []
         self.courier_mapping_widgets = []
 
-        # Validation timers for debouncing (used for regex validation)
-        self._validation_timers = {}
-
         self.setWindowTitle(f"Settings - CLIENT_{self.client_id}")
         self.setMinimumSize(900, 750)  # Slightly larger for new tabs
         self.setModal(True)
@@ -710,9 +707,9 @@ class SettingsWindow(QDialog):
             del condition_refs["feedback_label"]
 
         # Cancel pending validation timer
-        if condition_refs in self._validation_timers:
-            self._validation_timers[condition_refs].stop()
-            del self._validation_timers[condition_refs]
+        if "validation_timer" in condition_refs:
+            condition_refs["validation_timer"].stop()
+            del condition_refs["validation_timer"]
 
         # Remove the old value widget, if it exists
         if condition_refs["value_widget"]:
@@ -804,8 +801,8 @@ class SettingsWindow(QDialog):
         op = condition_refs["op"].currentText()
 
         # Cancel existing timer for this condition
-        if condition_refs in self._validation_timers:
-            self._validation_timers[condition_refs].stop()
+        if "validation_timer" in condition_refs:
+            condition_refs["validation_timer"].stop()
 
         # For regex: debounce 500ms
         if op == "matches regex":
@@ -813,7 +810,7 @@ class SettingsWindow(QDialog):
             timer.setSingleShot(True)
             timer.timeout.connect(lambda: self._perform_validation(condition_refs))
             timer.start(500)  # 500ms debounce
-            self._validation_timers[condition_refs] = timer
+            condition_refs["validation_timer"] = timer
         else:
             # For other operators: validate immediately
             self._perform_validation(condition_refs)

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -781,8 +781,7 @@ class SettingsWindow(QDialog):
         condition_refs["value_layout"].insertWidget(2, new_widget, 1)
         condition_refs["value_widget"] = new_widget
 
-        # Connect validation for QLineEdit widgets
-        from PySide6.QtWidgets import QLineEdit
+        # Connect validation for QLineEdit widgets (QLineEdit is already imported globally)
         if isinstance(new_widget, QLineEdit):
             new_widget.textChanged.connect(lambda: self._validate_condition_value(condition_refs))
 


### PR DESCRIPTION
Remove 4 deprecated action types (SET_PRIORITY, EXCLUDE_FROM_REPORT, SET_PACKAGING_TAG, EXCLUDE_SKU) from the Rule Engine. Deprecated actions now log warnings and are skipped. Users should migrate to ADD_INTERNAL_TAG for structured metadata.

Changes:
- Backend: Add deprecation warnings and remove handlers for deprecated actions
- Backend: Simplify _prepare_df_for_actions to only create Status_Note and Internal_Tags columns
- UI: Update ACTION_TYPES to show only 4 active action types
- UI: Remove redundant "Order Rules" tab (main Rules tab has level selector)
- Tests: Update 10 tests to use active action types, add deprecation warning test
- Docs: Update API.md and FUNCTIONS.md with migration examples

Active action types: ADD_TAG, ADD_ORDER_TAG, ADD_INTERNAL_TAG, SET_STATUS

All 36 tests passing. Breaking change in v1.9.0.