### PR TITLE
feat: Volumetric weight and packaging engine (#220)

### DIFF
--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -672,6 +672,12 @@ def _run_analysis_and_rules(
             ""
         )
 
+    # Enrich DataFrame with volumetric weights before Rule Engine
+    weight_config = config.get("weight_config", {})
+    if weight_config and weight_config.get("products"):
+        from .weight_calculator import enrich_dataframe_with_weights
+        final_df = enrich_dataframe_with_weights(final_df, weight_config)
+
     # Apply the rule engine
     rules = config.get("rules", [])
     if rules:

--- a/shopify_tool/weight_calculator.py
+++ b/shopify_tool/weight_calculator.py
@@ -1,0 +1,302 @@
+"""
+Volumetric weight calculator for products and packaging.
+
+Volumetric weight formula: (length_cm * width_cm * height_cm) / divisor
+Default divisor: 6000 (cm³ → kg, used by DPD/Speedy)
+
+Physical fit check:
+    Items are tested in all 6 orientations (rotations).
+    For multi-item orders, items are stacked flat (largest face down):
+      - Box L×W must fit the maximum footprint of any single item
+      - Box H must fit the sum of all items' thinnest dimensions (stacked height)
+    For SKUs with no_packaging=True: they are excluded from box selection.
+"""
+
+import logging
+from itertools import permutations
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Sentinel values used in Order_Min_Box column
+NO_BOX_NEEDED = "NO_BOX_NEEDED"  # all items have no_packaging=True
+NO_BOX_FITS = "NO_BOX_FITS"      # items have dimensions but no box is large enough
+UNKNOWN_DIMS = "UNKNOWN_DIMS"     # some SKUs have no dimensions configured
+
+
+def calc_sku_volumetric_weight(sku: str, weight_config: Dict) -> float:
+    """
+    Calculate volumetric weight for a single SKU.
+
+    Returns 0 if:
+    - SKU not found in weight_config
+    - SKU has no_packaging=True
+    - Dimensions are missing or zero
+    """
+    products = weight_config.get("products", {})
+    divisor = float(weight_config.get("volumetric_divisor", 6000))
+
+    if sku not in products:
+        return 0.0
+
+    product = products[sku]
+
+    if product.get("no_packaging", False):
+        return 0.0
+
+    length = float(product.get("length_cm") or 0)
+    width = float(product.get("width_cm") or 0)
+    height = float(product.get("height_cm") or 0)
+
+    if length <= 0 or width <= 0 or height <= 0 or divisor <= 0:
+        return 0.0
+
+    return (length * width * height) / divisor
+
+
+def calc_order_volumetric_weight(order_df: pd.DataFrame, weight_config: Dict) -> float:
+    """
+    Calculate total volumetric weight for an order group.
+
+    Sums (quantity * volumetric_weight_per_sku) for each line item.
+    SKUs with no_packaging=True contribute 0.
+    """
+    if "SKU" not in order_df.columns:
+        return 0.0
+
+    total = 0.0
+    for _, row in order_df.iterrows():
+        sku = str(row.get("SKU", "") or "")
+        if not sku or sku == "NO_SKU":
+            continue
+
+        qty = float(row.get("Quantity", 1) or 1)
+        sku_vol_weight = calc_sku_volumetric_weight(sku, weight_config)
+        total += qty * sku_vol_weight
+
+    return round(total, 4)
+
+
+def is_all_no_packaging(order_df: pd.DataFrame, weight_config: Dict) -> bool:
+    """
+    Returns True if ALL SKUs in the order have no_packaging=True.
+    Also returns True if the order has no recognized SKUs (all NO_SKU).
+    Returns False if any SKU requires packaging.
+    """
+    products = weight_config.get("products", {})
+
+    if "SKU" not in order_df.columns:
+        return False
+
+    has_any_sku = False
+    for _, row in order_df.iterrows():
+        sku = str(row.get("SKU", "") or "")
+        if not sku or sku == "NO_SKU":
+            continue
+
+        has_any_sku = True
+
+        # If SKU is not in config, we don't know — treat as packaging required
+        if sku not in products:
+            return False
+
+        if not products[sku].get("no_packaging", False):
+            return False
+
+    return has_any_sku  # True only if we found at least one SKU and all were no_packaging
+
+
+# ---------------------------------------------------------------------------
+# Physical fit logic
+# ---------------------------------------------------------------------------
+
+def _item_fits_in_box(item_dims: Tuple[float, float, float],
+                      box_dims: Tuple[float, float, float]) -> bool:
+    """
+    Check if a single item fits in a box, trying all 6 rotations.
+
+    Approach: sort both sets of dimensions.
+    If sorted(item) ≤ sorted(box) element-wise → fits in some rotation.
+    (This is equivalent to checking all permutations.)
+    """
+    si = sorted(item_dims)
+    sb = sorted(box_dims)
+    return si[0] <= sb[0] and si[1] <= sb[1] and si[2] <= sb[2]
+
+
+def _order_fits_in_box(item_list: List[Tuple[float, float, float]],
+                       box_dims: Tuple[float, float, float]) -> bool:
+    """
+    Check if a list of items fits in a box using two conditions:
+
+    1. Each individual item must physically fit in the box (dimension check, all rotations).
+       If any single item is too large for the box — the whole order doesn't fit.
+
+    2. Total volume of all items must be ≤ box volume.
+       This ensures there is enough space for all items together.
+
+    This is a practical approximation for fulfillment packing.
+    It is optimistic (assumes items can be arranged efficiently inside the box),
+    but condition 1 prevents clearly impossible cases (e.g. wide flat item in a narrow box).
+
+    Examples:
+    - 3 items 9×9×3 in XS 18.5×18.5×3:
+        • Each item fits individually ✓  (9≤18.5, 9≤18.5, 3≤3)
+        • Total volume 729 ≤ 1025 ✓  → fits ✓
+    - 1 item 24.5×24.5×2 in S 28×15.5×10:
+        • Item does NOT fit individually ✗  (24.5 > 15.5)  → doesn't fit ✓
+    """
+    if not item_list:
+        return True
+
+    box_volume = box_dims[0] * box_dims[1] * box_dims[2]
+    total_item_volume = 0.0
+
+    for dims in item_list:
+        # Condition 1: individual item must fit
+        if not _item_fits_in_box(dims, box_dims):
+            return False
+        total_item_volume += dims[0] * dims[1] * dims[2]
+
+    # Condition 2: total volume check
+    return total_item_volume <= box_volume
+
+
+def find_min_box_for_order(order_df: pd.DataFrame, weight_config: Dict) -> str:
+    """
+    Find the smallest box (by volume) that physically fits all items in the order.
+
+    Returns:
+    - Box name (str) if a fitting box is found
+    - NO_BOX_NEEDED if all items have no_packaging=True
+    - UNKNOWN_DIMS if some items have no dimensions configured
+    - NO_BOX_FITS if no configured box fits all items
+    """
+    products = weight_config.get("products", {})
+    boxes = weight_config.get("boxes", [])
+
+    if not products or "SKU" not in order_df.columns:
+        return UNKNOWN_DIMS
+
+    # Collect item dimensions (expanded by quantity, excluding no_packaging items)
+    item_dims_list: List[Tuple[float, float, float]] = []
+    has_packaging_items = False
+    has_unknown_dims = False
+
+    for _, row in order_df.iterrows():
+        sku = str(row.get("SKU", "") or "")
+        if not sku or sku == "NO_SKU":
+            continue
+
+        if sku not in products:
+            has_unknown_dims = True
+            continue
+
+        product = products[sku]
+        if product.get("no_packaging", False):
+            continue
+
+        # This SKU requires packaging
+        has_packaging_items = True
+
+        l = float(product.get("length_cm") or 0)
+        w = float(product.get("width_cm") or 0)
+        h = float(product.get("height_cm") or 0)
+
+        if l <= 0 or w <= 0 or h <= 0:
+            has_unknown_dims = True
+            continue
+
+        qty = int(float(row.get("Quantity", 1) or 1))
+        for _ in range(qty):
+            item_dims_list.append((l, w, h))
+
+    if not has_packaging_items and not has_unknown_dims:
+        return NO_BOX_NEEDED
+
+    if has_unknown_dims and not item_dims_list:
+        return UNKNOWN_DIMS
+
+    if not item_dims_list:
+        return NO_BOX_NEEDED
+
+    if not boxes:
+        return NO_BOX_FITS
+
+    # Sort boxes by volume (ascending) to find the smallest fitting box first
+    def box_volume(b):
+        return (float(b.get("length_cm") or 0) *
+                float(b.get("width_cm") or 0) *
+                float(b.get("height_cm") or 0))
+
+    sorted_boxes = sorted(
+        [b for b in boxes if box_volume(b) > 0],
+        key=box_volume
+    )
+
+    for box in sorted_boxes:
+        box_dims = (
+            float(box.get("length_cm") or 0),
+            float(box.get("width_cm") or 0),
+            float(box.get("height_cm") or 0),
+        )
+        if _order_fits_in_box(item_dims_list, box_dims):
+            return box.get("name", "").strip() or f"Box({box_dims})"
+
+    return NO_BOX_FITS
+
+
+def enrich_dataframe_with_weights(df: pd.DataFrame, weight_config: Dict) -> pd.DataFrame:
+    """
+    Adds volumetric weight and physical box columns to the DataFrame before Rule Engine runs.
+
+    Adds:
+    - SKU_Volumetric_Weight: per-line-item vol weight (per unit, not multiplied by qty)
+    - Order_Volumetric_Weight: total vol weight for the entire order (sum of qty*vol_weight)
+    - All_No_Packaging: True if all items in the order have no_packaging flag
+    - Order_Min_Box: name of the smallest box that physically fits all order items
+                     (or NO_BOX_NEEDED / NO_BOX_FITS / UNKNOWN_DIMS)
+
+    Rule Engine triggers available:
+    - order_volumetric_weight  (numeric)
+    - all_no_packaging         (boolean)
+    - Order_Min_Box            (string field, use "equals" / "contains" operators)
+    """
+    if not weight_config:
+        return df
+
+    if "SKU" not in df.columns or "Order_Number" not in df.columns:
+        logger.warning("[WeightCalc] SKU or Order_Number column missing, skipping weight enrichment")
+        return df
+
+    # Per-SKU volumetric weight (per unit)
+    df = df.copy()
+    df["SKU_Volumetric_Weight"] = df["SKU"].apply(
+        lambda sku: calc_sku_volumetric_weight(str(sku) if pd.notna(sku) else "", weight_config)
+    )
+
+    # Per-order aggregates
+    order_vol_weights = {}
+    order_all_no_pkg = {}
+    order_min_box = {}
+
+    boxes = weight_config.get("boxes", [])
+
+    for order_num, order_group in df.groupby("Order_Number"):
+        order_vol_weights[order_num] = calc_order_volumetric_weight(order_group, weight_config)
+        order_all_no_pkg[order_num] = is_all_no_packaging(order_group, weight_config)
+        if boxes:
+            order_min_box[order_num] = find_min_box_for_order(order_group, weight_config)
+
+    df["Order_Volumetric_Weight"] = df["Order_Number"].map(order_vol_weights).fillna(0.0)
+    df["All_No_Packaging"] = df["Order_Number"].map(order_all_no_pkg).fillna(False)
+    if boxes:
+        df["Order_Min_Box"] = df["Order_Number"].map(order_min_box).fillna(UNKNOWN_DIMS)
+
+    logger.info(
+        f"[WeightCalc] Enriched {len(df)} rows with volumetric weights. "
+        f"Orders: {len(order_vol_weights)}"
+    )
+    return df

--- a/shopify_tool/weight_calculator.py
+++ b/shopify_tool/weight_calculator.py
@@ -81,9 +81,13 @@ def calc_order_volumetric_weight(order_df: pd.DataFrame, weight_config: Dict) ->
 
 def is_all_no_packaging(order_df: pd.DataFrame, weight_config: Dict) -> bool:
     """
-    Returns True if ALL SKUs in the order have no_packaging=True.
-    Also returns True if the order has no recognized SKUs (all NO_SKU).
-    Returns False if any SKU requires packaging.
+    Returns True ONLY if at least one real SKU was found AND all such SKUs
+    have no_packaging=True.
+
+    Returns False when:
+    - No SKU column exists
+    - All rows are NO_SKU / empty (unknown packaging need → treat as required)
+    - Any SKU requires packaging or is not configured
     """
     products = weight_config.get("products", {})
 

--- a/tests/test_weight_calculator.py
+++ b/tests/test_weight_calculator.py
@@ -1,0 +1,347 @@
+"""Tests for the volumetric weight calculator module."""
+
+import pytest
+import pandas as pd
+
+from shopify_tool.weight_calculator import (
+    calc_sku_volumetric_weight,
+    calc_order_volumetric_weight,
+    is_all_no_packaging,
+    enrich_dataframe_with_weights,
+    find_min_box_for_order,
+    _item_fits_in_box,
+    _order_fits_in_box,
+    NO_BOX_NEEDED,
+    NO_BOX_FITS,
+    UNKNOWN_DIMS,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_WEIGHT_CONFIG = {
+    "volumetric_divisor": 6000,
+    "products": {
+        "SKU-A": {"name": "Product A", "length_cm": 30, "width_cm": 20, "height_cm": 10, "no_packaging": False},
+        "SKU-B": {"name": "Product B", "length_cm": 60, "width_cm": 40, "height_cm": 30, "no_packaging": False},
+        "SKU-NP": {"name": "No Packaging Product", "length_cm": 5, "width_cm": 5, "height_cm": 1, "no_packaging": True},
+    },
+    "boxes": [],
+}
+
+
+# ---------------------------------------------------------------------------
+# calc_sku_volumetric_weight
+# ---------------------------------------------------------------------------
+
+class TestCalcSkuVolumetricWeight:
+    def test_known_sku(self):
+        # 30 * 20 * 10 / 6000 = 6000/6000 = 1.0
+        result = calc_sku_volumetric_weight("SKU-A", SAMPLE_WEIGHT_CONFIG)
+        assert result == pytest.approx(1.0)
+
+    def test_larger_sku(self):
+        # 60 * 40 * 30 / 6000 = 72000/6000 = 12.0
+        result = calc_sku_volumetric_weight("SKU-B", SAMPLE_WEIGHT_CONFIG)
+        assert result == pytest.approx(12.0)
+
+    def test_no_packaging_sku_returns_zero(self):
+        result = calc_sku_volumetric_weight("SKU-NP", SAMPLE_WEIGHT_CONFIG)
+        assert result == 0.0
+
+    def test_unknown_sku_returns_zero(self):
+        result = calc_sku_volumetric_weight("UNKNOWN", SAMPLE_WEIGHT_CONFIG)
+        assert result == 0.0
+
+    def test_empty_sku_returns_zero(self):
+        result = calc_sku_volumetric_weight("", SAMPLE_WEIGHT_CONFIG)
+        assert result == 0.0
+
+    def test_missing_dimensions_returns_zero(self):
+        config = {
+            "volumetric_divisor": 6000,
+            "products": {
+                "SKU-X": {"name": "X", "length_cm": 0, "width_cm": 10, "height_cm": 10, "no_packaging": False}
+            }
+        }
+        assert calc_sku_volumetric_weight("SKU-X", config) == 0.0
+
+    def test_custom_divisor(self):
+        config = {
+            "volumetric_divisor": 5000,
+            "products": {
+                "SKU-D": {"name": "D", "length_cm": 50, "width_cm": 20, "height_cm": 10, "no_packaging": False}
+            }
+        }
+        # 50*20*10 / 5000 = 10000/5000 = 2.0
+        assert calc_sku_volumetric_weight("SKU-D", config) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# calc_order_volumetric_weight
+# ---------------------------------------------------------------------------
+
+class TestCalcOrderVolumetricWeight:
+    def test_single_item_qty1(self):
+        df = pd.DataFrame([{"Order_Number": "#1001", "SKU": "SKU-A", "Quantity": 1}])
+        result = calc_order_volumetric_weight(df, SAMPLE_WEIGHT_CONFIG)
+        assert result == pytest.approx(1.0)
+
+    def test_single_item_qty3(self):
+        df = pd.DataFrame([{"Order_Number": "#1001", "SKU": "SKU-A", "Quantity": 3}])
+        result = calc_order_volumetric_weight(df, SAMPLE_WEIGHT_CONFIG)
+        assert result == pytest.approx(3.0)
+
+    def test_mixed_items(self):
+        df = pd.DataFrame([
+            {"Order_Number": "#1001", "SKU": "SKU-A", "Quantity": 2},  # 2 * 1.0 = 2.0
+            {"Order_Number": "#1001", "SKU": "SKU-B", "Quantity": 1},  # 1 * 12.0 = 12.0
+        ])
+        result = calc_order_volumetric_weight(df, SAMPLE_WEIGHT_CONFIG)
+        assert result == pytest.approx(14.0)
+
+    def test_no_packaging_sku_contributes_zero(self):
+        df = pd.DataFrame([
+            {"Order_Number": "#1001", "SKU": "SKU-NP", "Quantity": 5},
+        ])
+        result = calc_order_volumetric_weight(df, SAMPLE_WEIGHT_CONFIG)
+        assert result == 0.0
+
+    def test_no_sku_rows_ignored(self):
+        df = pd.DataFrame([
+            {"Order_Number": "#1001", "SKU": "NO_SKU", "Quantity": 1},
+        ])
+        result = calc_order_volumetric_weight(df, SAMPLE_WEIGHT_CONFIG)
+        assert result == 0.0
+
+    def test_empty_dataframe(self):
+        df = pd.DataFrame(columns=["Order_Number", "SKU", "Quantity"])
+        result = calc_order_volumetric_weight(df, SAMPLE_WEIGHT_CONFIG)
+        assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# is_all_no_packaging
+# ---------------------------------------------------------------------------
+
+class TestIsAllNoPackaging:
+    def test_all_no_packaging(self):
+        df = pd.DataFrame([{"Order_Number": "#1001", "SKU": "SKU-NP", "Quantity": 2}])
+        assert is_all_no_packaging(df, SAMPLE_WEIGHT_CONFIG) is True
+
+    def test_mixed_requires_packaging(self):
+        df = pd.DataFrame([
+            {"Order_Number": "#1001", "SKU": "SKU-NP", "Quantity": 1},
+            {"Order_Number": "#1001", "SKU": "SKU-A", "Quantity": 1},
+        ])
+        assert is_all_no_packaging(df, SAMPLE_WEIGHT_CONFIG) is False
+
+    def test_regular_sku_requires_packaging(self):
+        df = pd.DataFrame([{"Order_Number": "#1001", "SKU": "SKU-A", "Quantity": 1}])
+        assert is_all_no_packaging(df, SAMPLE_WEIGHT_CONFIG) is False
+
+    def test_unknown_sku_treated_as_packaging_required(self):
+        df = pd.DataFrame([{"Order_Number": "#1001", "SKU": "UNKNOWN", "Quantity": 1}])
+        assert is_all_no_packaging(df, SAMPLE_WEIGHT_CONFIG) is False
+
+    def test_no_sku_column_returns_false(self):
+        df = pd.DataFrame([{"Order_Number": "#1001", "Quantity": 1}])
+        assert is_all_no_packaging(df, SAMPLE_WEIGHT_CONFIG) is False
+
+
+# ---------------------------------------------------------------------------
+# enrich_dataframe_with_weights
+# ---------------------------------------------------------------------------
+
+class TestEnrichDataframeWithWeights:
+    def _make_df(self):
+        return pd.DataFrame([
+            {"Order_Number": "#1001", "SKU": "SKU-A", "Quantity": 2},
+            {"Order_Number": "#1001", "SKU": "SKU-B", "Quantity": 1},
+            {"Order_Number": "#1002", "SKU": "SKU-NP", "Quantity": 3},
+        ])
+
+    def test_adds_sku_vol_weight_column(self):
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, SAMPLE_WEIGHT_CONFIG)
+        assert "SKU_Volumetric_Weight" in result.columns
+
+    def test_adds_order_vol_weight_column(self):
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, SAMPLE_WEIGHT_CONFIG)
+        assert "Order_Volumetric_Weight" in result.columns
+
+    def test_adds_all_no_packaging_column(self):
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, SAMPLE_WEIGHT_CONFIG)
+        assert "All_No_Packaging" in result.columns
+
+    def test_order_vol_weight_values(self):
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, SAMPLE_WEIGHT_CONFIG)
+        # #1001: 2*1.0 + 1*12.0 = 14.0
+        order_1001 = result[result["Order_Number"] == "#1001"]["Order_Volumetric_Weight"].iloc[0]
+        assert order_1001 == pytest.approx(14.0)
+        # #1002: SKU-NP is no_packaging so 0
+        order_1002 = result[result["Order_Number"] == "#1002"]["Order_Volumetric_Weight"].iloc[0]
+        assert order_1002 == pytest.approx(0.0)
+
+    def test_all_no_packaging_values(self):
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, SAMPLE_WEIGHT_CONFIG)
+        assert bool(result[result["Order_Number"] == "#1001"]["All_No_Packaging"].iloc[0]) is False
+        assert bool(result[result["Order_Number"] == "#1002"]["All_No_Packaging"].iloc[0]) is True
+
+    def test_sku_vol_weight_per_unit(self):
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, SAMPLE_WEIGHT_CONFIG)
+        # SKU-A per unit = 1.0 (not multiplied by qty)
+        sku_a_row = result[result["SKU"] == "SKU-A"].iloc[0]
+        assert sku_a_row["SKU_Volumetric_Weight"] == pytest.approx(1.0)
+
+    def test_empty_config_returns_unchanged(self):
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, {})
+        assert "SKU_Volumetric_Weight" not in result.columns
+        assert "Order_Volumetric_Weight" not in result.columns
+
+    def test_does_not_mutate_original_df(self):
+        df = self._make_df()
+        original_cols = list(df.columns)
+        enrich_dataframe_with_weights(df, SAMPLE_WEIGHT_CONFIG)
+        assert list(df.columns) == original_cols
+
+    def test_order_min_box_column_added_when_boxes_configured(self):
+        config_with_boxes = dict(SAMPLE_WEIGHT_CONFIG)
+        config_with_boxes["boxes"] = [
+            {"name": "S", "length_cm": 28, "width_cm": 15.5, "height_cm": 10},
+            {"name": "L", "length_cm": 32, "width_cm": 30, "height_cm": 14},
+        ]
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, config_with_boxes)
+        assert "Order_Min_Box" in result.columns
+
+    def test_order_min_box_not_added_when_no_boxes(self):
+        df = self._make_df()
+        result = enrich_dataframe_with_weights(df, SAMPLE_WEIGHT_CONFIG)
+        assert "Order_Min_Box" not in result.columns
+
+
+# ---------------------------------------------------------------------------
+# Physical fit: _item_fits_in_box
+# ---------------------------------------------------------------------------
+
+class TestItemFitsInBox:
+    def test_exact_fit(self):
+        assert _item_fits_in_box((10, 20, 30), (10, 20, 30)) is True
+
+    def test_fits_with_rotation(self):
+        # Item 30x10x20 fits in box 30x20x10 after rotation
+        assert _item_fits_in_box((30, 10, 20), (30, 20, 10)) is True
+
+    def test_does_not_fit(self):
+        # Item 24.5 x 24.5 x 2 in box 28 x 15.5 x 10
+        # sorted item: [2, 24.5, 24.5] vs sorted box: [10, 15.5, 28]
+        # 24.5 > 15.5 → does not fit
+        assert _item_fits_in_box((24.5, 24.5, 2), (28, 15.5, 10)) is False
+
+    def test_fits_in_large_box(self):
+        # Item 24.5 x 24.5 x 2 in box 32 x 30 x 14
+        assert _item_fits_in_box((24.5, 24.5, 2), (32, 30, 14)) is True
+
+    def test_item_too_tall(self):
+        assert _item_fits_in_box((5, 5, 50), (10, 10, 40)) is False
+
+
+# ---------------------------------------------------------------------------
+# Physical fit: find_min_box_for_order
+# ---------------------------------------------------------------------------
+
+BOXES = [
+    {"name": "XS", "length_cm": 18.5, "width_cm": 18.5, "height_cm": 3},
+    {"name": "S",  "length_cm": 28,   "width_cm": 15.5, "height_cm": 10},
+    {"name": "M",  "length_cm": 32,   "width_cm": 19,   "height_cm": 10},
+    {"name": "L",  "length_cm": 32,   "width_cm": 30,   "height_cm": 14},
+    {"name": "XL", "length_cm": 100,  "width_cm": 100,  "height_cm": 50},
+]
+
+WEIGHT_CONFIG_WITH_BOXES = {
+    "volumetric_divisor": 6000,
+    "products": {
+        "FLAT": {"name": "Flat Item", "length_cm": 24.5, "width_cm": 24.5, "height_cm": 2, "no_packaging": False},
+        "SMALL": {"name": "Small Item", "length_cm": 10, "width_cm": 10, "height_cm": 5, "no_packaging": False},
+        "NP": {"name": "No Pkg", "length_cm": 5, "width_cm": 5, "height_cm": 1, "no_packaging": True},
+    },
+    "boxes": BOXES,
+}
+
+
+class TestFindMinBoxForOrder:
+    def _make_order(self, rows):
+        return pd.DataFrame(rows)
+
+    def test_flat_item_fits_in_L_not_S(self):
+        # FLAT 24.5x24.5x2 should NOT fit in S(28x15.5x10) but SHOULD fit in L(32x30x14)
+        df = self._make_order([{"Order_Number": "#1", "SKU": "FLAT", "Quantity": 1}])
+        result = find_min_box_for_order(df, WEIGHT_CONFIG_WITH_BOXES)
+        assert result == "L"
+
+    def test_small_item_fits_in_XS(self):
+        # SMALL 10x10x5 fits in XS(18.5x18.5x3)?
+        # sorted item: [5, 10, 10] vs sorted XS: [3, 18.5, 18.5] → 5 > 3 → NO
+        # fits in S(28x15.5x10)? sorted item: [5,10,10] vs [10,15.5,28] → YES
+        df = self._make_order([{"Order_Number": "#1", "SKU": "SMALL", "Quantity": 1}])
+        result = find_min_box_for_order(df, WEIGHT_CONFIG_WITH_BOXES)
+        assert result == "S"
+
+    def test_all_no_packaging_returns_no_box_needed(self):
+        df = self._make_order([{"Order_Number": "#1", "SKU": "NP", "Quantity": 3}])
+        result = find_min_box_for_order(df, WEIGHT_CONFIG_WITH_BOXES)
+        assert result == NO_BOX_NEEDED
+
+    def test_unknown_sku_returns_unknown_dims(self):
+        df = self._make_order([{"Order_Number": "#1", "SKU": "UNKNOWN", "Quantity": 1}])
+        result = find_min_box_for_order(df, WEIGHT_CONFIG_WITH_BOXES)
+        assert result == UNKNOWN_DIMS
+
+    def test_no_boxes_configured_returns_no_box_fits(self):
+        config_no_boxes = dict(WEIGHT_CONFIG_WITH_BOXES)
+        config_no_boxes["boxes"] = []
+        df = self._make_order([{"Order_Number": "#1", "SKU": "FLAT", "Quantity": 1}])
+        result = find_min_box_for_order(df, config_no_boxes)
+        assert result == NO_BOX_FITS
+
+    def test_two_flat_items_side_by_side(self):
+        # Two FLAT (24.5x24.5x2): each item individually fails M (24.5 > 19) and S (24.5 > 15.5)
+        # Each item fits L (32x30x14): sorted item [2,24.5,24.5] ≤ sorted L [14,30,32] → YES
+        # Total volume 2x(24.5x24.5x2)=2401 ≤ L volume 13440 → YES
+        df = self._make_order([{"Order_Number": "#1", "SKU": "FLAT", "Quantity": 2}])
+        result = find_min_box_for_order(df, WEIGHT_CONFIG_WITH_BOXES)
+        assert result == "L"
+
+    def test_flat_items_fit_side_by_side_in_xs(self):
+        # 3 items 9x9x3 → each fits in XS (18.5x18.5x3): sorted [3,9,9] ≤ [3,18.5,18.5] → YES
+        # total volume 3x(9x9x3)=729 ≤ XS volume 18.5x18.5x3=1025.25 → YES
+        config = {
+            "volumetric_divisor": 6000,
+            "products": {
+                "THIN": {"name": "Thin", "length_cm": 9, "width_cm": 9, "height_cm": 3, "no_packaging": False}
+            },
+            "boxes": BOXES,
+        }
+        df = self._make_order([{"Order_Number": "#1", "SKU": "THIN", "Quantity": 3}])
+        result = find_min_box_for_order(df, config)
+        assert result == "XS"
+
+    def test_item_too_large_for_any_box(self):
+        config = {
+            "volumetric_divisor": 6000,
+            "products": {
+                "GIANT": {"name": "Giant", "length_cm": 200, "width_cm": 200, "height_cm": 200, "no_packaging": False}
+            },
+            "boxes": BOXES,
+        }
+        df = self._make_order([{"Order_Number": "#1", "SKU": "GIANT", "Quantity": 1}])
+        result = find_min_box_for_order(df, config)
+        assert result == NO_BOX_FITS


### PR DESCRIPTION
- New Weight tab in client Settings with product dimensions, box catalog, and volumetric divisor config (default 6000, DPD/Speedy standard)
- Import SKUs from stock CSV with auto-mapping via column_mappings
- Physical box selection via _order_fits_in_box: checks each item fits individually (all 6 rotations) + total volume ≤ box volume
- New Rule Engine order-level triggers: order_volumetric_weight, all_no_packaging, order_min_box
- Weight enrichment in core.py before RuleEngine.apply()
- Auto-migration _migrate_add_weight_config for existing client configs
- 41 unit tests covering all calculator functions

## Summary by Sourcery

Introduce volumetric weight and packaging support across settings, data enrichment, and rule evaluation for Shopify clients.

New Features:
- Add a Weight tab in client settings to manage volumetric divisor, per-SKU dimensions, no-packaging flags, and box catalog.
- Enable importing SKUs and names for volumetric configuration directly from a stock CSV using existing column mappings.
- Expose new order-level rule fields for volumetric weight, no-packaging detection, and minimum fitting box selection in the rule engine.

Enhancements:
- Enrich order dataframes with volumetric weight, no-packaging, and minimum box metadata before applying rules to support shipping-related logic.
- Persist weight configuration in client configs with default values and automatic migration for existing clients.

Tests:
- Add comprehensive unit tests for volumetric weight calculations, box selection logic, and DataFrame enrichment functions.