### PR TITLE
feat: add SKU Label Printing module (#231)

### DIFF
--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -165,6 +165,12 @@ class SettingsWindow(QDialog):
         if "stock_export_configs" not in self.config_data:
             self.config_data["stock_export_configs"] = []
 
+        if "sku_label_config" not in self.config_data:
+            self.config_data["sku_label_config"] = {
+                "sku_to_label": {},
+                "default_printer": ""
+            }
+
         # Widget lists
         self.rule_widgets = []
         self.packing_list_widgets = []
@@ -189,6 +195,7 @@ class SettingsWindow(QDialog):
         self.create_weight_tab()  # Volumetric Weight tab
         self.create_tag_categories_tab()  # Tag Categories tab
         self.create_column_config_tab()  # Column Configuration tab
+        self.create_sku_labels_tab()     # SKU Label Printing tab
 
         button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
         button_box.accepted.connect(self.save_settings)
@@ -3135,6 +3142,40 @@ class SettingsWindow(QDialog):
                 self.config_data["tag_categories"] = self.tag_categories_panel.get_categories()
 
             # ========================================
+            # SKU Labels Tab
+            # ========================================
+            if hasattr(self, "sku_table"):
+                sku_to_label = {}
+                for row in range(self.sku_table.rowCount()):
+                    sku_item = self.sku_table.item(row, 0)
+                    bc_item = self.sku_table.item(row, 1)
+                    path_widget = self.sku_table.cellWidget(row, 2)
+
+                    sku = sku_item.text().strip() if sku_item else ""
+                    if not sku:
+                        continue
+
+                    barcodes_raw = bc_item.text().strip() if bc_item else ""
+                    barcodes = [b.strip() for b in barcodes_raw.split(",") if b.strip()]
+
+                    path_edit = path_widget.findChild(QLineEdit) if path_widget else None
+                    pdf_path = path_edit.text().strip() if path_edit else ""
+
+                    # Preserve existing extra fields (backwards compat)
+                    existing = self.config_data["sku_label_config"]["sku_to_label"].get(sku, {})
+                    sku_to_label[sku] = {
+                        **{k: v for k, v in existing.items() if k not in ("barcodes", "pdf_path")},
+                        "barcodes": barcodes,
+                        "pdf_path": pdf_path,
+                    }
+
+                self.config_data["sku_label_config"] = {
+                    "sku_to_label": sku_to_label,
+                    "default_printer": self.sku_default_printer_combo.currentText()
+                    if hasattr(self, "sku_default_printer_combo") else "",
+                }
+
+            # ========================================
             # Save to server via ProfileManager
             # ========================================
             success = self.profile_manager.save_shopify_config(
@@ -3239,6 +3280,135 @@ class SettingsWindow(QDialog):
         layout.addWidget(self.column_config_panel)
 
         self.tab_widget.addTab(tab, "Column Config")
+
+    # ========================================
+    # SKU LABELS TAB
+    # ========================================
+    def create_sku_labels_tab(self):
+        """Create the SKU Label Printing settings tab."""
+        from PySide6.QtPrintSupport import QPrinterInfo
+        from gui.theme_manager import get_theme_manager
+
+        theme = get_theme_manager().get_current_theme()
+
+        tab = QWidget()
+        main_layout = QVBoxLayout(tab)
+        main_layout.setContentsMargins(10, 10, 10, 10)
+        main_layout.setSpacing(8)
+
+        header_label = QLabel("🖨️ SKU Label Printing")
+        header_label.setStyleSheet("font-size: 14pt; font-weight: bold;")
+        main_layout.addWidget(header_label)
+
+        help_text = QLabel(
+            "Map barcodes → SKU → PDF label file. "
+            "Each SKU can have multiple barcodes (comma-separated). "
+            "PDF files may be on the file server (UNC paths supported)."
+        )
+        help_text.setWordWrap(True)
+        help_text.setStyleSheet(
+            f"color: {theme.text_secondary}; font-style: italic; margin-bottom: 4px;"
+        )
+        main_layout.addWidget(help_text)
+
+        # Default printer row
+        printer_row = QHBoxLayout()
+        printer_row.addWidget(QLabel("Default Printer:"))
+        self.sku_default_printer_combo = QComboBox()
+        self.sku_default_printer_combo.addItem("")
+        for pi in QPrinterInfo.availablePrinters():
+            self.sku_default_printer_combo.addItem(pi.printerName())
+        saved_printer = self.config_data["sku_label_config"].get("default_printer", "")
+        if saved_printer:
+            idx = self.sku_default_printer_combo.findText(saved_printer)
+            if idx >= 0:
+                self.sku_default_printer_combo.setCurrentIndex(idx)
+        printer_row.addWidget(self.sku_default_printer_combo, 1)
+        main_layout.addLayout(printer_row)
+
+        # Mapping table group
+        mapping_group = QGroupBox("SKU → Barcodes → PDF Label Mappings")
+        mapping_layout = QVBoxLayout(mapping_group)
+
+        add_btn = QPushButton("+ Add Row")
+        add_btn.setMaximumWidth(140)
+        add_btn.clicked.connect(self._sku_add_mapping_row)
+        mapping_layout.addWidget(add_btn)
+
+        self.sku_table = QTableWidget()
+        self.sku_table.setColumnCount(4)
+        self.sku_table.setHorizontalHeaderLabels(["SKU", "Barcodes (comma-separated)", "PDF File", ""])
+        hdr = self.sku_table.horizontalHeader()
+        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        hdr.setSectionResizeMode(3, QHeaderView.ResizeMode.Fixed)
+        self.sku_table.setColumnWidth(3, 80)
+        self.sku_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.sku_table.verticalHeader().setVisible(False)
+        mapping_layout.addWidget(self.sku_table)
+
+        main_layout.addWidget(mapping_group, 1)
+
+        self.tab_widget.addTab(tab, "SKU Labels")
+
+        # Populate from config
+        self._sku_populate_table()
+
+    def _sku_populate_table(self):
+        """Populate the SKU mapping table from current config."""
+        sku_to_label = self.config_data.get("sku_label_config", {}).get("sku_to_label", {})
+        for sku, entry in sku_to_label.items():
+            barcodes_str = ", ".join(entry.get("barcodes", []))
+            pdf_path = entry.get("pdf_path", "")
+            self._sku_add_mapping_row(sku=sku, barcodes_str=barcodes_str, pdf_path=pdf_path)
+
+    def _sku_add_mapping_row(self, sku: str = "", barcodes_str: str = "", pdf_path: str = ""):
+        """Add one row to the SKU mapping table."""
+        row = self.sku_table.rowCount()
+        self.sku_table.insertRow(row)
+
+        self.sku_table.setItem(row, 0, QTableWidgetItem(sku))
+        self.sku_table.setItem(row, 1, QTableWidgetItem(barcodes_str))
+
+        # PDF path cell: QLineEdit + Browse button
+        path_widget = QWidget()
+        path_layout = QHBoxLayout(path_widget)
+        path_layout.setContentsMargins(2, 1, 2, 1)
+        path_layout.setSpacing(4)
+        path_edit = QLineEdit(pdf_path)
+        path_edit.setPlaceholderText("\\\\SERVER\\Share\\Labels\\sku.pdf")
+        browse_btn = QPushButton("Browse")
+        browse_btn.setMaximumWidth(60)
+        browse_btn.clicked.connect(lambda _, e=path_edit: self._sku_browse_pdf(e))
+        path_layout.addWidget(path_edit, 1)
+        path_layout.addWidget(browse_btn)
+        self.sku_table.setCellWidget(row, 2, path_widget)
+
+        # Delete button
+        del_btn = QPushButton("✕")
+        del_btn.setMaximumWidth(60)
+        del_btn.setToolTip("Delete row")
+        del_btn.clicked.connect(
+            lambda _, btn=del_btn: self.sku_table.removeRow(
+                self.sku_table.indexAt(btn.parent().pos()).row()
+            )
+        )
+        del_widget = QWidget()
+        del_layout = QHBoxLayout(del_widget)
+        del_layout.setContentsMargins(2, 1, 2, 1)
+        del_layout.addWidget(del_btn)
+        self.sku_table.setCellWidget(row, 3, del_widget)
+
+        self.sku_table.setRowHeight(row, 38)
+
+    def _sku_browse_pdf(self, path_edit: QLineEdit):
+        """Open file dialog to select a PDF label file."""
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select Label PDF", "", "PDF Files (*.pdf)"
+        )
+        if path:
+            path_edit.setText(path)
 
 
 # ========================================

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -178,8 +178,14 @@ class SettingsWindow(QDialog):
         self.courier_mapping_widgets = []
 
         self.setWindowTitle(f"Settings - CLIENT_{self.client_id}")
-        self.setMinimumSize(1150, 850)
+        self.setMinimumSize(1100, 600)
         self.setModal(True)
+
+        screen_geo = QApplication.primaryScreen().availableGeometry()
+        self.resize(
+            min(1250, screen_geo.width() - 40),
+            min(920, screen_geo.height() - 60),
+        )
 
         main_layout = QVBoxLayout(self)
         self.tab_widget = QTabWidget()
@@ -3171,8 +3177,7 @@ class SettingsWindow(QDialog):
 
                 self.config_data["sku_label_config"] = {
                     "sku_to_label": sku_to_label,
-                    "default_printer": self.sku_default_printer_combo.currentText()
-                    if hasattr(self, "sku_default_printer_combo") else "",
+                    "default_printer": self.sku_default_printer_combo.currentText(),
                 }
 
             # ========================================

--- a/gui/sku_label_widget.py
+++ b/gui/sku_label_widget.py
@@ -1,0 +1,366 @@
+"""
+SKU Label Widget - Tab for scanning barcodes and printing SKU PDF labels.
+
+Workflow:
+  1. User scans a barcode (or types and presses Enter)
+  2. App looks up the SKU from the barcode mapping
+  3. Fulfillable quantity from the current session is pre-filled
+  4. User adjusts copy count if needed, selects printer, and prints
+  5. After successful print the form auto-clears for the next scan
+"""
+
+import logging
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox,
+    QPushButton, QLabel, QLineEdit, QSpinBox, QComboBox, QFormLayout,
+    QMessageBox, QSizePolicy,
+)
+from PySide6.QtCore import Qt, QThreadPool
+
+from gui.worker import Worker
+from gui.theme_manager import get_theme_manager
+from shopify_tool.sku_label_manager import SKULabelManager
+
+logger = logging.getLogger(__name__)
+
+_NO_PRINTERS = "(no printers found)"
+_READY_MSG = "Ready — scan a product"
+_NO_CLIENT_MSG = "No active client — load a session first"
+
+
+class SKULabelWidget(QWidget):
+    """Tab widget for barcode-scan-to-print labeling workflow."""
+
+    def __init__(self, main_window, parent=None):
+        """
+        Initialize SKU Label widget.
+
+        Args:
+            main_window: MainWindow instance for accessing session data and config
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self.mw = main_window
+        self._manager: SKULabelManager | None = None
+        self._current_sku: str | None = None
+
+        self._init_ui()
+        self._connect_signals()
+
+    # ------------------------------------------------------------------
+    # UI Construction
+    # ------------------------------------------------------------------
+
+    def _init_ui(self):
+        """Build the layout."""
+        layout = QVBoxLayout(self)
+        layout.setSpacing(10)
+        layout.setContentsMargins(10, 10, 10, 10)
+
+        layout.addWidget(self._create_scan_section())
+        layout.addWidget(self._create_result_section())
+        layout.addWidget(self._create_print_section())
+        layout.addStretch()
+
+    def _create_scan_section(self) -> QGroupBox:
+        """Barcode input section."""
+        group = QGroupBox("Barcode Scan")
+        layout = QVBoxLayout(group)
+
+        theme = get_theme_manager().get_current_theme()
+
+        input_row = QHBoxLayout()
+        self.barcode_input = QLineEdit()
+        self.barcode_input.setPlaceholderText("Scan or type barcode and press Enter...")
+        self.barcode_input.setMinimumHeight(36)
+        self.barcode_input.setStyleSheet("font-size: 13px;")
+        input_row.addWidget(self.barcode_input, 1)
+
+        self.clear_btn = QPushButton("Clear")
+        self.clear_btn.setMaximumWidth(80)
+        self.clear_btn.setToolTip("Reset form and return focus to barcode input")
+        input_row.addWidget(self.clear_btn)
+
+        layout.addLayout(input_row)
+
+        self.scan_status_label = QLabel(_READY_MSG)
+        self.scan_status_label.setStyleSheet(f"color: {theme.text_secondary}; font-style: italic;")
+        layout.addWidget(self.scan_status_label)
+
+        return group
+
+    def _create_result_section(self) -> QGroupBox:
+        """Resolved SKU info section."""
+        group = QGroupBox("Resolved SKU")
+        form = QFormLayout(group)
+        form.setLabelAlignment(Qt.AlignRight)
+
+        theme = get_theme_manager().get_current_theme()
+
+        self.sku_value_label = QLabel("—")
+        self.sku_value_label.setStyleSheet("font-size: 14px; font-weight: bold;")
+        form.addRow("SKU:", self.sku_value_label)
+
+        self.fulfillable_value_label = QLabel("—")
+        self.fulfillable_value_label.setStyleSheet(
+            f"font-size: 13px; color: {theme.text_secondary};"
+        )
+        form.addRow("Fulfillable (session):", self.fulfillable_value_label)
+
+        return group
+
+    def _create_print_section(self) -> QGroupBox:
+        """Print controls section."""
+        group = QGroupBox("Print")
+        layout = QVBoxLayout(group)
+
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignRight)
+
+        self.copies_spinbox = QSpinBox()
+        self.copies_spinbox.setRange(1, 999)
+        self.copies_spinbox.setValue(1)
+        self.copies_spinbox.setMinimumWidth(100)
+        form.addRow("Copies:", self.copies_spinbox)
+
+        self.printer_combo = QComboBox()
+        self.printer_combo.setMinimumWidth(250)
+        self.printer_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        form.addRow("Printer:", self.printer_combo)
+
+        layout.addLayout(form)
+
+        self.print_btn = QPushButton("Print Label")
+        self.print_btn.setMinimumHeight(44)
+        self.print_btn.setStyleSheet(
+            "QPushButton {"
+            "  font-size: 15px; font-weight: bold;"
+            "  background-color: #4CAF50; color: white; border-radius: 5px;"
+            "}"
+            "QPushButton:hover { background-color: #45a049; }"
+            "QPushButton:disabled { background-color: #888; color: #ccc; }"
+        )
+        self.print_btn.setEnabled(False)
+        layout.addWidget(self.print_btn)
+
+        self.print_status_label = QLabel("")
+        self.print_status_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.print_status_label)
+
+        return group
+
+    # ------------------------------------------------------------------
+    # Signal Connections
+    # ------------------------------------------------------------------
+
+    def _connect_signals(self):
+        self.barcode_input.returnPressed.connect(self._on_barcode_submitted)
+        self.print_btn.clicked.connect(self._on_print_clicked)
+        self.clear_btn.clicked.connect(self._on_clear_clicked)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def showEvent(self, event):
+        """Refresh state when tab becomes visible."""
+        super().showEvent(event)
+        self._refresh_manager()
+        self._refresh_printers()
+        self.barcode_input.setFocus()
+
+    # ------------------------------------------------------------------
+    # State Management
+    # ------------------------------------------------------------------
+
+    def _refresh_manager(self):
+        """Rebuild the SKULabelManager from the current client config."""
+        if not hasattr(self.mw, "active_profile_config") or not self.mw.active_profile_config:
+            self._manager = None
+            self._set_scan_status(_NO_CLIENT_MSG, error=True)
+            return
+
+        config = self.mw.active_profile_config.get("sku_label_config", {})
+        self._manager = SKULabelManager(config)
+
+        # Restore saved default printer
+        saved_printer = config.get("default_printer", "")
+        if saved_printer:
+            idx = self.printer_combo.findText(saved_printer)
+            if idx >= 0:
+                self.printer_combo.setCurrentIndex(idx)
+
+        self._set_scan_status(_READY_MSG)
+
+    def _refresh_printers(self):
+        """Populate printer combo from available Windows printers."""
+        try:
+            from PySide6.QtPrintSupport import QPrinterInfo
+
+            current = self.printer_combo.currentText()
+            self.printer_combo.clear()
+
+            printers = QPrinterInfo.availablePrinters()
+            if not printers:
+                self.printer_combo.addItem(_NO_PRINTERS)
+                return
+
+            default_name = QPrinterInfo.defaultPrinter().printerName()
+            for pi in printers:
+                self.printer_combo.addItem(pi.printerName())
+
+            # Restore previous selection or system default
+            idx = self.printer_combo.findText(current) if current else -1
+            if idx >= 0:
+                self.printer_combo.setCurrentIndex(idx)
+            elif default_name:
+                idx = self.printer_combo.findText(default_name)
+                if idx >= 0:
+                    self.printer_combo.setCurrentIndex(idx)
+
+        except Exception:
+            logger.exception("Failed to enumerate printers")
+
+    # ------------------------------------------------------------------
+    # Scan Handling
+    # ------------------------------------------------------------------
+
+    def _on_barcode_submitted(self):
+        """Handle barcode scan / Enter key press."""
+        raw = self.barcode_input.text().strip()
+        if not raw:
+            return
+
+        if self._manager is None:
+            self._set_scan_status(_NO_CLIENT_MSG, error=True)
+            return
+
+        result = self._manager.lookup_by_barcode(raw)
+        if result is None:
+            self._set_scan_status(f"Barcode not found: {raw}", error=True)
+            self.barcode_input.selectAll()
+            self._clear_product_info()
+            return
+
+        sku = result["sku"]
+        self._current_sku = sku
+
+        # Update product info
+        self.sku_value_label.setText(sku)
+
+        # Fulfillable qty from session
+        analysis_df = getattr(self.mw, "analysis_results_df", None)
+        qty = self._manager.lookup_fulfillable_qty(sku, analysis_df)
+        self.fulfillable_value_label.setText(str(qty))
+        self.copies_spinbox.setValue(qty)
+
+        # Enable printing
+        self.print_btn.setEnabled(True)
+        self.print_status_label.setText("")
+        self._set_scan_status(f"Found: {sku}")
+
+        # Clear input for next scan
+        self.barcode_input.clear()
+
+    # ------------------------------------------------------------------
+    # Print Handling
+    # ------------------------------------------------------------------
+
+    def _on_print_clicked(self):
+        """Start background print job."""
+        if self._current_sku is None or self._manager is None:
+            return
+
+        printer_name = self.printer_combo.currentText()
+        if not printer_name or printer_name == _NO_PRINTERS:
+            QMessageBox.warning(self, "No Printer Selected", "Please select a printer.")
+            return
+
+        sku = self._current_sku
+        copies = self.copies_spinbox.value()
+        copy_word = "copy" if copies == 1 else "copies"
+
+        self.print_btn.setEnabled(False)
+        self.clear_btn.setEnabled(False)
+        self._set_print_status(f"Printing {copies} {copy_word} for {sku}...")
+
+        worker = Worker(self._manager.print_label, sku, copies, printer_name)
+        worker.signals.result.connect(self._on_print_result)
+        worker.signals.error.connect(self._on_print_error)
+        worker.signals.finished.connect(self._on_print_finished)
+        QThreadPool.globalInstance().start(worker)
+
+    def _on_print_result(self, result: dict):
+        """Handle print job result."""
+        if result["success"]:
+            pages = result["pages_printed"]
+            self._set_print_status(f"Printed {pages} page(s) successfully.", success=True)
+            logger.info("Print success: %d pages for SKU '%s'", pages, self._current_sku)
+            # Auto-clear after successful print
+            self._on_clear_clicked()
+        else:
+            err = result.get("error", "Unknown error")
+            self._set_print_status(f"Error: {err}", error=True)
+            QMessageBox.critical(
+                self,
+                "Print Error",
+                f"Failed to print label:\n\n{err}",
+            )
+
+    def _on_print_error(self, error_info: tuple):
+        """Handle unexpected Worker exception."""
+        _, value, _ = error_info
+        self._set_print_status(f"Error: {value}", error=True)
+        QMessageBox.critical(
+            self,
+            "Print Error",
+            f"Unexpected error:\n\n{value}",
+        )
+        logger.error("Unexpected print worker error: %s", value)
+
+    def _on_print_finished(self):
+        """Re-enable controls after print job completes."""
+        self.print_btn.setEnabled(self._current_sku is not None)
+        self.clear_btn.setEnabled(True)
+
+    # ------------------------------------------------------------------
+    # Clear / Reset
+    # ------------------------------------------------------------------
+
+    def _on_clear_clicked(self):
+        """Reset the form and return focus to barcode input."""
+        self._current_sku = None
+        self.barcode_input.clear()
+        self._clear_product_info()
+        self.copies_spinbox.setValue(1)
+        self.print_btn.setEnabled(False)
+        self.print_status_label.setText("")
+        self._set_scan_status(_READY_MSG)
+        self.barcode_input.setFocus()
+
+    def _clear_product_info(self):
+        """Clear resolved SKU info panel."""
+        self.sku_value_label.setText("—")
+        self.fulfillable_value_label.setText("—")
+
+    # ------------------------------------------------------------------
+    # Status Helpers
+    # ------------------------------------------------------------------
+
+    def _set_scan_status(self, text: str, *, error: bool = False):
+        theme = get_theme_manager().get_current_theme()
+        color = "#e53935" if error else theme.text_secondary
+        self.scan_status_label.setText(text)
+        self.scan_status_label.setStyleSheet(f"color: {color}; font-style: italic;")
+
+    def _set_print_status(self, text: str, *, success: bool = False, error: bool = False):
+        if success:
+            color = "#43a047"
+        elif error:
+            color = "#e53935"
+        else:
+            theme = get_theme_manager().get_current_theme()
+            color = theme.text_secondary
+        self.print_status_label.setText(text)
+        self.print_status_label.setStyleSheet(f"color: {color};")

--- a/gui/sku_label_widget.py
+++ b/gui/sku_label_widget.py
@@ -133,13 +133,14 @@ class SKULabelWidget(QWidget):
 
         self.print_btn = QPushButton("Print Label")
         self.print_btn.setMinimumHeight(44)
+        theme = get_theme_manager().get_current_theme()
         self.print_btn.setStyleSheet(
-            "QPushButton {"
-            "  font-size: 15px; font-weight: bold;"
-            "  background-color: #4CAF50; color: white; border-radius: 5px;"
-            "}"
-            "QPushButton:hover { background-color: #45a049; }"
-            "QPushButton:disabled { background-color: #888; color: #ccc; }"
+            f"QPushButton {{"
+            f"  font-size: 15px; font-weight: bold;"
+            f"  background-color: {theme.accent_green}; color: white; border-radius: 5px;"
+            f"}}"
+            f"QPushButton:hover {{ background-color: {theme.accent_green}; }}"
+            f"QPushButton:disabled {{ background-color: {theme.border}; color: {theme.text_secondary}; }}"
         )
         self.print_btn.setEnabled(False)
         layout.addWidget(self.print_btn)
@@ -183,14 +184,6 @@ class SKULabelWidget(QWidget):
 
         config = self.mw.active_profile_config.get("sku_label_config", {})
         self._manager = SKULabelManager(config)
-
-        # Restore saved default printer
-        saved_printer = config.get("default_printer", "")
-        if saved_printer:
-            idx = self.printer_combo.findText(saved_printer)
-            if idx >= 0:
-                self.printer_combo.setCurrentIndex(idx)
-
         self._set_scan_status(_READY_MSG)
 
     def _refresh_printers(self):
@@ -210,14 +203,14 @@ class SKULabelWidget(QWidget):
             for pi in printers:
                 self.printer_combo.addItem(pi.printerName())
 
-            # Restore previous selection or system default
-            idx = self.printer_combo.findText(current) if current else -1
-            if idx >= 0:
-                self.printer_combo.setCurrentIndex(idx)
-            elif default_name:
-                idx = self.printer_combo.findText(default_name)
-                if idx >= 0:
-                    self.printer_combo.setCurrentIndex(idx)
+            # Priority: current in-session selection → config default → system default
+            config_default = self._manager.default_printer if self._manager else ""
+            for candidate in (current, config_default, default_name):
+                if candidate:
+                    idx = self.printer_combo.findText(candidate)
+                    if idx >= 0:
+                        self.printer_combo.setCurrentIndex(idx)
+                        break
 
         except Exception:
             logger.exception("Failed to enumerate printers")
@@ -295,10 +288,9 @@ class SKULabelWidget(QWidget):
         """Handle print job result."""
         if result["success"]:
             pages = result["pages_printed"]
-            self._set_print_status(f"Printed {pages} page(s) successfully.", success=True)
             logger.info("Print success: %d pages for SKU '%s'", pages, self._current_sku)
-            # Auto-clear after successful print
             self._on_clear_clicked()
+            self._set_scan_status(f"Printed {pages} page(s). Ready — scan next product.")
         else:
             err = result.get("error", "Unknown error")
             self._set_print_status(f"Error: {err}", error=True)
@@ -350,17 +342,17 @@ class SKULabelWidget(QWidget):
 
     def _set_scan_status(self, text: str, *, error: bool = False):
         theme = get_theme_manager().get_current_theme()
-        color = "#e53935" if error else theme.text_secondary
+        color = theme.accent_red if error else theme.text_secondary
         self.scan_status_label.setText(text)
         self.scan_status_label.setStyleSheet(f"color: {color}; font-style: italic;")
 
     def _set_print_status(self, text: str, *, success: bool = False, error: bool = False):
+        theme = get_theme_manager().get_current_theme()
         if success:
-            color = "#43a047"
+            color = theme.accent_green
         elif error:
-            color = "#e53935"
+            color = theme.accent_red
         else:
-            theme = get_theme_manager().get_current_theme()
             color = theme.text_secondary
         self.print_status_label.setText(text)
         self.print_status_label.setStyleSheet(f"color: {color};")

--- a/gui/tools_widget.py
+++ b/gui/tools_widget.py
@@ -4,6 +4,7 @@ Tools Widget - Main container for utility tools.
 Contains sub-tabs:
 - Reference Labels: PDF processing for reference numbers
 - Barcode Generator: Generate warehouse barcode labels
+- SKU Labels: Barcode-scan-to-print labeling workflow
 """
 
 from PySide6.QtWidgets import (
@@ -13,6 +14,7 @@ from PySide6.QtCore import Qt
 
 from gui.reference_labels_widget import ReferenceLabelsWidget
 from gui.barcode_generator_widget import BarcodeGeneratorWidget
+from gui.sku_label_widget import SKULabelWidget
 
 
 class ToolsWidget(QWidget):
@@ -52,6 +54,13 @@ class ToolsWidget(QWidget):
         self.sub_tabs.addTab(
             self.barcode_generator_widget,
             "🏷️ Barcode Generator"
+        )
+
+        # Sub-tab 3: SKU Labels
+        self.sku_label_widget = SKULabelWidget(self.mw)
+        self.sub_tabs.addTab(
+            self.sku_label_widget,
+            "🖨️ SKU Labels"
         )
 
         layout.addWidget(self.sub_tabs)

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -687,6 +687,22 @@ class ProfileManager:
         logger.info(f"Added default 'weight_config' for CLIENT_{client_id}")
         return True
 
+    def _migrate_add_sku_label_config(self, client_id: str, config: Dict) -> bool:
+        """Add sku_label_config section if missing (new feature migration).
+
+        Returns:
+            bool: True if migration was performed, False if already present
+        """
+        if "sku_label_config" in config:
+            return False
+
+        config["sku_label_config"] = {
+            "sku_to_label": {},
+            "default_printer": ""
+        }
+        logger.info(f"Added default 'sku_label_config' for CLIENT_{client_id}")
+        return True
+
     @staticmethod
     def _create_default_shopify_config(client_id: str, client_name: str) -> Dict:
         """Create default Shopify configuration.
@@ -836,6 +852,11 @@ class ProfileManager:
                         }
                     }
                 }
+            },
+
+            "sku_label_config": {
+                "sku_to_label": {},
+                "default_printer": ""
             }
         }
 
@@ -922,8 +943,9 @@ class ProfileManager:
             migrated_tag_categories = self._migrate_add_tag_categories(client_id, config)
             migrated_tag_categories_v2 = self._migrate_tag_categories_v1_to_v2(client_id, config)
             migrated_weight = self._migrate_add_weight_config(client_id, config)
+            migrated_sku_labels = self._migrate_add_sku_label_config(client_id, config)
 
-            if migrated_mappings or migrated_delimiters or migrated_tag_categories or migrated_tag_categories_v2 or migrated_weight:
+            if migrated_mappings or migrated_delimiters or migrated_tag_categories or migrated_tag_categories_v2 or migrated_weight or migrated_sku_labels:
                 # If config was migrated, save it immediately
                 self.save_shopify_config(client_id, config)
                 logger.info(f"Config migrations completed for CLIENT_{client_id}")

--- a/shopify_tool/sku_label_manager.py
+++ b/shopify_tool/sku_label_manager.py
@@ -1,0 +1,223 @@
+"""
+SKU Label Manager - Business logic for SKU label lookup and PDF printing.
+
+Maps barcodes → SKUs → PDF label files. Handles label printing via
+QPrinter + QPdfDocument (PySide6). Designed to run in Worker threads.
+"""
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class SKULabelManager:
+    """Manages SKU-to-label mappings and PDF printing.
+
+    Config schema (sku_label_config section):
+        {
+            "sku_to_label": {
+                "SKU001": {
+                    "barcodes": ["1234567890", "0987654321"],
+                    "pdf_path": "\\\\SERVER\\Share\\Labels\\sku001.pdf"
+                }
+            },
+            "default_printer": ""
+        }
+    """
+
+    def __init__(self, config: dict):
+        """
+        Initialize with sku_label_config section from client config.
+
+        Args:
+            config: The sku_label_config dict from shopify_config.json
+        """
+        self._sku_to_label: dict = config.get("sku_to_label", {})
+        self._default_printer: str = config.get("default_printer", "")
+        self._barcode_index: dict[str, str] = self._build_barcode_index()
+
+    def _build_barcode_index(self) -> dict:
+        """Build reverse lookup index: barcode string → sku string."""
+        index = {}
+        for sku, entry in self._sku_to_label.items():
+            for barcode in entry.get("barcodes", []):
+                barcode = barcode.strip()
+                if barcode:
+                    if barcode in index:
+                        logger.warning(
+                            "Duplicate barcode '%s' maps to both '%s' and '%s' — using '%s'",
+                            barcode, index[barcode], sku, index[barcode]
+                        )
+                    else:
+                        index[barcode] = sku
+        return index
+
+    def lookup_by_barcode(self, barcode: str) -> dict | None:
+        """
+        Look up label entry by scanned barcode.
+
+        Args:
+            barcode: Scanned barcode string (stripped automatically)
+
+        Returns:
+            Dict with 'sku' and 'pdf_path', or None if not found
+        """
+        sku = self._barcode_index.get(barcode.strip())
+        if sku is None:
+            return None
+        entry = self._sku_to_label.get(sku, {})
+        return {
+            "sku": sku,
+            "pdf_path": entry.get("pdf_path", ""),
+        }
+
+    def lookup_fulfillable_qty(self, sku: str, analysis_df) -> int:
+        """
+        Get fulfillable quantity for a SKU from the current session analysis.
+
+        Args:
+            sku: SKU to look up
+            analysis_df: Current session's analysis DataFrame (may be None)
+
+        Returns:
+            Sum of Quantity for Fulfillable rows matching this SKU, or 1 as fallback
+        """
+        try:
+            if analysis_df is None or analysis_df.empty:
+                return 1
+            required_cols = {"SKU", "Order_Fulfillment_Status", "Quantity"}
+            if not required_cols.issubset(analysis_df.columns):
+                return 1
+            mask = (
+                (analysis_df["SKU"] == sku) &
+                (analysis_df["Order_Fulfillment_Status"] == "Fulfillable")
+            )
+            qty = analysis_df.loc[mask, "Quantity"].sum()
+            return int(qty) if qty > 0 else 1
+        except Exception:
+            logger.exception("Error looking up fulfillable qty for SKU: %s", sku)
+            return 1
+
+    def get_all_mappings(self) -> dict:
+        """Return the full sku_to_label mapping dict (read-only reference)."""
+        return self._sku_to_label
+
+    @property
+    def default_printer(self) -> str:
+        """Saved default printer name from config."""
+        return self._default_printer
+
+    def print_label(self, sku: str, copies: int, printer_name: str) -> dict:
+        """
+        Print the PDF label for a SKU N times to the specified printer.
+
+        Runs safely in a Worker (QRunnable) background thread — no UI objects created.
+
+        Args:
+            sku: SKU whose label PDF to print
+            copies: Number of copies to print
+            printer_name: Windows printer name as returned by QPrinterInfo
+
+        Returns:
+            Dict: {'success': bool, 'pages_printed': int, 'error': str|None}
+        """
+        from PySide6.QtPrintSupport import QPrinter, QPrinterInfo
+        from PySide6.QtPdf import QPdfDocument
+        from PySide6.QtGui import QPainter
+        from PySide6.QtCore import QSize, QRectF
+
+        entry = self._sku_to_label.get(sku)
+        if not entry:
+            return {
+                "success": False,
+                "pages_printed": 0,
+                "error": f"No label configured for SKU: {sku}",
+            }
+
+        pdf_path = entry.get("pdf_path", "")
+        if not pdf_path or not Path(pdf_path).exists():
+            return {
+                "success": False,
+                "pages_printed": 0,
+                "error": f"PDF file not found: {pdf_path}",
+            }
+
+        # Find the target printer by name
+        target_info = None
+        for pi in QPrinterInfo.availablePrinters():
+            if pi.printerName() == printer_name:
+                target_info = pi
+                break
+
+        if target_info is None:
+            return {
+                "success": False,
+                "pages_printed": 0,
+                "error": f"Printer not found: '{printer_name}'",
+            }
+
+        # Load PDF document
+        doc = QPdfDocument(None)
+        doc.load(pdf_path)
+
+        page_count = doc.pageCount()
+        if page_count == 0:
+            doc.close()
+            return {
+                "success": False,
+                "pages_printed": 0,
+                "error": f"PDF has no pages or could not be loaded: {pdf_path}",
+            }
+
+        # Create printer and painter
+        printer = QPrinter(target_info)
+        printer.setOutputFormat(QPrinter.OutputFormat.NativeFormat)
+
+        painter = QPainter()
+        if not painter.begin(printer):
+            doc.close()
+            return {
+                "success": False,
+                "pages_printed": 0,
+                "error": f"Failed to begin printing to '{printer_name}'",
+            }
+
+        pages_printed = 0
+        error_msg = None
+
+        try:
+            dpi = printer.resolution()
+            page_rect = printer.pageRect(QPrinter.Unit.DevicePixel)
+            target_rect = QRectF(page_rect)
+
+            for copy_idx in range(copies):
+                for page_idx in range(page_count):
+                    # Render PDF page to QImage at printer DPI
+                    page_size_pt = doc.pagePointSize(page_idx)
+                    render_w = max(1, int(page_size_pt.width() / 72.0 * dpi))
+                    render_h = max(1, int(page_size_pt.height() / 72.0 * dpi))
+                    image = doc.render(page_idx, QSize(render_w, render_h))
+
+                    painter.drawImage(target_rect, image)
+                    pages_printed += 1
+
+                    is_last = (copy_idx == copies - 1) and (page_idx == page_count - 1)
+                    if not is_last:
+                        printer.newPage()
+
+        except Exception as exc:
+            error_msg = str(exc)
+            logger.exception("Print error for SKU '%s'", sku)
+        finally:
+            painter.end()
+            doc.close()
+
+        if error_msg:
+            return {"success": False, "pages_printed": pages_printed, "error": error_msg}
+
+        logger.info(
+            "Printed %d page(s) for SKU '%s' (%d cop%s) to '%s'",
+            pages_printed, sku, copies, "y" if copies == 1 else "ies", printer_name,
+        )
+        return {"success": True, "pages_printed": pages_printed, "error": None}

--- a/shopify_tool/sku_label_manager.py
+++ b/shopify_tool/sku_label_manager.py
@@ -188,7 +188,7 @@ class SKULabelManager:
 
         try:
             dpi = printer.resolution()
-            page_rect = printer.pageRect(QPrinter.Unit.DevicePixel)
+            page_rect = printer.pageRect(QPrinter.DevicePixel)
             target_rect = QRectF(page_rect)
 
             for copy_idx in range(copies):


### PR DESCRIPTION
New Tools sub-tab for barcode-scan-to-print label workflow:

- gui/sku_label_widget.py — scan barcode → resolve SKU → print N copies of the configured PDF label to any Windows printer; auto-clears after success
- shopify_tool/sku_label_manager.py — many-to-one barcode→SKU index, fulfillable qty lookup from analysis_df, QPrinter+QPdfDocument background print pipeline
- gui/tools_widget.py — registers new "SKU Labels" sub-tab
- shopify_tool/profile_manager.py — adds sku_label_config to default config + auto-migration for existing clients
- gui/settings_window_pyside.py — new "SKU Labels" settings tab: SKU/barcode/PDF mapping table with default printer selection; saves to client config

## Summary by Sourcery

Add a new barcode-driven SKU label printing workflow, including UI, configuration, and backend logic for mapping barcodes to SKU PDF labels and sending them to Windows printers.

New Features:
- Introduce a SKU Label Printing settings tab where users can map SKUs to barcodes and PDF label files and choose a default printer.
- Add a SKU Labels tools sub-tab that lets users scan barcodes, resolve SKUs, prefill fulfillable quantity, select a printer, and print labels asynchronously.

Enhancements:
- Extend client configuration and migration logic to include a sku_label_config section with SKU-to-label mappings and default printer support.