### PR TITLE
fix: correct SettingsWindow sizing and add maximize button

### DIFF
--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -180,12 +180,7 @@ class SettingsWindow(QDialog):
         self.setWindowTitle(f"Settings - CLIENT_{self.client_id}")
         self.setMinimumSize(1100, 600)
         self.setModal(True)
-
-        screen_geo = QApplication.primaryScreen().availableGeometry()
-        self.resize(
-            min(1250, screen_geo.width() - 40),
-            min(920, screen_geo.height() - 60),
-        )
+        self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint)
 
         main_layout = QVBoxLayout(self)
         self.tab_widget = QTabWidget()
@@ -207,6 +202,10 @@ class SettingsWindow(QDialog):
         button_box.accepted.connect(self.save_settings)
         button_box.rejected.connect(self.reject)
         main_layout.addWidget(button_box)
+
+        _screen = parent.screen() if parent else QApplication.primaryScreen()
+        _geo = _screen.availableGeometry()
+        self.resize(min(1250, _geo.width() - 40), min(820, _geo.height() - 100))
 
     # Generic helper to delete a widget and its reference from a list
     def _delete_widget_from_list(self, widget_refs, ref_list):


### PR DESCRIPTION
1
- Add Qt.WindowMaximizeButtonHint via windowFlags() OR to preserve existing flags (setModal state was being clobbered by full flag override)
- Move resize() to after all tab content is built so Qt layout engine has finalized minimum size hints before the call
- Restore screen-aware sizing using parent screen geometry (min 1250×820, with 40/100px margins) instead of hardcoded values
- Lower height cap to 820 and increase margin to 100 to ensure Save/Cancel buttons are always visible above the taskbar

## Summary by Sourcery

Adjust settings window behavior to improve sizing and add standard window controls.

Enhancements:
- Enable a maximize button on the settings window while preserving existing window flags and modality.
- Defer resizing the settings window until after tab content is constructed so layout-based size hints are honored.
- Restore screen-aware initial sizing using the parent screen geometry with updated dimensions and margins to keep action buttons visible above the taskbar.