### PR TITLE
fix: preserve '#' prefix in barcode encoding for exact Shopify order …

### DIFF
--- a/START_DEV.bat
+++ b/START_DEV.bat
@@ -5,7 +5,7 @@ echo ========================================
 echo.
 
 REM Set development environment variable
-set FULFILLMENT_SERVER_PATH=C:\Dev\fulfillment-server-mock
+set FULFILLMENT_SERVER_PATH=D:\Dev\fulfillment-server-mock
 
 echo Environment: DEVELOPMENT
 echo Server Path: %FULFILLMENT_SERVER_PATH%
@@ -14,7 +14,7 @@ echo.
 REM Check if dev structure exists
 if not exist "%FULFILLMENT_SERVER_PATH%\Clients" (
     echo Dev environment not found. Running setup with pre-populated session...
-    python scripts/setup_dev_env.py --with-session --with-analysis "%FULFILLMENT_SERVER_PATH%"
+    py scripts/setup_dev_env.py --with-session --with-analysis "%FULFILLMENT_SERVER_PATH%"
     echo.
 )
 
@@ -22,6 +22,6 @@ echo ========================================
 echo Starting Shopify Tool...
 echo ========================================
 echo.
-python gui_main.py
+py gui_main.py
 
 pause

--- a/shopify_tool/barcode_processor.py
+++ b/shopify_tool/barcode_processor.py
@@ -89,14 +89,15 @@ def sanitize_order_number(order_number: str) -> str:
     """
     Clean order number for Code-128 barcode encoding.
 
-    Removes non-alphanumeric characters except hyphens and underscores.
-    Code-128 supports alphanumeric content for reliable scanning.
+    Preserves alphanumeric characters, hyphens, underscores, and the '#' prefix
+    used by Shopify order numbers (e.g. #1029392, #BG10129). Code-128 mode B
+    supports the full printable ASCII range so '#' encodes reliably.
 
     Args:
         order_number: Raw order number
 
     Returns:
-        Sanitized order number safe for barcode
+        Sanitized order number safe for barcode encoding
 
     Raises:
         InvalidOrderNumberError: If order number is empty after sanitization
@@ -104,8 +105,8 @@ def sanitize_order_number(order_number: str) -> str:
     if not order_number:
         raise InvalidOrderNumberError("Order number cannot be empty")
 
-    # Remove non-alphanumeric except hyphen and underscore
-    clean = ''.join(c for c in order_number if c.isalnum() or c in ['-', '_'])
+    # Remove characters outside Code-128 mode B printable set; preserve '#' for Shopify prefix
+    clean = ''.join(c for c in order_number if c.isalnum() or c in ['-', '_', '#'])
 
     if not clean:
         raise InvalidOrderNumberError(f"Order number '{order_number}' contains no valid characters")
@@ -432,7 +433,8 @@ def generate_barcode_label(
             draw.text((text_x_last, text_y), last_three, font=font_barcode_num_bold, fill='black')
 
         # === STEP 5: Save PNG with DPI metadata ===
-        output_file = output_dir / f"{safe_order_number}.png"
+        filename_safe = safe_order_number.replace('#', '')
+        output_file = output_dir / f"{filename_safe}.png"
         label_img.save(output_file, dpi=(dpi, dpi))
 
         # Get file size

--- a/tests/test_barcode_processor.py
+++ b/tests/test_barcode_processor.py
@@ -134,7 +134,15 @@ class TestUtilityFunctions:
     def test_sanitize_order_number_special_chars(self):
         """Test sanitizing order number with special characters."""
         result = sanitize_order_number("ORDER#12345!")
-        assert result == "ORDER12345"
+        assert result == "ORDER#12345"
+
+    def test_sanitize_shopify_hash_numeric(self):
+        """# prefix preserved for Shopify numeric orders."""
+        assert sanitize_order_number("#1029392") == "#1029392"
+
+    def test_sanitize_shopify_hash_alphanumeric(self):
+        """# prefix preserved for Shopify alphanumeric orders."""
+        assert sanitize_order_number("#BG10129") == "#BG10129"
 
     def test_sanitize_order_number_empty(self):
         """Test sanitizing empty order number."""


### PR DESCRIPTION
…number matching

- sanitize_order_number() now keeps '#' so #1029392 encodes as #1029392 in Code-128
- PNG filename strips '#' separately to stay filesystem-safe
- START_DEV.bat: replace python with py launcher to fix Windows App Execution Aliases conflict

## Summary by Sourcery

Preserve Shopify-style '#' order number prefixes in barcode values while keeping generated PNG filenames filesystem-safe, and adjust the Windows dev startup script to use the Python launcher.

Bug Fixes:
- Ensure Shopify order numbers with '#' prefixes are encoded verbatim in Code-128 barcodes instead of stripping the prefix.

Enhancements:
- Strip '#' only from generated barcode PNG filenames to avoid filesystem issues.
- Update START_DEV.bat to use the 'py' launcher and the new local fulfillment server path for development.

Tests:
- Extend barcode sanitization tests to cover '#' preservation for Shopify numeric and alphanumeric order numbers.