### PR TITLE
fix: resolve 6 UI and logic bugs across tag categories, writeoff, and…

### DIFF
--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -402,6 +402,10 @@ class ActionsHandler(QObject):
 
                 self.log.info(f"Tag categories updated for CLIENT_{self.mw.current_client_id}")
 
+                # Refresh tag delegate so new tags get correct colors immediately
+                if hasattr(self.mw, 'tag_delegate') and self.mw.tag_delegate is not None:
+                    self.mw.tag_delegate.tag_categories = updated_categories
+
             except Exception as e:
                 self.log.error(f"Error saving tag categories: {e}")
                 QMessageBox.critical(

--- a/gui/client_settings_dialog.py
+++ b/gui/client_settings_dialog.py
@@ -432,6 +432,7 @@ class ClientSettingsDialog(QDialog):
         """Create Appearance tab."""
         widget = QWidget()
         layout = QFormLayout(widget)
+        theme = get_theme_manager().get_current_theme()
 
         # Pin checkbox
         self.pin_checkbox = QCheckBox("Pin this client to top of sidebar")
@@ -467,7 +468,6 @@ class ClientSettingsDialog(QDialog):
             "Badges are displayed next to the client name."
         )
         info_label.setWordWrap(True)
-        theme = get_theme_manager().get_current_theme()
         info_label.setStyleSheet(f"color: {theme.text_secondary}; font-size: 9pt; padding: 10px;")
         layout.addRow(info_label)
 
@@ -477,6 +477,7 @@ class ClientSettingsDialog(QDialog):
         """Create Statistics tab."""
         widget = QWidget()
         layout = QFormLayout(widget)
+        theme = get_theme_manager().get_current_theme()
 
         # Total sessions (readonly)
         self.total_sessions_label = QLabel()

--- a/gui/reference_labels_widget.py
+++ b/gui/reference_labels_widget.py
@@ -258,7 +258,8 @@ class ReferenceLabelsWidget(QWidget):
             self.pdf_path = file_path
             file_name = Path(file_path).name
             self.pdf_label.setText(file_name)
-            self.pdf_label.setStyleSheet("color: black; font-weight: bold;")
+            theme = get_theme_manager().get_current_theme()
+            self.pdf_label.setStyleSheet(f"color: {theme.text}; font-weight: bold;")
             self.pdf_label.setToolTip(file_path)
 
             self.log.info(f"PDF selected: {file_path}")
@@ -277,7 +278,8 @@ class ReferenceLabelsWidget(QWidget):
             self.csv_path = file_path
             file_name = Path(file_path).name
             self.csv_label.setText(file_name)
-            self.csv_label.setStyleSheet("color: black; font-weight: bold;")
+            theme = get_theme_manager().get_current_theme()
+            self.csv_label.setStyleSheet(f"color: {theme.text}; font-weight: bold;")
             self.csv_label.setToolTip(file_path)
 
             self.log.info(f"CSV selected: {file_path}")
@@ -334,7 +336,8 @@ class ReferenceLabelsWidget(QWidget):
             self.output_dir.mkdir(parents=True, exist_ok=True)
 
             self.output_dir_label.setText(str(self.output_dir))
-            self.output_dir_label.setStyleSheet("color: black;")
+            theme = get_theme_manager().get_current_theme()
+            self.output_dir_label.setStyleSheet(f"color: {theme.text};")
 
             # Initialize history manager
             self.history = ReferenceLabelsHistory(self.output_dir)

--- a/gui/tag_categories_dialog.py
+++ b/gui/tag_categories_dialog.py
@@ -250,6 +250,9 @@ class TagCategoriesDialog(QDialog):
         self.writeoff_mappings_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.writeoff_mappings_table.setMaximumHeight(200)
         self.writeoff_mappings_table.setEnabled(False)  # Disabled until checkbox is checked
+        self.writeoff_mappings_table.itemSelectionChanged.connect(
+            self._update_remove_mapping_btn_state
+        )
         writeoff_layout.addWidget(self.writeoff_mappings_table)
 
         # Buttons
@@ -564,16 +567,19 @@ class TagCategoriesDialog(QDialog):
 
         return False
 
+    def _update_remove_mapping_btn_state(self):
+        """Update remove mapping button enabled state based on selection and checkbox."""
+        enabled = self.writeoff_enabled_checkbox.isChecked()
+        has_selection = len(self.writeoff_mappings_table.selectedItems()) > 0
+        self.remove_mapping_btn.setEnabled(enabled and has_selection)
+
     def _on_writeoff_enabled_changed(self, state):
         """Handle writeoff enabled checkbox state change."""
         enabled = (state == Qt.Checked)
 
         self.writeoff_mappings_table.setEnabled(enabled)
         self.add_mapping_btn.setEnabled(enabled)
-
-        # Enable remove button only if rows selected
-        has_selection = len(self.writeoff_mappings_table.selectedItems()) > 0
-        self.remove_mapping_btn.setEnabled(enabled and has_selection)
+        self._update_remove_mapping_btn_state()
 
         # Mark as modified
         self._on_editor_changed()

--- a/gui/tag_delegate.py
+++ b/gui/tag_delegate.py
@@ -85,8 +85,7 @@ class TagDelegate(QStyledItemDelegate):
         tags = parse_tags(tags_value)
         if not tags:
             return QSize(50, 30)
-        font = QFont()
-        font.setPointSize(8)
+        font = option.font
         metrics = QFontMetrics(font)
         padding = 8
         spacing = 4

--- a/gui/tag_delegate.py
+++ b/gui/tag_delegate.py
@@ -3,7 +3,7 @@
 import json
 from PySide6.QtWidgets import QStyledItemDelegate, QStyle
 from PySide6.QtCore import Qt, QRect, QSize
-from PySide6.QtGui import QPainter, QColor, QFont, QPen
+from PySide6.QtGui import QPainter, QColor, QFont, QPen, QFontMetrics
 
 from shopify_tool.tag_manager import parse_tags, get_tag_color
 
@@ -16,12 +16,14 @@ class TagDelegate(QStyledItemDelegate):
         self.tag_categories = tag_categories
 
     def paint(self, painter, option, index):
-        """Paint tags as colored badges while respecting row background color."""
-        # FIRST: Paint row background color from model
-        # This ensures Fulfillable (green) / Not Fulfillable (red) shows through
-        bg_color = index.data(Qt.BackgroundRole)
-        if bg_color:
-            painter.fillRect(option.rect, bg_color)
+        """Paint tags as colored badges while respecting row background and selection."""
+        # Handle selection highlight; fall back to model background color
+        if option.state & QStyle.State_Selected:
+            painter.fillRect(option.rect, option.palette.highlight())
+        else:
+            bg_color = index.data(Qt.BackgroundRole)
+            if bg_color:
+                painter.fillRect(option.rect, bg_color)
 
         # Get tags to render
         tags_value = index.data(Qt.DisplayRole)
@@ -78,5 +80,17 @@ class TagDelegate(QStyledItemDelegate):
         painter.restore()
 
     def sizeHint(self, option, index):
-        """Return size hint for cell (fixed height for badges)."""
-        return QSize(option.rect.width(), 30)
+        """Return size hint for cell based on actual badge widths."""
+        tags_value = index.data(Qt.DisplayRole)
+        tags = parse_tags(tags_value)
+        if not tags:
+            return QSize(50, 30)
+        font = QFont()
+        font.setPointSize(8)
+        metrics = QFontMetrics(font)
+        padding = 8
+        spacing = 4
+        total_width = 10  # left margin
+        for tag in tags:
+            total_width += metrics.horizontalAdvance(tag) + padding * 2 + spacing
+        return QSize(total_width, 30)

--- a/shopify_tool/sku_writeoff.py
+++ b/shopify_tool/sku_writeoff.py
@@ -143,13 +143,15 @@ def calculate_writeoff_quantities(
     # Accumulator: {sku: {"quantity": float, "tags": set, "orders": set}}
     writeoff_accumulator = {}
 
-    # Process each row
-    for idx, row in analysis_df.iterrows():
-        # Only write off packaging for orders that are actually Fulfillable
-        if "Order_Fulfillment_Status" in analysis_df.columns:
-            if row.get("Order_Fulfillment_Status", "") != "Fulfillable":
-                continue
+    # Pre-filter to Fulfillable rows only when the status column is present
+    has_status_col = "Order_Fulfillment_Status" in analysis_df.columns
+    if has_status_col:
+        rows_df = analysis_df[analysis_df["Order_Fulfillment_Status"] == "Fulfillable"]
+    else:
+        rows_df = analysis_df
 
+    # Process each row
+    for idx, row in rows_df.iterrows():
         tags = parse_tags(row.get("Internal_Tags"))
 
         # Get order number (use row index if Order_Number not present)

--- a/shopify_tool/sku_writeoff.py
+++ b/shopify_tool/sku_writeoff.py
@@ -145,6 +145,11 @@ def calculate_writeoff_quantities(
 
     # Process each row
     for idx, row in analysis_df.iterrows():
+        # Only write off packaging for orders that are actually Fulfillable
+        if "Order_Fulfillment_Status" in analysis_df.columns:
+            if row.get("Order_Fulfillment_Status", "") != "Fulfillable":
+                continue
+
         tags = parse_tags(row.get("Internal_Tags"))
 
         # Get order number (use row index if Order_Number not present)


### PR DESCRIPTION
… dialogs

- Tag colors: refresh TagDelegate.tag_categories after saving Tag Categories so manually added tags get correct colors immediately
- Remove Mapping button: connect itemSelectionChanged signal on writeoff mappings table; extract _update_remove_mapping_btn_state() helper
- Internal Tags column: fix sizeHint() to calculate actual badge widths for auto-resize; fix paint() to respect QStyle.State_Selected for row selection highlight
- Writeoff packaging: filter rows by Order_Fulfillment_Status == 'Fulfillable' before accumulating writeoff quantities (backward-compatible)
- Client settings dialog: move theme variable initialization to top of _create_appearance_tab() and _create_statistics_tab() to fix UnboundLocalError crash
- Reference labels dark theme: replace hardcoded 'color: black' with theme.text for PDF label, CSV label, and output dir label

## Summary by Sourcery

Fix multiple UI and logic issues across tag rendering, writeoff mappings, writeoff quantity calculation, reference labels theming, and client settings dialogs.

Bug Fixes:
- Refresh tag delegate category data after saving tag categories so newly added tags immediately display with correct colors.
- Ensure the writeoff mappings Remove Mapping button correctly reflects table selection state via a dedicated update helper.
- Correct tag column sizing by basing size hints on actual rendered badge widths instead of a fixed width.
- Respect row selection highlight when painting tag badges so selected rows render consistently with the UI style.
- Exclude non-fulfillable orders when calculating writeoff packaging quantities, gated by presence of the fulfillment status column.
- Prevent an UnboundLocalError in the client settings dialog by initializing theme data at the start of appearance and statistics tab creation.
- Make reference labels widget text colors theme-aware instead of using hardcoded black, improving dark theme support.