### PR TITLE
feat: refactor SettingsWindow UI — search, sub-tabs, embedded panels,…

### DIFF
--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -480,10 +480,27 @@ class ActionsHandler(QObject):
             )
             return
 
-        # Open selection dialog
-        from gui.report_selection_dialog import ReportSelectionDialog
+        # Open selection dialog (new preview-enabled dialogs)
+        analysis_df = self.mw.analysis_results_df
 
-        dialog = ReportSelectionDialog(report_type, report_configs, self.mw)
+        if report_type == "packing_lists":
+            from gui.report_selection_dialog import PackingListDialog
+            dialog = PackingListDialog(
+                report_configs,
+                analysis_df,
+                self._apply_filters,
+                self.mw
+            )
+        else:
+            from gui.report_selection_dialog import StockExportDialog
+            dialog = StockExportDialog(
+                report_configs,
+                analysis_df,
+                self._apply_filters,
+                writeoff_handler=self.generate_writeoff_report,
+                parent=self.mw
+            )
+
         dialog.reportSelected.connect(
             lambda rc: self._generate_single_report(report_type, rc, session_path)
         )

--- a/gui/barcode_generator_widget.py
+++ b/gui/barcode_generator_widget.py
@@ -403,17 +403,16 @@ class BarcodeGeneratorWidget(QWidget):
 
         # Merge tags from ALL rows of each order (not just the first row)
         if 'Internal_Tags' in self.filtered_orders_df.columns:
-            def _merge_tags(series):
+            merged_tags = {}
+            for order_num, group in self.filtered_orders_df.groupby('Order_Number', sort=False):
                 seen, result = set(), []
-                for val in series.dropna():
+                for val in group['Internal_Tags'].dropna():
                     for t in str(val).split(','):
                         t = t.strip()
                         if t and t not in seen:
                             seen.add(t)
                             result.append(t)
-                return ', '.join(result)
-
-            merged_tags = self.filtered_orders_df.groupby('Order_Number')['Internal_Tags'].apply(_merge_tags)
+                merged_tags[order_num] = ', '.join(result)
             unique_orders['Internal_Tags'] = unique_orders['Order_Number'].map(merged_tags)
 
         # Sort by natural order so sequential numbering (idx+1) matches numeric order

--- a/gui/barcode_generator_widget.py
+++ b/gui/barcode_generator_widget.py
@@ -401,6 +401,21 @@ class BarcodeGeneratorWidget(QWidget):
         # Add item_count column to unique_orders (total quantity of products)
         unique_orders['item_count'] = unique_orders['Order_Number'].map(item_counts)
 
+        # Merge tags from ALL rows of each order (not just the first row)
+        if 'Internal_Tags' in self.filtered_orders_df.columns:
+            def _merge_tags(series):
+                seen, result = set(), []
+                for val in series.dropna():
+                    for t in str(val).split(','):
+                        t = t.strip()
+                        if t and t not in seen:
+                            seen.add(t)
+                            result.append(t)
+                return ', '.join(result)
+
+            merged_tags = self.filtered_orders_df.groupby('Order_Number')['Internal_Tags'].apply(_merge_tags)
+            unique_orders['Internal_Tags'] = unique_orders['Order_Number'].map(merged_tags)
+
         # Sort by natural order so sequential numbering (idx+1) matches numeric order
         unique_orders['_order_sort'] = unique_orders['Order_Number'].apply(order_number_sort_key)
         unique_orders = unique_orders.sort_values('_order_sort').drop(columns=['_order_sort']).reset_index(drop=True)

--- a/gui/column_config_dialog.py
+++ b/gui/column_config_dialog.py
@@ -873,13 +873,14 @@ class ColumnConfigDialog(QDialog):
 
     config_applied = Signal()
 
-    def __init__(self, table_config_manager, parent=None):
+    def __init__(self, table_config_manager, parent=None, main_window=None):
         """
         Initialize the Column Configuration Dialog.
 
         Args:
             table_config_manager: TableConfigManager instance
-            parent: Parent widget (MainWindow)
+            parent: Qt parent widget
+            main_window: MainWindow reference (falls back to parent if not given)
         """
         super().__init__(parent)
         self.setWindowTitle("Manage Table Columns")
@@ -888,7 +889,7 @@ class ColumnConfigDialog(QDialog):
 
         main_layout = QVBoxLayout(self)
 
-        self.panel = ColumnConfigPanel(table_config_manager, main_window=parent, parent=self)
+        self.panel = ColumnConfigPanel(table_config_manager, main_window=main_window or parent, parent=self)
         # Remove the panel's built-in Apply button (dialog has its own)
         self.panel.apply_button.hide()
         self.panel.reset_button.hide()
@@ -916,6 +917,13 @@ class ColumnConfigDialog(QDialog):
 
         # Close dialog when panel successfully applies
         self.panel.config_applied.connect(self._on_panel_applied)
+
+    def __getattr__(self, name):
+        """Proxy attribute lookups to the embedded panel for backwards compatibility."""
+        panel = self.__dict__.get('panel')
+        if panel is not None and hasattr(panel, name):
+            return getattr(panel, name)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     def _on_panel_applied(self):
         """Called when panel.config_applied is emitted."""

--- a/gui/column_config_dialog.py
+++ b/gui/column_config_dialog.py
@@ -32,36 +32,35 @@ from gui.theme_manager import get_theme_manager
 logger = logging.getLogger(__name__)
 
 
-class ColumnConfigDialog(QDialog):
-    """Dialog for configuring table column visibility and order."""
+class ColumnConfigPanel(QWidget):
+    """Embeddable panel for configuring table column visibility and order.
 
-    # Signal emitted when configuration is applied
+    Can be used inside a QDialog (ColumnConfigDialog) or embedded directly
+    into a QTabWidget (e.g., SettingsWindow).
+    """
+
     config_applied = Signal()
 
-    def __init__(self, table_config_manager, parent=None):
+    def __init__(self, table_config_manager, main_window=None, parent=None):
         """
-        Initialize the Column Configuration Dialog.
+        Initialize the Column Configuration Panel.
 
         Args:
             table_config_manager: TableConfigManager instance
-            parent: Parent widget (MainWindow)
+            main_window: MainWindow reference (for analysis_results_df, tableView, etc.)
+            parent: Parent widget
         """
         super().__init__(parent)
         self.table_config_manager = table_config_manager
-        self.parent_window = parent
+        # parent_window kept for backward-compat within the methods below
+        self.parent_window = main_window
 
-        # Track original configuration for cancel
         self._original_config = None
-        self._original_view_name = None  # Store original view name for cancel
+        self._original_view_name = None
         self._current_columns: List[str] = []
         self._is_loading = False
 
-        # Initialize additional columns config (always defined)
         self.additional_columns_config: List[dict] = []
-
-        self.setWindowTitle("Manage Table Columns")
-        self.setMinimumSize(600, 700)
-        self.setModal(True)
 
         self._init_ui()
         self._connect_signals()
@@ -144,7 +143,6 @@ class ColumnConfigDialog(QDialog):
         additional_group = QGroupBox("Additional CSV Columns")
         additional_layout = QVBoxLayout()
 
-        # Info label
         info_label = QLabel(
             "Configure additional columns from your CSV file to include in analysis.\n"
             "These columns are not in the standard mapping but can be preserved if needed."
@@ -154,17 +152,14 @@ class ColumnConfigDialog(QDialog):
         info_label.setStyleSheet(f"color: {theme.text_secondary}; font-style: italic;")
         additional_layout.addWidget(info_label)
 
-        # Scan button
         self.scan_csv_button = QPushButton("Scan Current CSV for Available Columns")
         self.scan_csv_button.clicked.connect(self._on_scan_csv)
         additional_layout.addWidget(self.scan_csv_button)
 
-        # Additional columns list
         self.additional_columns_list = QListWidget()
         self.additional_columns_list.setMaximumHeight(200)
         additional_layout.addWidget(self.additional_columns_list)
 
-        # Bulk operations
         additional_buttons = QHBoxLayout()
         self.enable_all_additional_button = QPushButton("Enable All")
         self.enable_all_additional_button.clicked.connect(self._on_enable_all_additional)
@@ -178,53 +173,37 @@ class ColumnConfigDialog(QDialog):
         additional_group.setLayout(additional_layout)
         main_layout.addWidget(additional_group)
 
-        # Reset section
-        reset_layout = QHBoxLayout()
+        # Reset + Apply row
+        action_layout = QHBoxLayout()
         self.reset_button = QPushButton("Reset to Default")
         self.reset_button.setToolTip("Reset all columns to default visibility and order")
-        reset_layout.addStretch()
-        reset_layout.addWidget(self.reset_button)
-        main_layout.addLayout(reset_layout)
-
-        # Dialog buttons
-        button_layout = QHBoxLayout()
-        button_layout.addStretch()
-        self.cancel_button = QPushButton("Cancel")
-        self.apply_button = QPushButton("Apply")
+        action_layout.addWidget(self.reset_button)
+        action_layout.addStretch()
+        self.apply_button = QPushButton("Apply Column Configuration")
         self.apply_button.setDefault(True)
-        button_layout.addWidget(self.cancel_button)
-        button_layout.addWidget(self.apply_button)
-        main_layout.addLayout(button_layout)
+        action_layout.addWidget(self.apply_button)
+        main_layout.addLayout(action_layout)
 
     def _connect_signals(self):
         """Connect UI signals to slots."""
-        # Search
         self.search_input.textChanged.connect(self._on_search_changed)
 
-        # Column list
         self.column_list.itemChanged.connect(self._on_item_changed)
         self.column_list.currentRowChanged.connect(self._update_button_states)
 
-        # Reorder buttons
         self.up_button.clicked.connect(self._on_move_up)
         self.down_button.clicked.connect(self._on_move_down)
 
-        # Visibility controls
         self.show_all_button.clicked.connect(self._on_show_all)
         self.hide_all_button.clicked.connect(self._on_hide_all)
         self.auto_hide_checkbox.toggled.connect(self._on_auto_hide_toggled)
 
-        # View management
         self.view_combo.currentTextChanged.connect(self._on_view_changed)
         self.save_view_button.clicked.connect(self._on_save_view)
         self.delete_view_button.clicked.connect(self._on_delete_view)
 
-        # Reset
         self.reset_button.clicked.connect(self._on_reset)
-
-        # Dialog buttons
-        self.cancel_button.clicked.connect(self._on_cancel)
-        self.apply_button.clicked.connect(self._on_apply)
+        self.apply_button.clicked.connect(self.apply_config)
 
     def _load_current_config(self):
         """Load the current table configuration."""
@@ -236,26 +215,17 @@ class ColumnConfigDialog(QDialog):
         self._is_loading = True
 
         try:
-            # Get current configuration
             config = self.table_config_manager.get_current_config()
             if config is None:
-                # Load config for current client
                 config = self.table_config_manager.load_config(client_id)
 
-            # Store original config and view name for cancel
             self._original_config = config
             self._original_view_name = self.table_config_manager.get_current_view_name()
 
-            # Load auto-hide setting
             self.auto_hide_checkbox.setChecked(config.auto_hide_empty)
 
-            # Load views
             self._load_views()
-
-            # Load columns
             self._load_columns(config)
-
-            # Load existing additional columns configuration
             self._load_additional_columns_config()
 
         finally:
@@ -273,13 +243,11 @@ class ColumnConfigDialog(QDialog):
 
             self.view_combo.addItems(views)
 
-            # Set current view
             current_view = self.table_config_manager.get_current_view_name()
             index = self.view_combo.findText(current_view)
             if index >= 0:
                 self.view_combo.setCurrentIndex(index)
 
-            # Update delete button state
             self._update_delete_button_state()
 
         finally:
@@ -290,20 +258,15 @@ class ColumnConfigDialog(QDialog):
         self.column_list.clear()
         self._current_columns = []
 
-        # Get columns from current DataFrame or config
         if hasattr(self.parent_window, 'analysis_results_df') and \
            self.parent_window.analysis_results_df is not None:
             df = self.parent_window.analysis_results_df
             all_columns = df.columns.tolist()
         else:
-            # No DataFrame, use config columns
             all_columns = config.column_order if config.column_order else list(config.visible_columns.keys())
 
-        # Use config order if available, otherwise use DataFrame order
         if config.column_order:
-            # Start with ordered columns
             ordered_columns = [col for col in config.column_order if col in all_columns]
-            # Add any new columns not in config
             for col in all_columns:
                 if col not in ordered_columns:
                     ordered_columns.append(col)
@@ -311,19 +274,15 @@ class ColumnConfigDialog(QDialog):
         else:
             columns = all_columns
 
-        # Create list items
         for col_name in columns:
             item = QListWidgetItem(col_name)
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
 
-            # Check if column is visible
             is_visible = config.visible_columns.get(col_name, True)
             item.setCheckState(Qt.Checked if is_visible else Qt.Unchecked)
 
-            # Mark locked columns
             if col_name in config.locked_columns:
                 item.setToolTip("⚠ Locked column (always visible and first)")
-                # Set bold font for locked columns
                 font = item.font()
                 font.setBold(True)
                 item.setFont(font)
@@ -331,7 +290,6 @@ class ColumnConfigDialog(QDialog):
             self.column_list.addItem(item)
             self._current_columns.append(col_name)
 
-        # Update button states
         self._update_button_states()
 
     def _on_search_changed(self, text: str):
@@ -342,7 +300,6 @@ class ColumnConfigDialog(QDialog):
             item = self.column_list.item(i)
             column_name = item.text()
 
-            # Show/hide based on search
             if text in column_name.lower():
                 item.setHidden(False)
             else:
@@ -356,7 +313,6 @@ class ColumnConfigDialog(QDialog):
         column_name = item.text()
         config = self.table_config_manager.get_current_config()
 
-        # Prevent unchecking locked columns
         if column_name in config.locked_columns and item.checkState() == Qt.Unchecked:
             self._is_loading = True
             item.setCheckState(Qt.Checked)
@@ -378,7 +334,6 @@ class ColumnConfigDialog(QDialog):
         item = self.column_list.currentItem()
         column_name = item.text()
 
-        # Prevent moving locked columns or moving to locked position
         if column_name in config.locked_columns:
             QMessageBox.warning(
                 self,
@@ -387,7 +342,6 @@ class ColumnConfigDialog(QDialog):
             )
             return
 
-        # Prevent moving to position 0 if Order_Number is locked there
         if current_row == 1 and "Order_Number" in config.locked_columns:
             target_col = self.column_list.item(0).text()
             if target_col == "Order_Number":
@@ -398,12 +352,10 @@ class ColumnConfigDialog(QDialog):
                 )
                 return
 
-        # Move the item
         item = self.column_list.takeItem(current_row)
         self.column_list.insertItem(current_row - 1, item)
         self.column_list.setCurrentRow(current_row - 1)
 
-        # Update internal list
         self._current_columns.insert(current_row - 1, self._current_columns.pop(current_row))
 
     def _on_move_down(self):
@@ -416,7 +368,6 @@ class ColumnConfigDialog(QDialog):
         item = self.column_list.currentItem()
         column_name = item.text()
 
-        # Prevent moving locked columns
         if column_name in config.locked_columns:
             QMessageBox.warning(
                 self,
@@ -425,7 +376,6 @@ class ColumnConfigDialog(QDialog):
             )
             return
 
-        # Prevent moving above locked column to position 0
         if current_row == 0 and "Order_Number" in config.locked_columns:
             QMessageBox.warning(
                 self,
@@ -434,12 +384,10 @@ class ColumnConfigDialog(QDialog):
             )
             return
 
-        # Move the item
         item = self.column_list.takeItem(current_row)
         self.column_list.insertItem(current_row + 1, item)
         self.column_list.setCurrentRow(current_row + 1)
 
-        # Update internal list
         self._current_columns.insert(current_row + 1, self._current_columns.pop(current_row))
 
     def _on_show_all(self):
@@ -452,7 +400,6 @@ class ColumnConfigDialog(QDialog):
         finally:
             self._is_loading = False
 
-        # Disable auto-hide so empty columns stay visible after Apply
         self.auto_hide_checkbox.setChecked(False)
 
     def _on_hide_all(self):
@@ -465,7 +412,6 @@ class ColumnConfigDialog(QDialog):
                 item = self.column_list.item(i)
                 column_name = item.text()
 
-                # Skip locked columns
                 if column_name in config.locked_columns:
                     continue
 
@@ -475,7 +421,6 @@ class ColumnConfigDialog(QDialog):
 
     def _on_auto_hide_toggled(self, checked: bool):
         """Handle auto-hide toggle."""
-        # Will be saved when Apply is clicked
         pass
 
     def _on_view_changed(self, view_name: str):
@@ -483,23 +428,19 @@ class ColumnConfigDialog(QDialog):
         if self._is_loading or not view_name:
             return
 
-        # Load the selected view
         config = self.table_config_manager.load_view(view_name)
         if config:
             self._is_loading = True
             try:
-                # Update UI with new config
                 self.auto_hide_checkbox.setChecked(config.auto_hide_empty)
                 self._load_columns(config)
             finally:
                 self._is_loading = False
 
-        # Update delete button state
         self._update_delete_button_state()
 
     def _on_save_view(self):
         """Save current configuration as a named view."""
-        # Get view name from user
         view_name, ok = QInputDialog.getText(
             self,
             "Save View As",
@@ -512,7 +453,6 @@ class ColumnConfigDialog(QDialog):
 
         view_name = view_name.strip()
 
-        # Check if view already exists
         existing_views = self.table_config_manager.list_views()
         if view_name in existing_views:
             reply = QMessageBox.question(
@@ -525,15 +465,12 @@ class ColumnConfigDialog(QDialog):
             if reply == QMessageBox.No:
                 return
 
-        # Create config from current UI state
         config = self._get_config_from_ui()
 
-        # Save view
         try:
             self.table_config_manager.save_view(view_name, config)
             logger.info(f"View '{view_name}' saved successfully")
 
-            # Reload views and select the new one
             self._load_views()
             index = self.view_combo.findText(view_name)
             if index >= 0:
@@ -564,7 +501,6 @@ class ColumnConfigDialog(QDialog):
             )
             return
 
-        # Confirm deletion
         reply = QMessageBox.question(
             self,
             "Delete View",
@@ -576,12 +512,10 @@ class ColumnConfigDialog(QDialog):
         if reply == QMessageBox.No:
             return
 
-        # Delete view
         try:
             self.table_config_manager.delete_view(view_name)
             logger.info(f"View '{view_name}' deleted successfully")
 
-            # Reload views and select Default
             self._load_views()
             index = self.view_combo.findText("Default")
             if index >= 0:
@@ -608,18 +542,15 @@ class ColumnConfigDialog(QDialog):
         if reply == QMessageBox.No:
             return
 
-        # Get default config
         if hasattr(self.parent_window, 'analysis_results_df') and \
            self.parent_window.analysis_results_df is not None:
             df = self.parent_window.analysis_results_df
             columns = df.columns.tolist()
         else:
-            # Use current columns
             columns = self._current_columns
 
         default_config = self.table_config_manager.get_default_config(columns)
 
-        # Load default config into UI
         self._is_loading = True
         try:
             self.auto_hide_checkbox.setChecked(default_config.auto_hide_empty)
@@ -627,35 +558,25 @@ class ColumnConfigDialog(QDialog):
         finally:
             self._is_loading = False
 
-    def _on_cancel(self):
-        """Cancel changes and restore original view."""
-        # Restore original view if it was changed
+    def revert_config(self):
+        """Revert to the original view (called on cancel)."""
         if self._original_view_name and hasattr(self.parent_window, 'current_client_id'):
             client_id = self.parent_window.current_client_id
             if client_id:
-                # Reload original view
                 self.table_config_manager.load_config(client_id, self._original_view_name)
                 logger.info(f"Restored original view: {self._original_view_name}")
 
-        # Close dialog
-        self.reject()
-
-    def _on_apply(self):
-        """Apply the current configuration."""
+    def apply_config(self):
+        """Apply the current configuration (save + update table view)."""
         try:
-            # Create config from UI state
             config = self._get_config_from_ui()
 
-            # Save configuration
             if hasattr(self.parent_window, 'current_client_id') and self.parent_window.current_client_id:
                 client_id = self.parent_window.current_client_id
                 view_name = self.view_combo.currentText() or "Default"
                 self.table_config_manager.save_config(client_id, config, view_name)
 
-                # Save additional columns config (always save, even if empty)
                 if hasattr(self, 'additional_columns_config'):
-                    # CRITICAL: Sync UI state to config before saving
-                    # This ensures all checkbox changes are captured, even if signal handlers missed any
                     if self.additional_columns_config:
                         logger.debug("Syncing UI checkbox states to config before saving...")
                         self._sync_ui_to_config()
@@ -669,7 +590,6 @@ class ColumnConfigDialog(QDialog):
 
                     client_config = self.table_config_manager.pm.load_client_config(client_id)
 
-                    # Update additional_columns in config
                     if "ui_settings" not in client_config:
                         client_config["ui_settings"] = {}
                     if "table_view" not in client_config["ui_settings"]:
@@ -677,11 +597,9 @@ class ColumnConfigDialog(QDialog):
 
                     client_config["ui_settings"]["table_view"]["additional_columns"] = self.additional_columns_config
 
-                    # Save config
                     self.table_config_manager.pm.save_client_config(client_id, client_config)
                     logger.info(f"✓ Saved additional columns: {len(enabled_cols)} enabled ({', '.join([col['csv_name'] for col in enabled_cols])})")
 
-                # Apply to table view if available
                 if hasattr(self.parent_window, 'tableView') and \
                    hasattr(self.parent_window, 'analysis_results_df') and \
                    self.parent_window.analysis_results_df is not None:
@@ -692,7 +610,6 @@ class ColumnConfigDialog(QDialog):
 
                 logger.info("Column configuration applied successfully")
 
-                # Show info message if additional columns were configured and enabled
                 if hasattr(self, 'additional_columns_config') and any(col.get('enabled', False) for col in self.additional_columns_config):
                     QMessageBox.information(
                         self,
@@ -702,11 +619,8 @@ class ColumnConfigDialog(QDialog):
                         "to see the changes in the results table."
                     )
 
-                # Emit signal
                 self.config_applied.emit()
 
-                # Close dialog
-                self.accept()
             else:
                 QMessageBox.warning(
                     self,
@@ -726,7 +640,6 @@ class ColumnConfigDialog(QDialog):
         """Create TableConfig from current UI state."""
         from gui.table_config_manager import TableConfig
 
-        # Get column order and visibility
         visible_columns = {}
         column_order = []
 
@@ -738,12 +651,10 @@ class ColumnConfigDialog(QDialog):
             visible_columns[column_name] = is_visible
             column_order.append(column_name)
 
-        # Get current config for widths and locked columns
         current_config = self.table_config_manager.get_current_config()
         if current_config is None:
             current_config = self.table_config_manager.get_default_config(column_order)
 
-        # Create new config
         config = TableConfig(
             version=1,
             visible_columns=visible_columns,
@@ -760,21 +671,16 @@ class ColumnConfigDialog(QDialog):
         current_row = self.column_list.currentRow()
         count = self.column_list.count()
 
-        # Up button: enabled if not first row
         self.up_button.setEnabled(current_row > 0)
-
-        # Down button: enabled if not last row
         self.down_button.setEnabled(current_row >= 0 and current_row < count - 1)
 
     def _update_delete_button_state(self):
         """Update enabled state of delete view button."""
         view_name = self.view_combo.currentText()
-        # Cannot delete Default view
         self.delete_view_button.setEnabled(view_name != "Default" and bool(view_name))
 
     def _on_scan_csv(self):
         """Scan current analysis dataframe for additional columns."""
-        # Get main window reference
         main_window = self.table_config_manager.mw
 
         if not hasattr(main_window, 'last_loaded_orders_df') or main_window.last_loaded_orders_df is None:
@@ -785,36 +691,28 @@ class ColumnConfigDialog(QDialog):
             )
             return
 
-        # IMPORTANT: Save current UI state before scanning, so user's checkbox changes aren't lost
         if hasattr(self, 'additional_columns_config') and self.additional_columns_config:
             self._sync_ui_to_config()
 
-        # Get the original orders dataframe (before analysis)
         orders_df = main_window.last_loaded_orders_df
 
-        # Get column mappings from shopify config
         client_id = main_window.current_client_id
         shopify_config = self.table_config_manager.pm.load_shopify_config(client_id)
         column_mappings = shopify_config.get("column_mappings", {})
 
-        # Use current in-memory config if available, otherwise load from disk
         if hasattr(self, 'additional_columns_config') and self.additional_columns_config:
             current_additional = self.additional_columns_config
         else:
             client_config = self.table_config_manager.pm.load_client_config(client_id)
             current_additional = client_config.get("ui_settings", {}).get("table_view", {}).get("additional_columns", [])
 
-        # Discover available columns
         from shopify_tool.csv_utils import discover_additional_columns
         discovered = discover_additional_columns(orders_df, column_mappings, current_additional)
 
-        # Update UI list
         self._populate_additional_columns_list(discovered)
 
-        # Store config for saving later
         self.additional_columns_config = discovered
 
-        # Show result message
         available_count = sum(1 for col in discovered if col["exists_in_df"])
         QMessageBox.information(
             self,
@@ -830,18 +728,15 @@ class ColumnConfigDialog(QDialog):
         for col_config in columns_config:
             item = QListWidgetItem()
 
-            # Create widget for list item
             widget = QWidget()
             layout = QHBoxLayout()
             layout.setContentsMargins(4, 2, 4, 2)
 
-            # Checkbox for enabled state
             checkbox = QCheckBox(col_config["csv_name"])
             checkbox.setChecked(col_config["enabled"])
             checkbox.setProperty("internal_name", col_config["internal_name"])
             checkbox.stateChanged.connect(self._on_additional_column_toggled)
 
-            # Order-level checkbox
             order_level_cb = QCheckBox("Order-Level")
             order_level_cb.setChecked(col_config["is_order_level"])
             order_level_cb.setProperty("internal_name", col_config["internal_name"])
@@ -852,7 +747,6 @@ class ColumnConfigDialog(QDialog):
             layout.addStretch()
             layout.addWidget(order_level_cb)
 
-            # Visual indicator if column doesn't exist in current CSV
             if not col_config["exists_in_df"]:
                 not_found_label = QLabel("(not in current CSV)")
                 theme = get_theme_manager().get_current_theme()
@@ -862,7 +756,6 @@ class ColumnConfigDialog(QDialog):
 
             widget.setLayout(layout)
 
-            # Add to list
             item.setSizeHint(widget.sizeHint())
             self.additional_columns_list.addItem(item)
             self.additional_columns_list.setItemWidget(item, widget)
@@ -881,16 +774,11 @@ class ColumnConfigDialog(QDialog):
                 logger.debug("No client config found")
                 return
 
-            # Get existing additional columns configuration
             existing_additional = client_config.get("ui_settings", {}).get("table_view", {}).get("additional_columns", [])
 
             if existing_additional:
-                # Store config
                 self.additional_columns_config = existing_additional
-
-                # Populate the list with existing configuration
                 self._populate_additional_columns_list(existing_additional)
-
                 logger.info(f"Loaded {len(existing_additional)} additional columns from client config")
             else:
                 logger.debug("No additional columns configuration found for this client")
@@ -905,7 +793,6 @@ class ColumnConfigDialog(QDialog):
         csv_name = checkbox.text()
         is_enabled = (state == Qt.CheckState.Checked)
 
-        # Update config
         for col in self.additional_columns_config:
             if col["internal_name"] == internal_name:
                 col["enabled"] = is_enabled
@@ -917,7 +804,6 @@ class ColumnConfigDialog(QDialog):
         checkbox = self.sender()
         internal_name = checkbox.property("internal_name")
 
-        # Update config
         for col in self.additional_columns_config:
             if col["internal_name"] == internal_name:
                 col["is_order_level"] = (state == Qt.CheckState.Checked)
@@ -937,15 +823,10 @@ class ColumnConfigDialog(QDialog):
         self._populate_additional_columns_list(self.additional_columns_config)
 
     def _sync_ui_to_config(self):
-        """Sync current UI checkbox states back to self.additional_columns_config.
-
-        This is called before scanning CSV again, so that user's checkbox changes
-        are not lost when the list is regenerated.
-        """
+        """Sync current UI checkbox states back to self.additional_columns_config."""
         if not hasattr(self, 'additional_columns_config') or not self.additional_columns_config:
             return
 
-        # Build a map of current checkbox states from UI
         ui_states = {}
 
         for i in range(self.additional_columns_list.count()):
@@ -955,11 +836,10 @@ class ColumnConfigDialog(QDialog):
             if widget is None:
                 continue
 
-            # Find checkboxes in the widget
             checkboxes = widget.findChildren(QCheckBox)
             if len(checkboxes) >= 2:
-                main_checkbox = checkboxes[0]  # Column name checkbox
-                order_level_checkbox = checkboxes[1]  # Order-Level checkbox
+                main_checkbox = checkboxes[0]
+                order_level_checkbox = checkboxes[1]
 
                 internal_name = main_checkbox.property("internal_name")
                 if internal_name:
@@ -968,7 +848,6 @@ class ColumnConfigDialog(QDialog):
                         "is_order_level": order_level_checkbox.isChecked()
                     }
 
-        # Update config with UI states
         changes_count = 0
         for col in self.additional_columns_config:
             internal_name = col["internal_name"]
@@ -987,3 +866,67 @@ class ColumnConfigDialog(QDialog):
             logger.debug(f"Synced {changes_count} checkbox state changes from UI")
 
         logger.debug(f"Synced UI state to config: {len(ui_states)} columns updated")
+
+
+class ColumnConfigDialog(QDialog):
+    """Dialog wrapper around ColumnConfigPanel for standalone use."""
+
+    config_applied = Signal()
+
+    def __init__(self, table_config_manager, parent=None):
+        """
+        Initialize the Column Configuration Dialog.
+
+        Args:
+            table_config_manager: TableConfigManager instance
+            parent: Parent widget (MainWindow)
+        """
+        super().__init__(parent)
+        self.setWindowTitle("Manage Table Columns")
+        self.setMinimumSize(600, 700)
+        self.setModal(True)
+
+        main_layout = QVBoxLayout(self)
+
+        self.panel = ColumnConfigPanel(table_config_manager, main_window=parent, parent=self)
+        # Remove the panel's built-in Apply button (dialog has its own)
+        self.panel.apply_button.hide()
+        self.panel.reset_button.hide()
+        main_layout.addWidget(self.panel)
+
+        # Dialog-level buttons
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+
+        self.reset_button = QPushButton("Reset to Default")
+        self.reset_button.setToolTip("Reset all columns to default visibility and order")
+        self.reset_button.clicked.connect(self.panel._on_reset)
+        button_layout.addWidget(self.reset_button)
+
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self._on_cancel)
+        button_layout.addWidget(self.cancel_button)
+
+        self.apply_button = QPushButton("Apply")
+        self.apply_button.setDefault(True)
+        self.apply_button.clicked.connect(self._on_apply)
+        button_layout.addWidget(self.apply_button)
+
+        main_layout.addLayout(button_layout)
+
+        # Close dialog when panel successfully applies
+        self.panel.config_applied.connect(self._on_panel_applied)
+
+    def _on_panel_applied(self):
+        """Called when panel.config_applied is emitted."""
+        self.config_applied.emit()
+        self.accept()
+
+    def _on_apply(self):
+        """Trigger panel apply (dialog will close via signal)."""
+        self.panel.apply_config()
+
+    def _on_cancel(self):
+        """Cancel changes and restore original view."""
+        self.panel.revert_config()
+        self.reject()

--- a/gui/column_config_dialog.py
+++ b/gui/column_config_dialog.py
@@ -793,21 +793,19 @@ class ColumnConfigPanel(QWidget):
         csv_name = checkbox.text()
         is_enabled = (state == Qt.CheckState.Checked)
 
-        for col in self.additional_columns_config:
-            if col["internal_name"] == internal_name:
-                col["enabled"] = is_enabled
-                logger.debug(f"Toggled '{csv_name}' ({internal_name}): enabled={is_enabled}")
-                break
+        col = next((c for c in self.additional_columns_config if c["internal_name"] == internal_name), None)
+        if col:
+            col["enabled"] = is_enabled
+            logger.debug(f"Toggled '{csv_name}' ({internal_name}): enabled={is_enabled}")
 
     def _on_order_level_toggled(self, state):
         """Handle order-level checkbox state change."""
         checkbox = self.sender()
         internal_name = checkbox.property("internal_name")
 
-        for col in self.additional_columns_config:
-            if col["internal_name"] == internal_name:
-                col["is_order_level"] = (state == Qt.CheckState.Checked)
-                break
+        col = next((c for c in self.additional_columns_config if c["internal_name"] == internal_name), None)
+        if col:
+            col["is_order_level"] = (state == Qt.CheckState.Checked)
 
     def _on_enable_all_additional(self):
         """Enable all additional columns that exist in current CSV."""

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -197,8 +197,6 @@ class MainWindow(QMainWindow):
                     self.packing_list_button.setEnabled(False)
                 if hasattr(self, 'stock_export_button'):
                     self.stock_export_button.setEnabled(False)
-                if hasattr(self, 'writeoff_report_button'):
-                    self.writeoff_report_button.setEnabled(False)
                 if hasattr(self, 'add_product_button'):
                     self.add_product_button.setEnabled(False)
 
@@ -261,8 +259,6 @@ class MainWindow(QMainWindow):
         # Main actions
         self.run_analysis_button.clicked.connect(self.actions_handler.run_analysis)
         self.settings_button.clicked.connect(self.actions_handler.open_settings_window)
-        self.tag_categories_button.clicked.connect(self.actions_handler.open_tag_categories_dialog)
-        self.configure_columns_button.clicked.connect(self.open_column_config_dialog)
         self.add_product_button.clicked.connect(self.actions_handler.show_add_product_dialog)
 
         # Reports
@@ -271,9 +267,6 @@ class MainWindow(QMainWindow):
         )
         self.stock_export_button.clicked.connect(
             lambda: self.actions_handler.open_report_selection_dialog("stock_exports")
-        )
-        self.writeoff_report_button.clicked.connect(
-            lambda: self.actions_handler.generate_writeoff_report()
         )
 
         # Table interactions
@@ -631,10 +624,6 @@ class MainWindow(QMainWindow):
         if hasattr(self, 'settings_button_tab2'):
             self.settings_button_tab2.setEnabled(has_client)
 
-        # Tag Categories button
-        if hasattr(self, 'tag_categories_button'):
-            self.tag_categories_button.setEnabled(has_client)
-
         # File loading
         self.load_orders_btn.setEnabled(has_session)
         self.load_stock_btn.setEnabled(has_session)
@@ -652,12 +641,8 @@ class MainWindow(QMainWindow):
             self.packing_list_button.setEnabled(reports_enabled)
         if hasattr(self, 'stock_export_button'):
             self.stock_export_button.setEnabled(reports_enabled)
-        if hasattr(self, 'writeoff_report_button'):
-            self.writeoff_report_button.setEnabled(reports_enabled)
         if hasattr(self, 'add_product_button'):
             self.add_product_button.setEnabled(has_analysis)
-        if hasattr(self, 'configure_columns_button'):
-            self.configure_columns_button.setEnabled(has_analysis)
 
         # Tab 2 buttons
         if hasattr(self, 'packing_list_button_tab2'):

--- a/gui/report_selection_dialog.py
+++ b/gui/report_selection_dialog.py
@@ -1,5 +1,9 @@
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QPushButton, QLabel, QCheckBox, QFrame
-from PySide6.QtCore import Signal, Slot
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QCheckBox,
+    QFrame, QListWidget, QListWidgetItem, QSplitter, QGroupBox, QTextEdit,
+    QWidget
+)
+from PySide6.QtCore import Signal, Slot, Qt
 from gui.theme_manager import get_theme_manager
 
 
@@ -185,3 +189,270 @@ class ReportSelectionDialog(QDialog):
 
         self.reportSelected.emit(report_config)
         self.accept()
+
+
+class _BaseReportDialog(QDialog):
+    """Base class for the new preview-enabled report dialogs."""
+
+    reportSelected = Signal(dict)
+
+    def __init__(self, title, reports_config, analysis_df, apply_filters_fn, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self.setMinimumSize(750, 500)
+        self.reports_config = reports_config
+        self.analysis_df = analysis_df
+        self.apply_filters_fn = apply_filters_fn  # callable(df, filters) -> filtered_df
+        self._selected_config = None
+
+        self.theme = get_theme_manager().get_current_theme()
+        self._init_ui()
+        self._populate_list()
+
+        # Select first item automatically
+        if self.report_list.count() > 0:
+            self.report_list.setCurrentRow(0)
+
+    def _init_ui(self):
+        """Create the two-column splitter layout. Subclasses extend this."""
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(12, 12, 12, 12)
+
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.setHandleWidth(6)
+
+        # ---- Left panel: report list ----
+        left_panel = QWidget()
+        left_layout = QVBoxLayout(left_panel)
+        left_layout.setContentsMargins(0, 0, 6, 0)
+
+        list_label = QLabel("Available Reports")
+        list_label.setStyleSheet("font-weight: bold; font-size: 11pt; padding-bottom: 4px;")
+        left_layout.addWidget(list_label)
+
+        self.report_list = QListWidget()
+        self.report_list.currentRowChanged.connect(self._on_report_selected)
+        left_layout.addWidget(self.report_list)
+
+        splitter.addWidget(left_panel)
+
+        # ---- Right panel: preview + actions ----
+        right_panel = self._create_right_panel()
+        splitter.addWidget(right_panel)
+
+        splitter.setSizes([280, 460])
+        main_layout.addWidget(splitter, 1)
+
+    def _create_right_panel(self):
+        """Create the right panel. Subclasses override to add extra sections."""
+        panel = QWidget()
+        layout = QVBoxLayout(panel)
+        layout.setContentsMargins(6, 0, 0, 0)
+
+        # Preview group
+        preview_group = QGroupBox("Preview")
+        preview_layout = QVBoxLayout(preview_group)
+
+        self.preview_orders_label = QLabel("Select a report to see preview")
+        self.preview_orders_label.setStyleSheet("font-size: 10pt; padding: 2px;")
+        preview_layout.addWidget(self.preview_orders_label)
+
+        self.preview_filters_text = QTextEdit()
+        self.preview_filters_text.setReadOnly(True)
+        self.preview_filters_text.setMaximumHeight(120)
+        self.preview_filters_text.setStyleSheet(
+            f"background-color: {self.theme.background}; "
+            f"color: {self.theme.text_secondary}; font-size: 9pt;"
+        )
+        preview_layout.addWidget(self.preview_filters_text)
+
+        layout.addWidget(preview_group)
+
+        # Subclasses add extra sections here
+        self._add_extra_sections(layout)
+
+        layout.addStretch()
+
+        # Generate button
+        self.generate_btn = QPushButton("Generate Report")
+        self.generate_btn.setMinimumHeight(40)
+        self.generate_btn.setEnabled(False)
+        self.generate_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #2196F3;
+                color: white;
+                font-size: 13px;
+                font-weight: bold;
+                border: none;
+                border-radius: 4px;
+            }
+            QPushButton:hover { background-color: #1976D2; }
+            QPushButton:pressed { background-color: #0D47A1; }
+            QPushButton:disabled { background-color: #757575; color: #bdbdbd; }
+        """)
+        self.generate_btn.clicked.connect(self._on_generate)
+        layout.addWidget(self.generate_btn)
+
+        return panel
+
+    def _add_extra_sections(self, layout):
+        """Override in subclasses to add sections between preview and generate button."""
+        pass
+
+    def _populate_list(self):
+        """Fill the report list from reports_config."""
+        self.report_list.clear()
+        for cfg in self.reports_config:
+            name = cfg.get("name", "Unnamed Report")
+            filters = cfg.get("filters", [])
+            item = QListWidgetItem(name)
+            item.setData(Qt.UserRole, cfg)
+            item.setToolTip(f"Filters: {len(filters)} active" if filters else "No filters")
+            self.report_list.addItem(item)
+
+    def _on_report_selected(self, row):
+        """Handle selection of a report from the list."""
+        if row < 0:
+            self._selected_config = None
+            self.generate_btn.setEnabled(False)
+            self.preview_orders_label.setText("Select a report to see preview")
+            self.preview_filters_text.setPlainText("")
+            return
+
+        item = self.report_list.item(row)
+        cfg = item.data(Qt.UserRole)
+        self._selected_config = cfg
+        self.generate_btn.setEnabled(True)
+        self._update_preview(cfg)
+
+    def _update_preview(self, cfg):
+        """Compute and show preview for the selected report config."""
+        filters = cfg.get("filters", [])
+
+        # Count matching rows
+        if self.analysis_df is not None and not self.analysis_df.empty and self.apply_filters_fn:
+            try:
+                filtered = self.apply_filters_fn(self.analysis_df, filters)
+                order_col = "Order_Number" if "Order_Number" in filtered.columns else filtered.columns[0]
+                num_orders = filtered[order_col].nunique() if not filtered.empty else 0
+                num_rows = len(filtered)
+                self.preview_orders_label.setText(
+                    f"Matching: {num_orders} orders · {num_rows} rows"
+                )
+            except Exception:
+                self.preview_orders_label.setText("Preview unavailable")
+        else:
+            self.preview_orders_label.setText("Run analysis first to see preview")
+
+        # Format filters description
+        if filters:
+            lines = []
+            for f in filters:
+                field = f.get("field", "?")
+                op = f.get("operator", "=")
+                val = f.get("value", "")
+                lines.append(f"• {field} {op} {val}")
+            self.preview_filters_text.setPlainText("\n".join(lines))
+        else:
+            self.preview_filters_text.setPlainText("(no filters — includes all data)")
+
+    def _build_emit_config(self):
+        """Build the config dict to emit. Override to inject extra fields."""
+        return dict(self._selected_config)
+
+    def _on_generate(self):
+        """Emit reportSelected with the selected config and close."""
+        if self._selected_config is None:
+            return
+        emit_config = self._build_emit_config()
+        self.reportSelected.emit(emit_config)
+        self.accept()
+
+
+class PackingListDialog(_BaseReportDialog):
+    """Two-column dialog for selecting and previewing packing list reports."""
+
+    def __init__(self, reports_config, analysis_df, apply_filters_fn, parent=None):
+        super().__init__(
+            "Generate Packing List",
+            reports_config,
+            analysis_df,
+            apply_filters_fn,
+            parent
+        )
+        self.setWindowTitle("Generate Packing List")
+
+
+class StockExportDialog(_BaseReportDialog):
+    """Two-column dialog for selecting and previewing stock export reports.
+
+    Includes an integrated Writeoff Report section replacing the old standalone button.
+    """
+
+    writeoff_requested = Signal()  # emitted when "Generate Writeoff Only" is clicked
+
+    def __init__(self, reports_config, analysis_df, apply_filters_fn,
+                 writeoff_handler=None, parent=None):
+        """
+        Args:
+            writeoff_handler: Callable to call when "Generate Writeoff Only" is clicked.
+                              If None, the button is hidden.
+        """
+        self._writeoff_handler = writeoff_handler
+        super().__init__(
+            "Generate Stock Export",
+            reports_config,
+            analysis_df,
+            apply_filters_fn,
+            parent
+        )
+        self.setWindowTitle("Generate Stock Export")
+
+    def _add_extra_sections(self, layout):
+        """Add the Writeoff section between preview and generate button."""
+        sep = QFrame()
+        sep.setFrameShape(QFrame.HLine)
+        sep.setFrameShadow(QFrame.Sunken)
+        layout.addWidget(sep)
+
+        writeoff_group = QGroupBox("Writeoff Report")
+        writeoff_layout = QVBoxLayout(writeoff_group)
+
+        self.writeoff_checkbox = QCheckBox("Include Packaging Materials in export (SKU Writeoff)")
+        self.writeoff_checkbox.setToolTip(
+            "When enabled, packaging materials (based on Internal Tags) will be\n"
+            "automatically added to the stock export as separate SKU lines.\n"
+            "Example: Orders with 'BOX' tag will add PKG-BOX-SMALL to the export."
+        )
+        writeoff_layout.addWidget(self.writeoff_checkbox)
+
+        if self._writeoff_handler:
+            self.writeoff_only_btn = QPushButton("Generate Writeoff Report Only")
+            self.writeoff_only_btn.setMinimumHeight(36)
+            self.writeoff_only_btn.setStyleSheet("""
+                QPushButton {
+                    background-color: #FF9800;
+                    color: white;
+                    font-weight: bold;
+                    border: none;
+                    border-radius: 4px;
+                }
+                QPushButton:hover { background-color: #F57C00; }
+                QPushButton:pressed { background-color: #E65100; }
+            """)
+            self.writeoff_only_btn.clicked.connect(self._on_writeoff_only)
+            writeoff_layout.addWidget(self.writeoff_only_btn)
+
+        layout.addWidget(writeoff_group)
+
+    def _on_writeoff_only(self):
+        """Call writeoff handler and close the dialog."""
+        if self._writeoff_handler:
+            self._writeoff_handler()
+        self.accept()
+
+    def _build_emit_config(self):
+        """Include apply_writeoff flag in the emitted config."""
+        cfg = dict(self._selected_config)
+        cfg["apply_writeoff"] = self.writeoff_checkbox.isChecked() if hasattr(self, 'writeoff_checkbox') else False
+        return cfg

--- a/gui/report_selection_dialog.py
+++ b/gui/report_selection_dialog.py
@@ -92,9 +92,10 @@ class ReportSelectionDialog(QDialog):
         tooltip = self._create_tooltip_text(report_config)
         button.setToolTip(tooltip)
 
-        button.setStyleSheet("""
-            QPushButton {
-                background-color: #2196F3;
+        theme = get_theme_manager().get_current_theme()
+        button.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {theme.accent_blue};
                 color: white;
                 padding: 10px;
                 font-size: 13px;
@@ -102,13 +103,9 @@ class ReportSelectionDialog(QDialog):
                 text-align: left;
                 border: none;
                 border-radius: 4px;
-            }
-            QPushButton:hover {
-                background-color: #1976D2;
-            }
-            QPushButton:pressed {
-                background-color: #0D47A1;
-            }
+            }}
+            QPushButton:hover {{ background-color: {theme.button_hover_light}; }}
+            QPushButton:pressed {{ background-color: {theme.button_hover_light}; }}
         """)
 
         return button
@@ -206,6 +203,7 @@ class _BaseReportDialog(QDialog):
         self._selected_config = None
 
         self.theme = get_theme_manager().get_current_theme()
+        self._preview_cache: dict = {}  # filters fingerprint → (num_orders, num_rows)
         self._init_ui()
         self._populate_list()
 
@@ -277,18 +275,18 @@ class _BaseReportDialog(QDialog):
         self.generate_btn = QPushButton("Generate Report")
         self.generate_btn.setMinimumHeight(40)
         self.generate_btn.setEnabled(False)
-        self.generate_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #2196F3;
+        self.generate_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {self.theme.accent_blue};
                 color: white;
                 font-size: 13px;
                 font-weight: bold;
                 border: none;
                 border-radius: 4px;
-            }
-            QPushButton:hover { background-color: #1976D2; }
-            QPushButton:pressed { background-color: #0D47A1; }
-            QPushButton:disabled { background-color: #757575; color: #bdbdbd; }
+            }}
+            QPushButton:hover {{ background-color: {self.theme.button_hover_light}; }}
+            QPushButton:pressed {{ background-color: {self.theme.button_hover_light}; }}
+            QPushButton:disabled {{ background-color: {self.theme.border}; color: {self.theme.text_secondary}; }}
         """)
         self.generate_btn.clicked.connect(self._on_generate)
         layout.addWidget(self.generate_btn)
@@ -329,13 +327,16 @@ class _BaseReportDialog(QDialog):
         """Compute and show preview for the selected report config."""
         filters = cfg.get("filters", [])
 
-        # Count matching rows
+        # Count matching rows (cached by filter fingerprint to avoid re-filtering on every click)
         if self.analysis_df is not None and not self.analysis_df.empty and self.apply_filters_fn:
             try:
-                filtered = self.apply_filters_fn(self.analysis_df, filters)
-                order_col = "Order_Number" if "Order_Number" in filtered.columns else filtered.columns[0]
-                num_orders = filtered[order_col].nunique() if not filtered.empty else 0
-                num_rows = len(filtered)
+                cache_key = str(filters)
+                if cache_key not in self._preview_cache:
+                    filtered = self.apply_filters_fn(self.analysis_df, filters)
+                    order_col = "Order_Number" if "Order_Number" in filtered.columns else (filtered.columns[0] if not filtered.empty else None)
+                    num_orders = filtered[order_col].nunique() if (not filtered.empty and order_col) else 0
+                    self._preview_cache[cache_key] = (num_orders, len(filtered))
+                num_orders, num_rows = self._preview_cache[cache_key]
                 self.preview_orders_label.setText(
                     f"Matching: {num_orders} orders · {num_rows} rows"
                 )
@@ -429,16 +430,17 @@ class StockExportDialog(_BaseReportDialog):
         if self._writeoff_handler:
             self.writeoff_only_btn = QPushButton("Generate Writeoff Report Only")
             self.writeoff_only_btn.setMinimumHeight(36)
-            self.writeoff_only_btn.setStyleSheet("""
-                QPushButton {
-                    background-color: #FF9800;
+            theme = get_theme_manager().get_current_theme()
+            self.writeoff_only_btn.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: {theme.accent_orange};
                     color: white;
                     font-weight: bold;
                     border: none;
                     border-radius: 4px;
-                }
-                QPushButton:hover { background-color: #F57C00; }
-                QPushButton:pressed { background-color: #E65100; }
+                }}
+                QPushButton:hover {{ background-color: #F57C00; }}
+                QPushButton:pressed {{ background-color: #E65100; }}
             """)
             self.writeoff_only_btn.clicked.connect(self._on_writeoff_only)
             writeoff_layout.addWidget(self.writeoff_only_btn)

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -172,7 +172,7 @@ class SettingsWindow(QDialog):
         self.courier_mapping_widgets = []
 
         self.setWindowTitle(f"Settings - CLIENT_{self.client_id}")
-        self.setMinimumSize(900, 750)  # Slightly larger for new tabs
+        self.setMinimumSize(1150, 850)
         self.setModal(True)
 
         main_layout = QVBoxLayout(self)
@@ -187,6 +187,8 @@ class SettingsWindow(QDialog):
         self.create_mappings_tab()
         self.create_sets_tab()  # Sets/Bundles tab
         self.create_weight_tab()  # Volumetric Weight tab
+        self.create_tag_categories_tab()  # Tag Categories tab
+        self.create_column_config_tab()  # Column Configuration tab
 
         button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
         button_box.accepted.connect(self.save_settings)
@@ -198,6 +200,7 @@ class SettingsWindow(QDialog):
         """Generic helper to delete a group box widget and its reference from a list."""
         widget_refs["group_box"].deleteLater()
         ref_list.remove(widget_refs)
+        self._update_rules_count_label()
 
     # Generic helper to delete a row widget and its reference from a list
     def _delete_row_from_list(self, row_widget, ref_list, ref_dict):
@@ -455,9 +458,20 @@ class SettingsWindow(QDialog):
         """Creates the 'Rules' tab for dynamically managing automation rules."""
         tab = QWidget()
         main_layout = QVBoxLayout(tab)
+
+        # Header row with Add button and rule count label
+        header_row = QHBoxLayout()
         add_rule_btn = QPushButton("Add New Rule")
-        add_rule_btn.clicked.connect(lambda: [self.add_rule_widget(), self._update_priority_labels()])
-        main_layout.addWidget(add_rule_btn, 0, Qt.AlignLeft)
+        add_rule_btn.clicked.connect(lambda: [self.add_rule_widget(), self._update_priority_labels(), self._update_rules_count_label()])
+        header_row.addWidget(add_rule_btn)
+        header_row.addStretch()
+        self.rules_count_label = QLabel("")
+        from gui.theme_manager import get_theme_manager
+        theme = get_theme_manager().get_current_theme()
+        self.rules_count_label.setStyleSheet(f"color: {theme.text_secondary}; font-size: 9pt;")
+        header_row.addWidget(self.rules_count_label)
+        main_layout.addLayout(header_row)
+
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
         main_layout.addWidget(scroll_area)
@@ -468,7 +482,33 @@ class SettingsWindow(QDialog):
         self.tab_widget.addTab(tab, "Rules")
         for rule_config in self.config_data.get("rules", []):
             self.add_rule_widget(rule_config)
-        self._update_priority_labels()  # NEW: Update priority labels after loading rules
+        self._update_priority_labels()
+        self._update_rules_count_label()
+
+    def _update_rules_count_label(self):
+        """Update the rules summary label in the Rules tab header."""
+        if not hasattr(self, 'rules_count_label'):
+            return
+        rules = self.config_data.get("rules", [])
+        article_count = sum(1 for r in rules if r.get("level", "article") == "article")
+        order_count = sum(1 for r in rules if r.get("level") == "order")
+        # Count from live widgets instead if available
+        if hasattr(self, 'rule_widgets'):
+            article_count = 0
+            order_count = 0
+            for rw in self.rule_widgets:
+                level = rw.get("level_combo")
+                if level:
+                    if level.currentText() == "order":
+                        order_count += 1
+                    else:
+                        article_count += 1
+        parts = []
+        if article_count:
+            parts.append(f"{article_count} article rule{'s' if article_count != 1 else ''}")
+        if order_count:
+            parts.append(f"{order_count} order rule{'s' if order_count != 1 else ''}")
+        self.rules_count_label.setText(", ".join(parts) if parts else "No rules defined")
 
     def add_rule_widget(self, config=None):
         """Adds a new group of widgets for creating/editing a single rule.
@@ -1807,6 +1847,13 @@ class SettingsWindow(QDialog):
         help_text.setStyleSheet(f"color: {theme.text_secondary}; font-style: italic; margin-bottom: 10px;")
         main_layout.addWidget(help_text)
 
+        # Search box
+        self.sets_search = QLineEdit()
+        self.sets_search.setPlaceholderText("Search by SKU or components...")
+        self.sets_search.setClearButtonEnabled(True)
+        self.sets_search.textChanged.connect(self._filter_sets_table)
+        main_layout.addWidget(self.sets_search)
+
         # Sets table
         self.sets_table = QTableWidget()
         self.sets_table.setColumnCount(3)
@@ -1907,6 +1954,21 @@ class SettingsWindow(QDialog):
 
             actions_layout.addStretch()
             self.sets_table.setCellWidget(row_idx, 2, actions_widget)
+
+        # Re-apply search filter after repopulate
+        if hasattr(self, 'sets_search'):
+            self._filter_sets_table(self.sets_search.text())
+
+    def _filter_sets_table(self, text: str):
+        """Filter sets table rows by SKU or components text."""
+        text = text.lower().strip()
+        for row in range(self.sets_table.rowCount()):
+            sku_item = self.sets_table.item(row, 0)
+            comp_item = self.sets_table.item(row, 1)
+            sku_text = sku_item.text().lower() if sku_item else ""
+            comp_text = comp_item.text().lower() if comp_item else ""
+            visible = not text or text in sku_text or text in comp_text
+            self.sets_table.setRowHidden(row, not visible)
 
     def _add_set_dialog(self):
         """Show dialog to add a new set."""
@@ -2063,10 +2125,13 @@ class SettingsWindow(QDialog):
 
     # ========================================
     def create_weight_tab(self):
-        """Create the Volumetric Weight management tab."""
+        """Create the Volumetric Weight management tab with sub-tabs for Products and Boxes."""
+        from PySide6.QtWidgets import QTabWidget as _QTabWidget
+
         tab = QWidget()
         main_layout = QVBoxLayout(tab)
-        main_layout.setSpacing(10)
+        main_layout.setSpacing(6)
+        main_layout.setContentsMargins(8, 8, 8, 8)
 
         from gui.theme_manager import get_theme_manager
         theme = get_theme_manager().get_current_theme()
@@ -2077,27 +2142,38 @@ class SettingsWindow(QDialog):
             "boxes": []
         })
 
-        # ---- Global Settings ----
-        global_group = QGroupBox("Global Settings")
-        global_layout = QFormLayout(global_group)
-
+        # ---- Global Settings (compact row) ----
+        global_row = QHBoxLayout()
+        global_row.setContentsMargins(0, 0, 0, 0)
+        div_label = QLabel("Volumetric Divisor (cm³ → kg):")
         self.weight_divisor_spin = QDoubleSpinBox()
         self.weight_divisor_spin.setRange(1, 100000)
         self.weight_divisor_spin.setDecimals(0)
         self.weight_divisor_spin.setValue(float(weight_cfg.get("volumetric_divisor", 6000)))
+        self.weight_divisor_spin.setFixedWidth(100)
         self.weight_divisor_spin.setToolTip(
             "Volumetric weight formula: L × W × H / divisor\n"
             "6000 = DPD/Speedy standard (cm³ → kg)\n"
             "5000 = DHL/FedEx standard"
         )
-        global_layout.addRow("Volumetric Divisor (cm³ → kg):", self.weight_divisor_spin)
-        main_layout.addWidget(global_group)
+        hint = QLabel("(6000 = DPD/Speedy · 5000 = DHL/FedEx)")
+        hint.setStyleSheet(f"color: {theme.text_secondary}; font-size: 9pt;")
+        global_row.addWidget(div_label)
+        global_row.addWidget(self.weight_divisor_spin)
+        global_row.addWidget(hint)
+        global_row.addStretch()
+        main_layout.addLayout(global_row)
 
-        # ---- Products Section ----
-        products_group = QGroupBox("Products (SKU Dimensions)")
-        products_layout = QVBoxLayout(products_group)
+        # ---- Sub-tabs: Products | Boxes ----
+        weight_sub_tabs = _QTabWidget()
+        weight_sub_tabs.setDocumentMode(True)
 
-        # Toolbar
+        # --- Products sub-tab ---
+        products_tab = QWidget()
+        products_layout = QVBoxLayout(products_tab)
+        products_layout.setContentsMargins(4, 6, 4, 4)
+        products_layout.setSpacing(4)
+
         prod_toolbar = QHBoxLayout()
         import_sku_btn = QPushButton("Import from Stock CSV")
         import_sku_btn.setToolTip("Load SKUs from the current stock CSV file")
@@ -2120,7 +2196,12 @@ class SettingsWindow(QDialog):
         prod_toolbar.addStretch()
         products_layout.addLayout(prod_toolbar)
 
-        # Table: SKU | Name | L(cm) | W(cm) | H(cm) | Vol.Weight | No Packaging
+        self.products_search = QLineEdit()
+        self.products_search.setPlaceholderText("Search by SKU or name...")
+        self.products_search.setClearButtonEnabled(True)
+        self.products_search.textChanged.connect(self._filter_products_table)
+        products_layout.addWidget(self.products_search)
+
         self.weight_products_table = QTableWidget(0, 7)
         self.weight_products_table.setHorizontalHeaderLabels([
             "SKU", "Name", "L (cm)", "W (cm)", "H (cm)", "Vol. Weight (kg)", "No Packaging"
@@ -2133,17 +2214,18 @@ class SettingsWindow(QDialog):
         self.weight_products_table.setColumnWidth(5, 110)
         self.weight_products_table.setColumnWidth(6, 100)
         self.weight_products_table.setAlternatingRowColors(True)
-        self.weight_products_table.setMinimumHeight(200)
-        # Recalculate vol weight when dimensions change
         self.weight_products_table.cellChanged.connect(
             lambda row, col: self._weight_recalc_vol_weight(self.weight_products_table, row, col, [2, 3, 4])
         )
         products_layout.addWidget(self.weight_products_table)
-        main_layout.addWidget(products_group)
 
-        # ---- Boxes Section ----
-        boxes_group = QGroupBox("Boxes (Packaging Reference)")
-        boxes_layout = QVBoxLayout(boxes_group)
+        weight_sub_tabs.addTab(products_tab, "Products (SKU Dimensions)")
+
+        # --- Boxes sub-tab ---
+        boxes_tab = QWidget()
+        boxes_layout = QVBoxLayout(boxes_tab)
+        boxes_layout.setContentsMargins(4, 6, 4, 4)
+        boxes_layout.setSpacing(4)
 
         box_toolbar = QHBoxLayout()
         import_box_btn = QPushButton("Import CSV")
@@ -2163,7 +2245,12 @@ class SettingsWindow(QDialog):
         box_toolbar.addStretch()
         boxes_layout.addLayout(box_toolbar)
 
-        # Table: Name | L(cm) | W(cm) | H(cm) | Vol.Weight
+        self.boxes_search = QLineEdit()
+        self.boxes_search.setPlaceholderText("Search by box name...")
+        self.boxes_search.setClearButtonEnabled(True)
+        self.boxes_search.textChanged.connect(self._filter_boxes_table)
+        boxes_layout.addWidget(self.boxes_search)
+
         self.weight_boxes_table = QTableWidget(0, 5)
         self.weight_boxes_table.setHorizontalHeaderLabels([
             "Box Name", "L (cm)", "W (cm)", "H (cm)", "Vol. Weight (kg)"
@@ -2174,24 +2261,23 @@ class SettingsWindow(QDialog):
         self.weight_boxes_table.setColumnWidth(3, 70)
         self.weight_boxes_table.setColumnWidth(4, 110)
         self.weight_boxes_table.setAlternatingRowColors(True)
-        self.weight_boxes_table.setMinimumHeight(150)
         self.weight_boxes_table.cellChanged.connect(
             lambda row, col: self._weight_recalc_vol_weight(self.weight_boxes_table, row, col, [1, 2, 3])
         )
         boxes_layout.addWidget(self.weight_boxes_table)
-        main_layout.addWidget(boxes_group)
 
-        tips = QLabel(
-            "Volumetric weight = L × W × H / Divisor\n"
-            "No Packaging: orders where ALL items have this flag will skip box selection\n"
-            "order_min_box — smallest box that physically fits all items (e.g. 'S', 'M', 'L')\n"
-            "Possible values: box name / NO_BOX_NEEDED / NO_BOX_FITS / UNKNOWN_DIMS"
+        tips_box = QLabel(
+            "Volumetric weight = L × W × H / Divisor · "
+            "No Packaging skips box selection · "
+            "Values: box name / NO_BOX_NEEDED / NO_BOX_FITS / UNKNOWN_DIMS"
         )
-        tips.setStyleSheet(f"color: {theme.text_secondary}; font-size: 9pt; margin-top: 5px;")
-        tips.setWordWrap(True)
-        main_layout.addWidget(tips)
-        main_layout.addStretch()
+        tips_box.setStyleSheet(f"color: {theme.text_secondary}; font-size: 9pt;")
+        tips_box.setWordWrap(True)
+        boxes_layout.addWidget(tips_box)
 
+        weight_sub_tabs.addTab(boxes_tab, "Boxes (Packaging Reference)")
+
+        main_layout.addWidget(weight_sub_tabs, 1)
         self.tab_widget.addTab(tab, "Weight")
 
         # Populate with existing data
@@ -2250,6 +2336,8 @@ class SettingsWindow(QDialog):
             chk_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
             self.weight_products_table.setCellWidget(row, 6, chk_widget)
         self.weight_products_table.blockSignals(False)
+        if hasattr(self, 'products_search'):
+            self._filter_products_table(self.products_search.text())
 
     def _weight_populate_boxes(self, boxes: list):
         """Fill boxes table from config list."""
@@ -2272,6 +2360,28 @@ class SettingsWindow(QDialog):
             vol_item.setFlags(vol_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
             self.weight_boxes_table.setItem(row, 4, vol_item)
         self.weight_boxes_table.blockSignals(False)
+        if hasattr(self, 'boxes_search'):
+            self._filter_boxes_table(self.boxes_search.text())
+
+    def _filter_products_table(self, text: str):
+        """Filter products table rows by SKU or name."""
+        text = text.lower().strip()
+        for row in range(self.weight_products_table.rowCount()):
+            sku_item = self.weight_products_table.item(row, 0)
+            name_item = self.weight_products_table.item(row, 1)
+            sku_text = sku_item.text().lower() if sku_item else ""
+            name_text = name_item.text().lower() if name_item else ""
+            visible = not text or text in sku_text or text in name_text
+            self.weight_products_table.setRowHidden(row, not visible)
+
+    def _filter_boxes_table(self, text: str):
+        """Filter boxes table rows by box name."""
+        text = text.lower().strip()
+        for row in range(self.weight_boxes_table.rowCount()):
+            name_item = self.weight_boxes_table.item(row, 0)
+            name_text = name_item.text().lower() if name_item else ""
+            visible = not text or text in name_text
+            self.weight_boxes_table.setRowHidden(row, not visible)
 
     def _weight_add_product_row(self):
         """Add a blank product row to the products table."""
@@ -3014,6 +3124,17 @@ class SettingsWindow(QDialog):
             self.config_data["weight_config"] = self._weight_collect_config()
 
             # ========================================
+            # Tag Categories Tab
+            # ========================================
+            if hasattr(self, 'tag_categories_panel'):
+                is_valid, errors = self.tag_categories_panel.validate_categories()
+                if not is_valid:
+                    error_msg = "Tag Categories validation errors:\n\n" + "\n".join(f"- {err}" for err in errors)
+                    QMessageBox.warning(self, "Tag Categories Invalid", error_msg)
+                    return
+                self.config_data["tag_categories"] = self.tag_categories_panel.get_categories()
+
+            # ========================================
             # Save to server via ProfileManager
             # ========================================
             success = self.profile_manager.save_shopify_config(
@@ -3060,6 +3181,64 @@ class SettingsWindow(QDialog):
                 "Error",
                 f"Failed to save settings:\n\n{str(e)}\n\n{traceback.format_exc()}"
             )
+    # ========================================
+    # TAG CATEGORIES TAB
+    # ========================================
+    def create_tag_categories_tab(self):
+        """Create the Tag Categories management tab."""
+        from gui.tag_categories_dialog import TagCategoriesPanel
+
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(0)
+
+        tag_categories = self.config_data.get("tag_categories", {"version": 2, "categories": {}})
+        self.tag_categories_panel = TagCategoriesPanel(tag_categories, parent=tab)
+        layout.addWidget(self.tag_categories_panel)
+
+        self.tab_widget.addTab(tab, "Tag Categories")
+
+    # ========================================
+    # COLUMN CONFIGURATION TAB
+    # ========================================
+    def create_column_config_tab(self):
+        """Create the Column Configuration tab (embedded ColumnConfigPanel)."""
+        from gui.column_config_dialog import ColumnConfigPanel
+
+        main_window = self.parent()
+        if main_window is None or not hasattr(main_window, 'table_config_manager'):
+            tab = QWidget()
+            layout = QVBoxLayout(tab)
+            layout.addWidget(QLabel("Column configuration is not available in this context."))
+            self.tab_widget.addTab(tab, "Column Config")
+            return
+
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(10, 10, 10, 10)
+
+        header_label = QLabel("📋 Column Configuration")
+        header_label.setStyleSheet("font-size: 14pt; font-weight: bold;")
+        layout.addWidget(header_label)
+
+        from gui.theme_manager import get_theme_manager
+        theme = get_theme_manager().get_current_theme()
+        help_text = QLabel(
+            "Configure which columns are visible in the analysis table, their order, and saved views."
+        )
+        help_text.setWordWrap(True)
+        help_text.setStyleSheet(f"color: {theme.text_secondary}; font-style: italic; margin-bottom: 6px;")
+        layout.addWidget(help_text)
+
+        self.column_config_panel = ColumnConfigPanel(
+            main_window.table_config_manager,
+            main_window=main_window,
+            parent=tab
+        )
+        layout.addWidget(self.column_config_panel)
+
+        self.tab_widget.addTab(tab, "Column Config")
 
 
 # ========================================

--- a/gui/tag_categories_dialog.py
+++ b/gui/tag_categories_dialog.py
@@ -259,7 +259,13 @@ class TagCategoriesPanel(QWidget):
             item = QListWidgetItem(category_config.get("label", category_id))
             item.setData(Qt.UserRole, category_id)
             color = category_config.get("color", "#9E9E9E")
-            item.setBackground(QColor(color).lighter(180))
+            _cat = QColor(color)
+            _bg = QColor(get_theme_manager().get_current_theme().background)
+            item.setBackground(QColor(
+                int(_cat.red() * 0.45 + _bg.red() * 0.55),
+                int(_cat.green() * 0.45 + _bg.green() * 0.55),
+                int(_cat.blue() * 0.45 + _bg.blue() * 0.55),
+            ))
             self.categories_list.addItem(item)
 
     def _on_category_selected(self, current: QListWidgetItem, previous: QListWidgetItem):
@@ -429,7 +435,13 @@ class TagCategoriesPanel(QWidget):
         current_item = self.categories_list.currentItem()
         if current_item:
             current_item.setText(category["label"])
-            current_item.setBackground(QColor(self.current_color).lighter(180))
+            _cat = QColor(self.current_color)
+            _bg = QColor(get_theme_manager().get_current_theme().background)
+            current_item.setBackground(QColor(
+                int(_cat.red() * 0.45 + _bg.red() * 0.55),
+                int(_cat.green() * 0.45 + _bg.green() * 0.55),
+                int(_cat.blue() * 0.45 + _bg.blue() * 0.55),
+            ))
 
     def _choose_color(self):
         """Open color picker dialog."""

--- a/gui/tag_categories_dialog.py
+++ b/gui/tag_categories_dialog.py
@@ -34,8 +34,6 @@ class TagCategoriesPanel(QWidget):
     def __init__(self, tag_categories: Dict, parent=None):
         super().__init__(parent)
 
-        # Store original and working copy
-        self.original_categories = tag_categories.copy()
         self.working_categories = tag_categories.copy()
 
         # Ensure v2 format

--- a/gui/tag_categories_dialog.py
+++ b/gui/tag_categories_dialog.py
@@ -709,6 +709,14 @@ class TagCategoriesDialog(QDialog):
 
         self.button_box = button_box
 
+    def __getattr__(self, name):
+        """Proxy attribute lookups to the embedded panel for backwards compatibility."""
+        # Avoid infinite recursion during __init__ before self.panel exists
+        panel = self.__dict__.get('panel')
+        if panel is not None and hasattr(panel, name):
+            return getattr(panel, name)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
     def _validate(self) -> bool:
         is_valid, errors = self.panel.validate_categories()
         if not is_valid:

--- a/gui/tag_categories_dialog.py
+++ b/gui/tag_categories_dialog.py
@@ -11,7 +11,7 @@ from PySide6.QtWidgets import (
     QListWidget, QListWidgetItem, QWidget, QFormLayout, QSpinBox,
     QDialogButtonBox, QMessageBox, QColorDialog, QSplitter, QGroupBox,
     QCheckBox, QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView,
-    QDoubleSpinBox, QComboBox
+    QDoubleSpinBox, QComboBox, QInputDialog
 )
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QColor
@@ -22,24 +22,17 @@ from gui.theme_manager import get_theme_manager
 logger = logging.getLogger(__name__)
 
 
-class TagCategoriesDialog(QDialog):
-    """Dialog for managing tag categories (v2 format)."""
+class TagCategoriesPanel(QWidget):
+    """Embeddable panel for managing tag categories (v2 format).
 
-    # Signal emitted when categories are saved
+    Can be used standalone inside a QDialog or embedded directly into
+    a QTabWidget (e.g., SettingsWindow).
+    """
+
     categories_updated = Signal(dict)
 
     def __init__(self, tag_categories: Dict, parent=None):
-        """
-        Initialize Tag Categories Dialog.
-
-        Args:
-            tag_categories: Tag categories dict (v2 format expected)
-            parent: Parent widget
-        """
         super().__init__(parent)
-        self.setWindowTitle("Tag Categories Management")
-        self.setModal(True)
-        self.setMinimumSize(900, 600)
 
         # Store original and working copy
         self.original_categories = tag_categories.copy()
@@ -55,51 +48,31 @@ class TagCategoriesDialog(QDialog):
         self.current_category_id: Optional[str] = None
         self.modified = False
 
-        # Store theme for use across methods
         self.theme = get_theme_manager().get_current_theme()
 
         self._init_ui()
         self._load_categories()
 
-        # Listen for theme changes
-        theme_manager = get_theme_manager()
-        theme_manager.theme_changed.connect(self._on_theme_changed)
+        get_theme_manager().theme_changed.connect(self._on_theme_changed)
 
     def _init_ui(self):
-        """Initialize the user interface."""
+        """Initialize the panel UI (splitter layout, no dialog buttons)."""
         layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
 
-        # Title
-        title_label = QLabel("Manage Tag Categories")
-        title_label.setStyleSheet("font-size: 14pt; font-weight: bold; padding: 10px;")
-        layout.addWidget(title_label)
-
-        # Create splitter for two-panel layout
         splitter = QSplitter(Qt.Horizontal)
 
-        # Left panel: Categories list
         left_panel = self._create_categories_list_panel()
         splitter.addWidget(left_panel)
 
-        # Right panel: Category editor
         right_panel = self._create_category_editor_panel()
         splitter.addWidget(right_panel)
 
-        # Set initial splitter sizes (30% left, 70% right)
-        splitter.setSizes([270, 630])
+        splitter.setSizes([320, 780])
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 3)
 
-        layout.addWidget(splitter)
-
-        # Button box
-        button_box = QDialogButtonBox(
-            QDialogButtonBox.Save | QDialogButtonBox.Cancel | QDialogButtonBox.Apply
-        )
-        button_box.accepted.connect(self._on_save)
-        button_box.rejected.connect(self._on_cancel)
-        button_box.button(QDialogButtonBox.Apply).clicked.connect(self._on_apply)
-        layout.addWidget(button_box)
-
-        self.button_box = button_box
+        layout.addWidget(splitter, 1)
 
     def _create_categories_list_panel(self) -> QWidget:
         """Create left panel with categories list."""
@@ -107,17 +80,14 @@ class TagCategoriesDialog(QDialog):
         layout = QVBoxLayout(panel)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Header
         header_label = QLabel("Categories")
         header_label.setStyleSheet("font-weight: bold; font-size: 11pt; padding: 5px;")
         layout.addWidget(header_label)
 
-        # List widget
         self.categories_list = QListWidget()
         self.categories_list.currentItemChanged.connect(self._on_category_selected)
         layout.addWidget(self.categories_list)
 
-        # Buttons
         buttons_layout = QHBoxLayout()
 
         self.new_category_btn = QPushButton("+ New")
@@ -141,15 +111,12 @@ class TagCategoriesDialog(QDialog):
         layout = QVBoxLayout(panel)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Header
         self.editor_header_label = QLabel("Category Editor")
         self.editor_header_label.setStyleSheet("font-weight: bold; font-size: 11pt; padding: 5px;")
         layout.addWidget(self.editor_header_label)
 
-        # Form layout for category fields
         form_layout = QFormLayout()
 
-        # Category ID (read-only for existing, editable for new)
         self.category_id_input = QLineEdit()
         self.category_id_input.setPlaceholderText("e.g., my_category")
         self.category_id_input.setToolTip(
@@ -159,14 +126,12 @@ class TagCategoriesDialog(QDialog):
         self.category_id_input.textChanged.connect(self._on_editor_changed)
         form_layout.addRow("Category ID:", self.category_id_input)
 
-        # Display Label
         self.label_input = QLineEdit()
         self.label_input.setPlaceholderText("e.g., My Category")
         self.label_input.setToolTip("Display name for this category")
         self.label_input.textChanged.connect(self._on_editor_changed)
         form_layout.addRow("Display Label:", self.label_input)
 
-        # Color picker
         color_layout = QHBoxLayout()
         self.color_display = QLabel()
         self.color_display.setFixedSize(40, 30)
@@ -181,7 +146,6 @@ class TagCategoriesDialog(QDialog):
         self.current_color = "#9E9E9E"
         form_layout.addRow("Color:", color_layout)
 
-        # Display Order
         self.order_spin = QSpinBox()
         self.order_spin.setMinimum(1)
         self.order_spin.setMaximum(999)
@@ -196,12 +160,10 @@ class TagCategoriesDialog(QDialog):
         tags_group = QGroupBox("Tags")
         tags_layout = QVBoxLayout(tags_group)
 
-        # Tags list
         self.tags_list = QListWidget()
         self.tags_list.setMaximumHeight(150)
         tags_layout.addWidget(self.tags_list)
 
-        # Add/Remove tag buttons
         tag_buttons_layout = QHBoxLayout()
 
         self.add_tag_btn = QPushButton("+ Add Tag")
@@ -227,7 +189,6 @@ class TagCategoriesDialog(QDialog):
         writeoff_group = QGroupBox("SKU Writeoff")
         writeoff_layout = QVBoxLayout(writeoff_group)
 
-        # Enable checkbox
         self.writeoff_enabled_checkbox = QCheckBox("Enable writeoff for this category")
         self.writeoff_enabled_checkbox.setToolTip(
             "When enabled, tags in this category can trigger automatic SKU writeoffs\n"
@@ -236,7 +197,6 @@ class TagCategoriesDialog(QDialog):
         self.writeoff_enabled_checkbox.stateChanged.connect(self._on_writeoff_enabled_changed)
         writeoff_layout.addWidget(self.writeoff_enabled_checkbox)
 
-        # Mappings table
         mappings_label = QLabel("Writeoff Mappings:")
         mappings_label.setStyleSheet("font-weight: bold; margin-top: 10px;")
         writeoff_layout.addWidget(mappings_label)
@@ -249,13 +209,12 @@ class TagCategoriesDialog(QDialog):
         self.writeoff_mappings_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeToContents)
         self.writeoff_mappings_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.writeoff_mappings_table.setMaximumHeight(200)
-        self.writeoff_mappings_table.setEnabled(False)  # Disabled until checkbox is checked
+        self.writeoff_mappings_table.setEnabled(False)
         self.writeoff_mappings_table.itemSelectionChanged.connect(
             self._update_remove_mapping_btn_state
         )
         writeoff_layout.addWidget(self.writeoff_mappings_table)
 
-        # Buttons
         mappings_buttons = QHBoxLayout()
         self.add_mapping_btn = QPushButton("+ Add Mapping")
         self.add_mapping_btn.clicked.connect(self._on_add_mapping)
@@ -273,10 +232,19 @@ class TagCategoriesDialog(QDialog):
 
         layout.addStretch()
 
-        # Initially disable editor
         self._set_editor_enabled(False)
 
         return panel
+
+    # ------------------------------------------------------------------
+    # Data management
+    # ------------------------------------------------------------------
+
+    def get_categories(self) -> Dict:
+        """Return the current working categories dict (including pending edits)."""
+        if self.current_category_id:
+            self._save_editor_to_working_copy()
+        return self.working_categories
 
     def _load_categories(self):
         """Load categories into the list widget."""
@@ -284,7 +252,6 @@ class TagCategoriesDialog(QDialog):
 
         categories = self.working_categories.get("categories", {})
 
-        # Sort by order
         sorted_categories = sorted(
             categories.items(),
             key=lambda x: x[1].get("order", 999)
@@ -293,11 +260,8 @@ class TagCategoriesDialog(QDialog):
         for category_id, category_config in sorted_categories:
             item = QListWidgetItem(category_config.get("label", category_id))
             item.setData(Qt.UserRole, category_id)
-
-            # Show color indicator
             color = category_config.get("color", "#9E9E9E")
             item.setBackground(QColor(color).lighter(180))
-
             self.categories_list.addItem(item)
 
     def _on_category_selected(self, current: QListWidgetItem, previous: QListWidgetItem):
@@ -310,7 +274,6 @@ class TagCategoriesDialog(QDialog):
         category_id = current.data(Qt.UserRole)
         self.current_category_id = category_id
 
-        # Load category into editor
         self._load_category_into_editor(category_id)
         self._set_editor_enabled(True)
         self.delete_category_btn.setEnabled(True)
@@ -320,43 +283,36 @@ class TagCategoriesDialog(QDialog):
         categories = self.working_categories.get("categories", {})
         category = categories.get(category_id, {})
 
-        # Block signals while loading
         self.category_id_input.blockSignals(True)
         self.label_input.blockSignals(True)
         self.order_spin.blockSignals(True)
 
-        # Load fields
         self.category_id_input.setText(category_id)
-        self.category_id_input.setReadOnly(True)  # Cannot change ID for existing
+        self.category_id_input.setReadOnly(True)
 
         self.label_input.setText(category.get("label", ""))
         self.current_color = category.get("color", "#9E9E9E")
         self.color_display.setStyleSheet(f"border: 1px solid {self.theme.border}; background-color: {self.current_color};")
         self.order_spin.setValue(category.get("order", 1))
 
-        # Load tags
         self.tags_list.clear()
         for tag in category.get("tags", []):
             self.tags_list.addItem(tag)
 
-        # Unblock signals
         self.category_id_input.blockSignals(False)
         self.label_input.blockSignals(False)
         self.order_spin.blockSignals(False)
 
-        # Load writeoff configuration
         sku_writeoff = category.get("sku_writeoff", {"enabled": False, "mappings": {}})
 
         self.writeoff_enabled_checkbox.blockSignals(True)
 
-        # Load enabled state
         enabled = sku_writeoff.get("enabled", False)
         self.writeoff_enabled_checkbox.setChecked(enabled)
         self.writeoff_mappings_table.setEnabled(enabled)
         self.add_mapping_btn.setEnabled(enabled)
         self.remove_mapping_btn.setEnabled(False)
 
-        # Load mappings
         self.writeoff_mappings_table.setRowCount(0)
         mappings = sku_writeoff.get("mappings", {})
 
@@ -378,13 +334,11 @@ class TagCategoriesDialog(QDialog):
 
         self.writeoff_enabled_checkbox.blockSignals(False)
 
-        # Update header
         self.editor_header_label.setText(f"Editing: {category.get('label', category_id)}")
 
     def _on_theme_changed(self):
         """Handle theme changes."""
         self.theme = get_theme_manager().get_current_theme()
-        # Update color display if editor is active
         if self.current_category_id:
             self.color_display.setStyleSheet(
                 f"border: 1px solid {self.theme.border}; background-color: {self.current_color};"
@@ -399,7 +353,6 @@ class TagCategoriesDialog(QDialog):
         self.tags_list.setEnabled(enabled)
         self.add_tag_btn.setEnabled(enabled)
 
-        # Enable writeoff controls based on overall enabled state AND checkbox state
         self.writeoff_enabled_checkbox.setEnabled(enabled)
         if enabled and self.writeoff_enabled_checkbox.isChecked():
             self.writeoff_mappings_table.setEnabled(True)
@@ -421,8 +374,6 @@ class TagCategoriesDialog(QDialog):
         """Handle editor field changes."""
         if not self.current_category_id:
             return
-
-        # Save changes to working copy
         self._save_editor_to_working_copy()
         self.modified = True
 
@@ -432,25 +383,19 @@ class TagCategoriesDialog(QDialog):
             return
 
         categories = self.working_categories.setdefault("categories", {})
-
-        # Get or create category
         category = categories.setdefault(self.current_category_id, {})
 
-        # Update fields
         category["label"] = self.label_input.text()
         category["color"] = self.current_color
         category["order"] = self.order_spin.value()
 
-        # Update tags
         tags = []
         for i in range(self.tags_list.count()):
             tags.append(self.tags_list.item(i).text())
         category["tags"] = tags
 
-        # Save writeoff configuration
         enabled = self.writeoff_enabled_checkbox.isChecked()
 
-        # Extract mappings from table
         mappings = {}
         for row in range(self.writeoff_mappings_table.rowCount()):
             tag_item = self.writeoff_mappings_table.item(row, 0)
@@ -483,7 +428,6 @@ class TagCategoriesDialog(QDialog):
             "mappings": mappings
         }
 
-        # Update list item
         current_item = self.categories_list.currentItem()
         if current_item:
             current_item.setText(category["label"])
@@ -506,8 +450,6 @@ class TagCategoriesDialog(QDialog):
 
     def _on_add_tag(self):
         """Handle add tag button click."""
-        from PySide6.QtWidgets import QInputDialog
-
         tag, ok = QInputDialog.getText(
             self,
             "Add Tag",
@@ -523,13 +465,11 @@ class TagCategoriesDialog(QDialog):
                 QMessageBox.warning(self, "Invalid Tag", "Tag cannot be empty.")
                 return
 
-            # Check for duplicates in current category
             existing_tags = [self.tags_list.item(i).text() for i in range(self.tags_list.count())]
             if tag in existing_tags:
                 QMessageBox.warning(self, "Duplicate Tag", f"Tag '{tag}' already exists in this category.")
                 return
 
-            # Check for duplicates in other categories
             if self._is_tag_in_other_categories(tag):
                 QMessageBox.warning(
                     self,
@@ -539,7 +479,6 @@ class TagCategoriesDialog(QDialog):
                 )
                 return
 
-            # Add tag
             self.tags_list.addItem(tag)
             self._on_editor_changed()
 
@@ -561,14 +500,13 @@ class TagCategoriesDialog(QDialog):
         for category_id, category_config in categories.items():
             if category_id == self.current_category_id:
                 continue
-
             if tag in category_config.get("tags", []):
                 return True
 
         return False
 
     def _update_remove_mapping_btn_state(self):
-        """Update remove mapping button enabled state based on selection and checkbox."""
+        """Update remove mapping button enabled state."""
         enabled = self.writeoff_enabled_checkbox.isChecked()
         has_selection = len(self.writeoff_mappings_table.selectedItems()) > 0
         self.remove_mapping_btn.setEnabled(enabled and has_selection)
@@ -581,7 +519,6 @@ class TagCategoriesDialog(QDialog):
         self.add_mapping_btn.setEnabled(enabled)
         self._update_remove_mapping_btn_state()
 
-        # Mark as modified
         self._on_editor_changed()
 
     def _on_add_mapping(self):
@@ -589,7 +526,6 @@ class TagCategoriesDialog(QDialog):
         if not self.current_category_id:
             return
 
-        # Get current category tags
         categories = self.working_categories.get("categories", {})
         category = categories.get(self.current_category_id, {})
         available_tags = category.get("tags", [])
@@ -602,22 +538,18 @@ class TagCategoriesDialog(QDialog):
             )
             return
 
-        # Custom dialog for mapping input
         dialog = QDialog(self)
         dialog.setWindowTitle("Add Writeoff Mapping")
         dialog_layout = QFormLayout(dialog)
 
-        # Tag selector
         tag_combo = QComboBox()
         tag_combo.addItems(available_tags)
         dialog_layout.addRow("Tag:", tag_combo)
 
-        # SKU input
         sku_input = QLineEdit()
         sku_input.setPlaceholderText("e.g., PKG-BOX-SMALL")
         dialog_layout.addRow("SKU:", sku_input)
 
-        # Quantity spinner
         quantity_spin = QDoubleSpinBox()
         quantity_spin.setMinimum(0.01)
         quantity_spin.setMaximum(999.99)
@@ -625,7 +557,6 @@ class TagCategoriesDialog(QDialog):
         quantity_spin.setValue(1.0)
         dialog_layout.addRow("Quantity:", quantity_spin)
 
-        # Buttons
         button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         button_box.accepted.connect(dialog.accept)
         button_box.rejected.connect(dialog.reject)
@@ -640,7 +571,6 @@ class TagCategoriesDialog(QDialog):
                 QMessageBox.warning(self, "Invalid Input", "SKU cannot be empty.")
                 return
 
-            # Add row to table
             row_position = self.writeoff_mappings_table.rowCount()
             self.writeoff_mappings_table.insertRow(row_position)
 
@@ -657,7 +587,6 @@ class TagCategoriesDialog(QDialog):
         if not selected_rows:
             return
 
-        # Remove in reverse order to avoid index shifting
         for row in sorted(selected_rows, reverse=True):
             self.writeoff_mappings_table.removeRow(row)
 
@@ -665,8 +594,6 @@ class TagCategoriesDialog(QDialog):
 
     def _on_new_category(self):
         """Handle new category button click."""
-        from PySide6.QtWidgets import QInputDialog
-
         category_id, ok = QInputDialog.getText(
             self,
             "New Category",
@@ -680,7 +607,6 @@ class TagCategoriesDialog(QDialog):
 
         category_id = category_id.strip().lower()
 
-        # Validate ID
         if not category_id:
             QMessageBox.warning(self, "Invalid ID", "Category ID cannot be empty.")
             return
@@ -693,13 +619,11 @@ class TagCategoriesDialog(QDialog):
             )
             return
 
-        # Check for duplicates
         categories = self.working_categories.get("categories", {})
         if category_id in categories:
             QMessageBox.warning(self, "Duplicate ID", f"Category '{category_id}' already exists.")
             return
 
-        # Create new category
         new_category = {
             "label": category_id.replace("_", " ").title(),
             "color": "#9E9E9E",
@@ -714,10 +638,8 @@ class TagCategoriesDialog(QDialog):
         categories[category_id] = new_category
         self.modified = True
 
-        # Reload list and select new category
         self._load_categories()
 
-        # Find and select new item
         for i in range(self.categories_list.count()):
             item = self.categories_list.item(i)
             if item.data(Qt.UserRole) == category_id:
@@ -732,7 +654,6 @@ class TagCategoriesDialog(QDialog):
         categories = self.working_categories.get("categories", {})
         category = categories.get(self.current_category_id, {})
 
-        # Confirm deletion
         reply = QMessageBox.question(
             self,
             "Delete Category",
@@ -746,53 +667,71 @@ class TagCategoriesDialog(QDialog):
             del categories[self.current_category_id]
             self.modified = True
 
-            # Clear selection and reload
             self.current_category_id = None
             self._load_categories()
             self._set_editor_enabled(False)
             self.delete_category_btn.setEnabled(False)
 
-    def _validate_categories(self) -> bool:
-        """Validate current categories configuration."""
-        # Save current editor state first
+    def validate_categories(self) -> tuple:
+        """Validate current categories. Returns (is_valid, errors)."""
         if self.current_category_id:
             self._save_editor_to_working_copy()
+        return validate_tag_categories_v2(self.working_categories)
 
-        # Validate using tag_manager validator
-        is_valid, errors = validate_tag_categories_v2(self.working_categories)
 
+class TagCategoriesDialog(QDialog):
+    """Dialog wrapper around TagCategoriesPanel for standalone use."""
+
+    categories_updated = Signal(dict)
+
+    def __init__(self, tag_categories: Dict, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Tag Categories Management")
+        self.setModal(True)
+        self.setMinimumSize(900, 600)
+
+        layout = QVBoxLayout(self)
+
+        title_label = QLabel("Manage Tag Categories")
+        title_label.setStyleSheet("font-size: 14pt; font-weight: bold; padding: 10px;")
+        layout.addWidget(title_label)
+
+        self.panel = TagCategoriesPanel(tag_categories, parent=self)
+        layout.addWidget(self.panel)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.Save | QDialogButtonBox.Cancel | QDialogButtonBox.Apply
+        )
+        button_box.accepted.connect(self._on_save)
+        button_box.rejected.connect(self._on_cancel)
+        button_box.button(QDialogButtonBox.Apply).clicked.connect(self._on_apply)
+        layout.addWidget(button_box)
+
+        self.button_box = button_box
+
+    def _validate(self) -> bool:
+        is_valid, errors = self.panel.validate_categories()
         if not is_valid:
             error_msg = "Validation errors:\n\n" + "\n".join(f"- {err}" for err in errors)
             QMessageBox.critical(self, "Validation Failed", error_msg)
             return False
-
         return True
 
     def _on_apply(self):
-        """Handle Apply button click (save without closing)."""
-        if not self._validate_categories():
+        if not self._validate():
             return
-
-        self.categories_updated.emit(self.working_categories)
-        self.modified = False
-
-        QMessageBox.information(
-            self,
-            "Saved",
-            "Tag categories have been saved successfully."
-        )
+        self.categories_updated.emit(self.panel.get_categories())
+        self.panel.modified = False
+        QMessageBox.information(self, "Saved", "Tag categories have been saved successfully.")
 
     def _on_save(self):
-        """Handle Save button click (save and close)."""
-        if not self._validate_categories():
+        if not self._validate():
             return
-
-        self.categories_updated.emit(self.working_categories)
+        self.categories_updated.emit(self.panel.get_categories())
         self.accept()
 
     def _on_cancel(self):
-        """Handle Cancel button click."""
-        if self.modified:
+        if self.panel.modified:
             reply = QMessageBox.question(
                 self,
                 "Unsaved Changes",
@@ -800,12 +739,10 @@ class TagCategoriesDialog(QDialog):
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No
             )
-
             if reply == QMessageBox.No:
                 return
-
         self.reject()
 
     def get_categories(self) -> Dict:
         """Get the current categories configuration."""
-        return self.working_categories
+        return self.panel.get_categories()

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -1002,7 +1002,7 @@ class UIManager:
             if category_id in categories:
                 category_label = categories[category_id].get("label", category_id)
             else:
-                category_label = "Інші"  # Custom/unknown tags
+                category_label = "Others"  # Custom/unknown tags
 
             if category_label not in grouped:
                 grouped[category_label] = []
@@ -1626,7 +1626,7 @@ class UIManager:
         courier_hscroll.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         courier_hscroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         courier_hscroll.setSizeAdjustPolicy(QScrollArea.AdjustToContents)
-        courier_hscroll.setMinimumHeight(130)
+        courier_hscroll.setMinimumHeight(90)
 
         courier_container = QWidget()
         self.mw.courier_cards_layout = QHBoxLayout(courier_container)

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -885,8 +885,7 @@ class UIManager:
             from gui.tag_delegate import TagDelegate
 
             tag_categories = self.mw.active_profile_config.get("tag_categories", {})
-            if not hasattr(self.mw, 'tag_delegate') or self.mw.tag_delegate is None:
-                self.mw.tag_delegate = TagDelegate(tag_categories, self.mw)
+            self.mw.tag_delegate = TagDelegate(tag_categories, self.mw)
 
             # Adjust column index for checkbox column if enabled
             col_index = main_df.columns.get_loc("Internal_Tags")
@@ -1557,16 +1556,16 @@ class UIManager:
         card = QFrame()
         card.setFrameShape(QFrame.StyledPanel)
         card.setFrameShadow(QFrame.Raised)
-        card.setMinimumWidth(80)
+        card.setMinimumWidth(60)
         card_layout = QVBoxLayout(card)
         card_layout.setSpacing(2)
-        card_layout.setContentsMargins(12, 8, 12, 8)
+        card_layout.setContentsMargins(6, 4, 6, 4)
 
         count_lbl = QLabel(count)
         count_lbl.setAlignment(Qt.AlignCenter)
         count_lbl.setStyleSheet(
-            f"font-size: 20px; font-weight: bold; color: white; "
-            f"background-color: {color}; border-radius: 10px; padding: 4px 8px;"
+            f"font-size: 14px; font-weight: bold; color: white; "
+            f"background-color: {color}; border-radius: 8px; padding: 2px 6px;"
         )
 
         tag_lbl = QLabel(tag)
@@ -1638,7 +1637,12 @@ class UIManager:
         courier_group_layout.addWidget(courier_hscroll)
         layout.addWidget(courier_group)
 
-        # ── 3. Tags Breakdown (Fulfillable) ────────────────────────────────
+        # ── 3 & 4. Tags Breakdown (Fulfillable + Not Fulfillable, side by side) ──
+        tags_row_widget = QWidget()
+        tags_row_layout = QHBoxLayout(tags_row_widget)
+        tags_row_layout.setSpacing(8)
+        tags_row_layout.setContentsMargins(0, 0, 0, 0)
+
         tags_f_group = QGroupBox("🏷️ Fulfillable Tags")
         tags_f_group_layout = QVBoxLayout(tags_f_group)
         tags_f_group_layout.setContentsMargins(8, 8, 8, 8)
@@ -1650,7 +1654,7 @@ class UIManager:
         tags_f_hscroll.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         tags_f_hscroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         tags_f_hscroll.setSizeAdjustPolicy(QScrollArea.AdjustToContents)
-        tags_f_hscroll.setMinimumHeight(130)
+        tags_f_hscroll.setMinimumHeight(90)
 
         tags_f_container = QWidget()
         self.mw.tags_fulfillable_layout = QHBoxLayout(tags_f_container)
@@ -1659,9 +1663,8 @@ class UIManager:
         self.mw.tags_fulfillable_layout.addStretch()
         tags_f_hscroll.setWidget(tags_f_container)
         tags_f_group_layout.addWidget(tags_f_hscroll)
-        layout.addWidget(tags_f_group)
+        tags_row_layout.addWidget(tags_f_group)
 
-        # ── 4. Tags Breakdown (Not Fulfillable) ────────────────────────────
         tags_nf_group = QGroupBox("🏷️ Not Fulfillable Tags")
         tags_nf_group_layout = QVBoxLayout(tags_nf_group)
         tags_nf_group_layout.setContentsMargins(8, 8, 8, 8)
@@ -1673,7 +1676,7 @@ class UIManager:
         tags_nf_hscroll.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         tags_nf_hscroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         tags_nf_hscroll.setSizeAdjustPolicy(QScrollArea.AdjustToContents)
-        tags_nf_hscroll.setMinimumHeight(130)
+        tags_nf_hscroll.setMinimumHeight(90)
 
         tags_nf_container = QWidget()
         self.mw.tags_not_fulfillable_layout = QHBoxLayout(tags_nf_container)
@@ -1682,7 +1685,9 @@ class UIManager:
         self.mw.tags_not_fulfillable_layout.addStretch()
         tags_nf_hscroll.setWidget(tags_nf_container)
         tags_nf_group_layout.addWidget(tags_nf_hscroll)
-        layout.addWidget(tags_nf_group)
+        tags_row_layout.addWidget(tags_nf_group)
+
+        layout.addWidget(tags_row_widget)
 
         # ── 5. SKU Summary ─────────────────────────────────────────────────
         sku_group = QGroupBox("📦 SKU Summary")

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -612,16 +612,11 @@ class UIManager:
         self.mw.packing_list_button.setToolTip("Generate packing lists based on pre-defined filters.")
         self.mw.stock_export_button = QPushButton("📊 Create Stock Export")
         self.mw.stock_export_button.setToolTip("Generate stock export files for couriers.")
-        self.mw.writeoff_report_button = QPushButton("📦 Create Writeoff Report")
-        self.mw.writeoff_report_button.setToolTip("Generate SKU writeoff report based on Internal Tags.")
-
         self.mw.packing_list_button.setEnabled(False)
         self.mw.stock_export_button.setEnabled(False)
-        self.mw.writeoff_report_button.setEnabled(False)
 
         layout.addWidget(self.mw.packing_list_button)
         layout.addWidget(self.mw.stock_export_button)
-        layout.addWidget(self.mw.writeoff_report_button)
 
         # Add "Open Session Folder" button
         self.mw.open_session_folder_button = QPushButton("📁 Open Session Folder")
@@ -708,17 +703,7 @@ class UIManager:
         self.mw.settings_button.setEnabled(False)
         settings_layout.addWidget(self.mw.settings_button)
 
-        # Tag Categories
-        self.mw.tag_categories_button = QPushButton("🏷️ Tag Categories")
-        self.mw.tag_categories_button.setToolTip("Manage Internal Tags categories")
-        self.mw.tag_categories_button.setEnabled(False)
-        settings_layout.addWidget(self.mw.tag_categories_button)
-
-        # Configure Columns
-        self.mw.configure_columns_button = QPushButton("📊 Configure Columns")
-        self.mw.configure_columns_button.setToolTip("Customize table columns")
-        self.mw.configure_columns_button.setEnabled(False)
-        settings_layout.addWidget(self.mw.configure_columns_button)
+        # (Tag Categories and Configure Columns moved to Settings window tabs)
 
         main_layout.addLayout(settings_layout)
 

--- a/tests/test_column_config_dialog.py
+++ b/tests/test_column_config_dialog.py
@@ -110,27 +110,7 @@ def table_config_manager(mock_main_window, mock_profile_manager):
 @pytest.fixture
 def dialog(qapp, table_config_manager, mock_main_window):
     """Create a ColumnConfigDialog for testing."""
-    # Temporarily set parent_window before init to avoid loading issues
-    # We'll create the dialog with the manager that already has the config loaded
-    dialog = ColumnConfigDialog.__new__(ColumnConfigDialog)
-    dialog.table_config_manager = table_config_manager
-    dialog.parent_window = mock_main_window
-    dialog._current_columns = []
-    dialog._is_loading = False
-
-    # Initialize QDialog part
-    from PySide6.QtWidgets import QDialog
-    QDialog.__init__(dialog, None)
-
-    dialog.setWindowTitle("Manage Table Columns")
-    dialog.setMinimumSize(600, 700)
-    dialog.setModal(True)
-
-    # Initialize UI
-    dialog._init_ui()
-    dialog._connect_signals()
-    dialog._load_current_config()
-
+    dialog = ColumnConfigDialog(table_config_manager, parent=None, main_window=mock_main_window)
     yield dialog
     dialog.close()
 

--- a/tests/test_tag_categories_dialog.py
+++ b/tests/test_tag_categories_dialog.py
@@ -45,11 +45,11 @@ def tag_categories_v2():
 
 
 @pytest.fixture
-def dialog(qtbot, tag_categories_v2):
+def dialog(qapp, tag_categories_v2):
     """Create dialog instance."""
     dlg = TagCategoriesDialog(tag_categories_v2)
-    qtbot.addWidget(dlg)
-    return dlg
+    yield dlg
+    dlg.close()
 
 
 # ============================================================================
@@ -149,7 +149,7 @@ def test_edit_category_order(dialog):
     assert categories["packaging"]["order"] == 5
 
 
-def test_edit_category_color(dialog, qtbot):
+def test_edit_category_color(dialog):
     """Test editing category color."""
     dialog.categories_list.setCurrentRow(0)
 
@@ -229,7 +229,7 @@ def test_add_tag_duplicate_across_categories_warning(dialog, monkeypatch):
     assert "another category" in str(mock_warning.call_args).lower()
 
 
-def test_remove_tag_from_category(dialog, qtbot):
+def test_remove_tag_from_category(dialog):
     """Test removing tag from category."""
     dialog.categories_list.setCurrentRow(0)
 
@@ -374,7 +374,7 @@ def test_validation_fails_with_invalid_config(dialog, monkeypatch):
     # Break the config
     dialog.working_categories["categories"]["packaging"]["color"] = "invalid"  # Invalid color
 
-    result = dialog._validate_categories()
+    result = dialog._validate()
 
     assert result is False
     # Should show error message
@@ -383,7 +383,7 @@ def test_validation_fails_with_invalid_config(dialog, monkeypatch):
 
 def test_validation_passes_with_valid_config(dialog):
     """Test validation passes with valid config."""
-    result = dialog._validate_categories()
+    result = dialog._validate()
 
     assert result is True
 
@@ -393,7 +393,7 @@ def test_validation_passes_with_valid_config(dialog):
 # ============================================================================
 
 
-def test_save_emits_signal(dialog, qtbot, monkeypatch):
+def test_save_emits_signal(dialog, monkeypatch):
     """Test save button emits categories_updated signal."""
     signal_spy = Mock()
     dialog.categories_updated.connect(signal_spy)


### PR DESCRIPTION
… new report dialogs

- Add SKU/component search to Sets table and Products/Boxes search to Weight tab
- Split Weight tab into Products and Boxes sub-tabs (QTabWidget) for full table height
- Embed TagCategoriesPanel into SettingsWindow tab; remove toolbar button
- Embed ColumnConfigPanel into SettingsWindow tab; remove toolbar button
- Redesign Packing List and Stock Export dialogs with two-column preview layout
- Move Writeoff Report controls into StockExportDialog; remove standalone toolbar button
- Expand SettingsWindow minimum size to 1150×850

## Summary by Sourcery

Refine the Settings window and reporting workflows with embedded configuration panels, searchable tables, and redesigned preview-enabled report dialogs, while cleaning up redundant toolbar buttons.

New Features:
- Introduce preview-enabled Packing List and Stock Export dialogs with report filtering summaries and row/order counts.
- Add integrated Writeoff Report controls directly into the Stock Export dialog, including an option to generate writeoff-only reports.
- Embed Tag Categories and Column Configuration management as dedicated tabs within the Settings window.
- Add search filters to the Sets table and Weight tab products/boxes tables for quicker lookup.

Enhancements:
- Refactor volumetric Weight settings into separate Products and Boxes sub-tabs to improve layout and table visibility.
- Expose rules count summary in the Rules tab header and keep it updated as rules are added or removed.
- Extract TagCategories and ColumnConfig logic into reusable embeddable panels that can be used in both dialogs and tabs.
- Increase the minimum size of the Settings window to better accommodate the expanded UI.