### PR TITLE
fix: update server path to new network share location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,7 @@ Consolidation release: Barcode Generator (Feature #5), Reference Labels processo
 - Added SessionManager — server-based session lifecycle
 - Added StatsManager — unified statistics for Shopify and Packing tools
 - Added JSON export for Packing Tool integration
-- Migrated from local storage to centralized file server (`\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment\`)
+- Migrated from local storage to centralized file server (`\\192.168.88.101\_Fulfilment_\0UFulfilment\`)
 - Centralized logging under `Logs/shopify_tool/`
 
 ---

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For detailed architecture information, see [docs/ARCHITECTURE.md](docs/ARCHITECT
 
 - Python 3.9+
 - Windows 10/11
-- Network access to the file server at `\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment\`
+- Network access to the file server at `\\192.168.88.101\_Fulfilment_\0UFulfilment\`
 
 ### Production Setup
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -901,7 +901,7 @@ def __init__(self, base_path: str)
 ```
 
 **Parameters**:
-- `base_path` (str): Root path on file server (e.g., `\\\\192.168.88.101\\Z_GreenDelivery\\WAREHOUSE\\0UFulfilment`)
+- `base_path` (str): Root path on file server (e.g., `\\\\192.168.88.101\\_Fulfilment_\\0UFulfilment`)
 
 **Raises**:
 - `NetworkError`: If file server is not accessible

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -432,7 +432,7 @@ Worker threads communicate back to the main thread exclusively via Qt signals (`
     └── shopify_tool/               # Application logs
 ```
 
-The server path defaults to `\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment\`. Setting the `FULFILLMENT_SERVER_PATH` environment variable overrides this for local development.
+The server path defaults to `\\192.168.88.101\_Fulfilment_\0UFulfilment\`. Setting the `FULFILLMENT_SERVER_PATH` environment variable overrides this for local development.
 
 ### Integration with Packing Tool
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -47,7 +47,7 @@ Record analysis completion:
 from shared import StatsManager
 
 # Initialize (pass path to 0UFulfilment directory)
-base_path = r"\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment"
+base_path = r"\\192.168.88.101\_Fulfilment_\0UFulfilment"
 stats_manager = StatsManager(base_path)
 
 # After completing analysis
@@ -70,7 +70,7 @@ Record packing session completion:
 from shared import StatsManager
 
 # Initialize
-base_path = r"\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment"
+base_path = r"\\192.168.88.101\_Fulfilment_\0UFulfilment"
 stats_manager = StatsManager(base_path)
 
 # After completing packing session

--- a/shared/stats_manager.py
+++ b/shared/stats_manager.py
@@ -721,7 +721,7 @@ class StatsManager:
 # Example usage
 if __name__ == "__main__":
     # Example for testing
-    base_path = r"\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment"
+    base_path = r"\\192.168.88.101\_Fulfilment_\0UFulfilment"
 
     # Create manager
     manager = StatsManager(base_path)

--- a/shopify_tool/logger_config.py
+++ b/shopify_tool/logger_config.py
@@ -64,7 +64,7 @@ def setup_logging(
     separately by the UI code.
 
     Args:
-        server_base_path: Base path to the server (e.g., r"\\\\192.168.88.101\\Z_GreenDelivery\\WAREHOUSE\\0UFulfilment")
+        server_base_path: Base path to the server (e.g., r"\\\\192.168.88.101\\_Fulfilment_\\0UFulfilment")
                          If None, uses local "logs" directory for development/testing
         client_id: Current client ID for structured logging (optional)
         session_id: Current session ID for structured logging (optional)

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -132,7 +132,7 @@ class ProfileManager:
             return env_path
 
         # Default to production path
-        prod_path = r"\\192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment"
+        prod_path = r"\\192.168.88.101\_Fulfilment_\0UFulfilment"
         logger.info(f"Using default production server path: {prod_path}")
         return prod_path
 


### PR DESCRIPTION
Replace \192.168.88.101\Z_GreenDelivery\WAREHOUSE\0UFulfilment with \192.168.88.101\_Fulfilment_\0UFulfilment across all code and docs.

## Summary by Sourcery

Update the default fulfillment server path to the new network share across code and documentation.

Enhancements:
- Change the default production fulfillment server path used by shared utilities and Shopify tooling to the new network share location.

Documentation:
- Refresh all user-facing docs and examples to reference the new fulfillment file server path.