### PR TITLE
perf: replace TTL cache with mtime-based cache, optimize hot paths an…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,3 +201,41 @@ When adding a new module, add corresponding `tests/test_<module>.py`. Aim for ed
 These target: `barcode_generator_widget.py`, `client_settings_dialog.py`, `column_config_dialog.py`, `column_mapping_widget.py`, `reference_labels_widget.py`, `rule_test_dialog.py`, `tag_categories_dialog.py`, `tag_management_panel.py`, `session_browser_widget.py`, `report_selection_dialog.py`
 
 Run them and delete, or commit to `scripts/` — do not leave them in the root.
+
+## Ponytail — Lazy Senior Dev Mode
+
+You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+
+Before writing any code, stop at the first rung that holds:
+
+1. Does this need to be built at all? (YAGNI)
+2. Does the standard library already do this? Use it.
+3. Does a native platform feature cover it? Use it.
+4. Does an already-installed dependency solve it? Use it.
+5. Can this be one line? Make it one line.
+6. Only then: write the minimum code that works.
+
+Rules:
+
+- No abstractions that weren't explicitly requested.
+- No new dependency if it can be avoided.
+- No boilerplate nobody asked for.
+- Deletion over addition. Boring over clever. Fewest files possible.
+- Question complex requests: "Do you actually need X, or does Y cover it?"
+- Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
+- Mark intentional simplifications with a `ponytail:` comment. If the shortcut has a known ceiling (global lock, O(n²) scan, naive heuristic), the comment names the ceiling and the upgrade path.
+
+Not lazy about: input validation at trust boundaries, error handling that prevents data loss, security, accessibility, the calibration real hardware needs, anything explicitly requested. Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind, the smallest thing that fails if the logic breaks (an assert-based demo/self-check or one small test file; no frameworks, no fixtures). Trivial one-liners need no test.
+
+---
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+

--- a/gui/pandas_model.py
+++ b/gui/pandas_model.py
@@ -184,10 +184,14 @@ class PandasModel(QAbstractTableModel):
         has_system_note = "System_note" in self._dataframe.columns
         has_status = "Order_Fulfillment_Status" in self._dataframe.columns
 
+        # Pre-compute column indices so the hot loop uses iat (scalar, ~5-10x faster than iloc[i]["col"])
+        sn_col = self._dataframe.columns.get_loc("System_note") if has_system_note else -1
+        st_col = self._dataframe.columns.get_loc("Order_Fulfillment_Status") if has_status else -1
+
         for i in range(n):
             try:
                 if has_system_note:
-                    sn_val = self._dataframe.iloc[i]["System_note"]
+                    sn_val = self._dataframe.iat[i, sn_col]
                     if pd.notna(sn_val):
                         sn = str(sn_val)
                         if "Repeat" in sn and not sn.startswith("Cannot fulfill"):
@@ -196,7 +200,7 @@ class PandasModel(QAbstractTableModel):
                             continue
 
                 if has_status:
-                    status = self._dataframe.iloc[i]["Order_Fulfillment_Status"]
+                    status = self._dataframe.iat[i, st_col]
                     if status == "Fulfillable":
                         bg[i] = self.colors["Fulfillable"]
                         fg[i] = self.text_colors["Fulfillable"]

--- a/shopify_tool/analysis.py
+++ b/shopify_tool/analysis.py
@@ -77,11 +77,11 @@ def _build_fifo_lots(stock_df: pd.DataFrame) -> Optional[Dict[str, List[dict]]]:
 
     for sku, group in stock_df.groupby("SKU"):
         lots = []
-        for _, row in group.iterrows():
-            qty = float(row["Stock"]) if pd.notna(row["Stock"]) else 0.0
+        for row in group.itertuples(index=False):
+            qty = float(row.Stock) if pd.notna(row.Stock) else 0.0
             if qty <= 0:
                 continue
-            raw_e = row["Expiry_Date"] if has_expiry and pd.notna(row.get("Expiry_Date")) else None
+            raw_e = row.Expiry_Date if has_expiry and pd.notna(row.Expiry_Date) else None
             if raw_e is None:
                 expiry_raw = "1"
             elif isinstance(raw_e, float):
@@ -89,7 +89,7 @@ def _build_fifo_lots(stock_df: pd.DataFrame) -> Optional[Dict[str, List[dict]]]:
             else:
                 expiry_raw = str(raw_e).strip()
 
-            raw_b = row["Batch"] if has_batch and pd.notna(row.get("Batch")) else None
+            raw_b = row.Batch if has_batch and pd.notna(row.Batch) else None
             if raw_b is None:
                 batch_raw = None
             elif isinstance(raw_b, float):
@@ -156,67 +156,52 @@ def _clean_and_prepare_data(
     logger.debug("Phase 1/7: Cleaning and preparing data...")
 
     # --- Step 0: Apply Column Mappings ---
-    # Check if DataFrames already have internal names (backward compatibility for tests)
-    orders_has_internal_names = all(
-        col in orders_df.columns for col in ["Order_Number", "SKU", "Quantity"]
-    )
-    stock_has_internal_names = all(
-        col in stock_df.columns for col in ["SKU", "Stock"]
-    )
-
-    # If DataFrames already have internal names, skip mapping
-    if orders_has_internal_names and stock_has_internal_names and column_mappings is None:
-        # Already using internal names (e.g., in tests), no mapping needed
-        pass
-    else:
-        # Apply column mappings
-        # Default mappings for backward compatibility (Shopify + Bulgarian warehouse)
-        if column_mappings is None:
-            column_mappings = {
-                "orders": {
-                    "Name": "Order_Number",
-                    "Lineitem sku": "SKU",
-                    "Lineitem quantity": "Quantity",
-                    "Lineitem name": "Product_Name",
-                    "Shipping Method": "Shipping_Method",
-                    "Shipping Country": "Shipping_Country",
-                    "Tags": "Tags",
-                    "Notes": "Notes",
-                    "Total": "Total_Price",
-                    "Subtotal": "Subtotal"
-                },
-                "stock": {
-                    "Артикул": "SKU",
-                    "Име": "Product_Name",
-                    "Наличност": "Stock",
-                    "Годност": "Expiry_Date",
-                    "Партида": "Batch"
-                }
+    if column_mappings is None:
+        column_mappings = {
+            "orders": {
+                "Name": "Order_Number",
+                "Lineitem sku": "SKU",
+                "Lineitem quantity": "Quantity",
+                "Lineitem name": "Product_Name",
+                "Shipping Method": "Shipping_Method",
+                "Shipping Country": "Shipping_Country",
+                "Tags": "Tags",
+                "Notes": "Notes",
+                "Total": "Total_Price",
+                "Subtotal": "Subtotal"
+            },
+            "stock": {
+                "Артикул": "SKU",
+                "Име": "Product_Name",
+                "Наличност": "Stock",
+                "Годност": "Expiry_Date",
+                "Партида": "Batch"
             }
+        }
 
-        # Get mappings for orders and stock
-        orders_mappings = column_mappings.get("orders", {})
-        stock_mappings = column_mappings.get("stock", {})
+    # Get mappings for orders and stock
+    orders_mappings = column_mappings.get("orders", {})
+    stock_mappings = column_mappings.get("stock", {})
 
-        # Inject lot column defaults for any keys not already in the config mapping.
-        # This ensures lot tracking works for existing clients whose configs pre-date
-        # this feature without requiring a config migration or UI change.
-        missing = {k: v for k, v in _LOT_COLUMN_DEFAULTS.items() if k not in stock_mappings}
-        if missing:
-            stock_mappings = {**stock_mappings, **missing}
+    # Inject lot column defaults for any keys not already in the config mapping.
+    # This ensures lot tracking works for existing clients whose configs pre-date
+    # this feature without requiring a config migration or UI change.
+    missing = {k: v for k, v in _LOT_COLUMN_DEFAULTS.items() if k not in stock_mappings}
+    if missing:
+        stock_mappings = {**stock_mappings, **missing}
 
-        # Apply mappings to orders DataFrame
-        # Only rename columns that exist in the DataFrame AND are different from internal names
-        orders_rename_map = {csv_col: internal_col for csv_col, internal_col in orders_mappings.items()
-                             if csv_col in orders_df.columns and csv_col != internal_col}
-        if orders_rename_map:
-            orders_df = orders_df.rename(columns=orders_rename_map)
+    # Apply mappings to orders DataFrame
+    # Only rename columns that exist in the DataFrame AND are different from internal names
+    orders_rename_map = {csv_col: internal_col for csv_col, internal_col in orders_mappings.items()
+                         if csv_col in orders_df.columns and csv_col != internal_col}
+    if orders_rename_map:
+        orders_df = orders_df.rename(columns=orders_rename_map)
 
-        # Apply mappings to stock DataFrame
-        stock_rename_map = {csv_col: internal_col for csv_col, internal_col in stock_mappings.items()
-                            if csv_col in stock_df.columns and csv_col != internal_col}
-        if stock_rename_map:
-            stock_df = stock_df.rename(columns=stock_rename_map)
+    # Apply mappings to stock DataFrame
+    stock_rename_map = {csv_col: internal_col for csv_col, internal_col in stock_mappings.items()
+                        if csv_col in stock_df.columns and csv_col != internal_col}
+    if stock_rename_map:
+        stock_df = stock_df.rename(columns=stock_rename_map)
 
     # Rename additional columns from CSV names to internal names
     if additional_columns_config:
@@ -481,10 +466,12 @@ def _simulate_stock_allocation(
                    lots were allocated per order.
 
     Returns:
-        Tuple of (fulfillment_results, lot_allocations):
+        Tuple of (fulfillment_results, lot_allocations, final_stock_dict):
         - fulfillment_results: {order_number: {"fulfillable": bool, "reason": str}}
         - lot_allocations: {order_number: {sku: [{expiry, batch, qty_allocated}]}}
                            Empty dict when fifo_lots is None.
+        - final_stock_dict: {sku: remaining_qty} after all fulfillments applied.
+                            Eliminates the need for a separate _calculate_final_stock replay pass.
     """
     logger.debug("Phase 3/7: Simulating stock allocation...")
 
@@ -497,9 +484,11 @@ def _simulate_stock_allocation(
     else:
         orders_for_simulation = orders_df.copy()
 
-    # Add item_count to orders for filtering
-    order_item_counts = orders_for_simulation.groupby("Order_Number").size().rename("item_count")
-    orders_with_counts = pd.merge(orders_for_simulation, order_item_counts, on="Order_Number")
+    # Pre-group required quantities per order — single O(N) pass avoids O(N²) per-order scans
+    order_required_quantities: Dict[str, "pd.Series"] = {
+        order_num: grp.groupby("SKU")["Quantity"].sum()
+        for order_num, grp in orders_for_simulation.groupby("Order_Number")
+    }
 
     fulfillment_results = {}
 
@@ -510,8 +499,9 @@ def _simulate_stock_allocation(
         lot_allocations: Dict[str, Dict[str, List[dict]]] = {}
 
         for order_number in prioritized_orders["Order_Number"]:
-            order_items = orders_with_counts[orders_with_counts["Order_Number"] == order_number]
-            required_quantities = order_items.groupby("SKU")["Quantity"].sum()
+            required_quantities = order_required_quantities.get(order_number)
+            if required_quantities is None:
+                continue
 
             can_fulfill_order = True
             unfulfillable_reasons = []
@@ -537,14 +527,17 @@ def _simulate_stock_allocation(
                     "reason": "; ".join(unfulfillable_reasons)
                 }
 
+        final_stock_dict = live_stock
+
     else:
         # --- FIFO LOT PATH ---
         live_lots = copy.deepcopy(fifo_lots)
         lot_allocations = {}
 
         for order_number in prioritized_orders["Order_Number"]:
-            order_items = orders_with_counts[orders_with_counts["Order_Number"] == order_number]
-            required_quantities = order_items.groupby("SKU")["Quantity"].sum()
+            required_quantities = order_required_quantities.get(order_number)
+            if required_quantities is None:
+                continue
 
             can_fulfill_order = True
             unfulfillable_reasons = []
@@ -588,10 +581,16 @@ def _simulate_stock_allocation(
                     "reason": "; ".join(unfulfillable_reasons)
                 }
 
+        # Derive final stock from remaining live_lots; seed from stock_df for zero-stock SKUs
+        # (SKUs whose all lots had qty<=0 are absent from live_lots; seed preserves them at 0)
+        final_stock_dict = dict(zip(stock_df["SKU"], stock_df["Stock"])) if "Stock" in stock_df.columns else {}
+        for sku, lots in live_lots.items():
+            final_stock_dict[sku] = sum(lot["qty"] for lot in lots)
+
     fulfillable_count = sum(1 for r in fulfillment_results.values() if r.get("fulfillable", False))
     logger.debug(f"Fulfillable: {fulfillable_count}/{len(fulfillment_results)} orders")
 
-    return fulfillment_results, lot_allocations
+    return fulfillment_results, lot_allocations, final_stock_dict
 
 
 def _calculate_final_stock(
@@ -1257,14 +1256,16 @@ def run_analysis(stock_df, orders_df, history_df, column_mappings=None, courier_
 
         # Phase 3: Simulate stock allocation
         logger.info("Phase 3/7: Stock allocation simulation")
-        fulfillment_results, lot_allocations = _simulate_stock_allocation(
+        fulfillment_results, lot_allocations, final_stock_dict = _simulate_stock_allocation(
             orders_clean, stock_clean, prioritized_orders, fifo_lots
         )
 
-        # Phase 4: Calculate final stock
+        # Phase 4: Convert live stock dict to DataFrame (no replay needed — simulation already tracked it)
         logger.info("Phase 4/7: Final stock calculations")
-        final_stock = _calculate_final_stock(
-            stock_clean, fulfillment_results, orders_clean
+        final_stock = (
+            pd.Series(final_stock_dict, name="Final_Stock")
+            .reset_index()
+            .rename(columns={"index": "SKU"})
         )
 
         # Phase 5: Already handled in Phase 6 (_detect_repeated_orders is called there)
@@ -1489,16 +1490,14 @@ def toggle_order_fulfillment(df, order_number):
     if df is None:
         return False, "DataFrame is None.", df
 
-    # Convert order_number to string for comparison (handles int/float order numbers)
+    # Compute boolean mask once — reused for existence check, status lookup, and status update
     order_number_str = str(order_number).strip()
-    order_numbers_str = df["Order_Number"].astype(str).str.strip()
+    order_mask = df["Order_Number"].astype(str).str.strip() == order_number_str
 
-    if order_number_str not in order_numbers_str.values:
+    if not order_mask.any():
         return False, "Order number not found.", df
 
     # Find current status (assuming all rows for an order have the same status)
-    # Use string comparison for finding the order
-    order_mask = order_numbers_str == order_number_str
     current_status = df.loc[order_mask, "Order_Fulfillment_Status"].iloc[0]
 
     if current_status == "Fulfillable":
@@ -1518,11 +1517,14 @@ def toggle_order_fulfillment(df, order_number):
         order_items = df.loc[order_mask]
         items_needed = order_items.groupby("SKU")["Quantity"].sum()
 
+        # Pre-compute once — avoids O(N) unique() call inside each loop iteration
+        known_skus = set(df["SKU"])
+
         # Pre-flight check for stock availability
         lacking_skus = []
         for sku, needed_qty in items_needed.items():
             # Check if the SKU is even in our dataframe (for the unlisted stock case)
-            if sku not in df["SKU"].unique():
+            if sku not in known_skus:
                 continue  # This is an unlisted item, we assume it's on hand
 
             # Get current final stock for this SKU
@@ -1538,7 +1540,7 @@ def toggle_order_fulfillment(df, order_number):
         # If check passes, deduct stock
         for sku, needed_qty in items_needed.items():
             # For unlisted SKUs, we need to add them to the df to track their negative stock
-            if sku not in df["SKU"].unique():
+            if sku not in known_skus:
                 # Find one of the order rows to copy base data from
                 template_row = order_items.iloc[0].to_dict()
                 new_row = {key: (None if key not in ["SKU", "Quantity"] else template_row[key]) for key in df.columns}

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -61,9 +61,10 @@ class ProfileManager:
         is_network_available (bool): Whether file server is accessible
     """
 
-    # Class-level caches (shared across instances)
-    _config_cache: Dict[str, Tuple[Dict, datetime]] = {}
-    CACHE_TIMEOUT_SECONDS = 60  # Cache valid for 1 minute
+    # Class-level cache: key → (data, mtime_float). mtime-based invalidation is more
+    # correct than TTL — no stale reads after a write, no unnecessary re-reads within a window.
+    # Key includes base_path so multiple instances with different roots don't collide.
+    _config_cache: Dict[str, Tuple[Dict, float]] = {}
 
     # Class-level constants for metadata cache
     METADATA_CACHE_TIMEOUT_SECONDS = 300  # 5 minutes
@@ -384,7 +385,9 @@ class ProfileManager:
             "stock": {
                 "Артикул": "SKU",
                 "Име": "Product_Name",
-                "Наличност": "Stock"
+                "Наличност": "Stock",
+                "Годност": "Expiry_Date",
+                "Партида": "Batch"
             }
         }
 
@@ -903,10 +906,10 @@ class ProfileManager:
             return None
 
     def load_shopify_config(self, client_id: str) -> Optional[Dict]:
-        """Load Shopify configuration for a client with caching.
+        """Load Shopify configuration for a client with mtime-based caching.
 
-        Uses time-based caching (60 seconds) to reduce network round-trips.
-        Automatically migrates old v1 configs to v2 format.
+        Cache is invalidated by file mtime rather than TTL: no stale reads after
+        another PC saves a change, and no unnecessary re-reads while the file is stable.
 
         Args:
             client_id (str): Client ID
@@ -915,23 +918,24 @@ class ProfileManager:
             Optional[Dict]: Shopify configuration or None if not found
         """
         client_id = client_id.upper()
-        cache_key = f"shopify_{client_id}"
-
-        # Check cache first
-        if cache_key in self._config_cache:
-            cached_data, cached_time = self._config_cache[cache_key]
-            age_seconds = (datetime.now() - cached_time).total_seconds()
-
-            if age_seconds < self.CACHE_TIMEOUT_SECONDS:
-                logger.debug(f"Using cached shopify config for {client_id}")
-                return cached_data
-
-        # Load from disk
+        cache_key = f"{self.base_path}::shopify_{client_id}"
         config_path = self.clients_dir / f"CLIENT_{client_id}" / "shopify_config.json"
 
         if not config_path.exists():
             logger.warning(f"Shopify config not found: CLIENT_{client_id}")
             return None
+
+        # Check cache against current file mtime
+        try:
+            current_mtime = config_path.stat().st_mtime
+        except OSError:
+            current_mtime = None
+
+        if current_mtime is not None and cache_key in self._config_cache:
+            cached_data, cached_mtime = self._config_cache[cache_key]
+            if cached_mtime == current_mtime:
+                logger.debug(f"Using cached shopify config for {client_id}")
+                return cached_data
 
         try:
             with open(config_path, 'r', encoding='utf-8') as f:
@@ -946,12 +950,14 @@ class ProfileManager:
             migrated_sku_labels = self._migrate_add_sku_label_config(client_id, config)
 
             if migrated_mappings or migrated_delimiters or migrated_tag_categories or migrated_tag_categories_v2 or migrated_weight or migrated_sku_labels:
-                # If config was migrated, save it immediately
+                # If config was migrated, save it immediately (cache is invalidated by save)
                 self.save_shopify_config(client_id, config)
                 logger.info(f"Config migrations completed for CLIENT_{client_id}")
+                return config
 
-            # Update cache
-            self._config_cache[cache_key] = (config, datetime.now())
+            # Update cache with current mtime
+            if current_mtime is not None:
+                self._config_cache[cache_key] = (config, current_mtime)
 
             return config
 
@@ -1023,7 +1029,7 @@ class ProfileManager:
 
                 if success:
                     # Invalidate cache
-                    cache_key = f"shopify_{client_id}"
+                    cache_key = f"{self.base_path}::shopify_{client_id}"
                     self._config_cache.pop(cache_key, None)
 
                     elapsed_ms = (time.perf_counter() - start_time) * 1000

--- a/tests/test_fifo_lots.py
+++ b/tests/test_fifo_lots.py
@@ -172,7 +172,7 @@ class TestSimulateStockAllocationFifo:
         stock = _make_stock_df({"A": 10})
         prioritized = _make_prioritized(["O1"])
 
-        results, lot_allocs = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=None)
+        results, lot_allocs, _ = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=None)
         assert results["O1"]["fulfillable"] is True
         assert lot_allocs == {}
 
@@ -185,7 +185,7 @@ class TestSimulateStockAllocationFifo:
         stock = _make_stock_df({"A": 10})
         prioritized = _make_prioritized(["O1"])
 
-        results, lot_allocs = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
+        results, lot_allocs, _ = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
         assert results["O1"]["fulfillable"] is True
         assert "O1" in lot_allocs
         assert lot_allocs["O1"]["A"][0]["qty_allocated"] == 5
@@ -205,7 +205,7 @@ class TestSimulateStockAllocationFifo:
         stock = _make_stock_df({"A": 15})
         prioritized = _make_prioritized(["O1"])
 
-        results, lot_allocs = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
+        results, lot_allocs, _ = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
         assert results["O1"]["fulfillable"] is True
         alloc = lot_allocs["O1"]["A"]
         assert len(alloc) == 2
@@ -224,7 +224,7 @@ class TestSimulateStockAllocationFifo:
         stock = _make_stock_df({"A": 3})
         prioritized = _make_prioritized(["O1"])
 
-        results, lot_allocs = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
+        results, lot_allocs, _ = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
         assert results["O1"]["fulfillable"] is False
         assert "O1" not in lot_allocs
         # Stock must not be mutated on failure
@@ -236,7 +236,7 @@ class TestSimulateStockAllocationFifo:
         stock = _make_stock_df({})
         prioritized = _make_prioritized(["O1"])
 
-        results, lot_allocs = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
+        results, lot_allocs, _ = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
         assert results["O1"]["fulfillable"] is False
 
     def test_all_or_nothing_semantics(self):
@@ -252,7 +252,7 @@ class TestSimulateStockAllocationFifo:
         stock = _make_stock_df({"A": 10, "B": 0})
         prioritized = _make_prioritized(["O1"])
 
-        results, lot_allocs = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
+        results, lot_allocs, _ = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
         assert results["O1"]["fulfillable"] is False
         assert "O1" not in lot_allocs
         # A's lot must not have been decremented
@@ -270,7 +270,7 @@ class TestSimulateStockAllocationFifo:
         stock = _make_stock_df({"A": 6})
         prioritized = _make_prioritized(["O1", "O2"])
 
-        results, lot_allocs = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
+        results, lot_allocs, _ = _simulate_stock_allocation(orders, stock, prioritized, fifo_lots=fifo_lots)
         assert results["O1"]["fulfillable"] is True
         assert results["O2"]["fulfillable"] is False  # only 2 remain after O1
 

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -265,27 +265,23 @@ class TestCaching:
         assert config1 is not config2  # Different object reference
         assert config2["settings"]["low_stock_threshold"] == 10
 
-    def test_cache_expiration(self, profile_manager):
-        """Test that cache expires after timeout."""
+    def test_cache_invalidation_by_mtime(self, profile_manager):
+        """Test that cache is invalidated when file mtime changes (mtime-based cache)."""
         profile_manager.create_client_profile("M", "M Cosmetics")
 
-        # First load
+        # First load — populates cache
         config1 = profile_manager.load_shopify_config("M")
 
-        # Manually expire cache by modifying timeout
-        old_timeout = ProfileManager.CACHE_TIMEOUT_SECONDS
-        ProfileManager.CACHE_TIMEOUT_SECONDS = 0.1
+        # Advance mtime by touching the file
+        config_path = profile_manager.clients_dir / "CLIENT_M" / "shopify_config.json"
+        current_mtime = config_path.stat().st_mtime
+        import os
+        os.utime(config_path, (current_mtime + 1, current_mtime + 1))
 
-        # Wait for expiration
-        time.sleep(0.2)
-
-        # Second load (should be fresh from disk)
+        # Second load — mtime changed, should re-read from disk
         config2 = profile_manager.load_shopify_config("M")
 
-        # Restore timeout
-        ProfileManager.CACHE_TIMEOUT_SECONDS = old_timeout
-
-        # Should be different objects (cache expired)
+        # Different objects because cache was invalidated
         assert config1 is not config2
 
 


### PR DESCRIPTION
…d simplify column mapping

- profile_manager: swap 60s TTL cache for mtime-based invalidation — no stale reads after another PC saves, no unnecessary re-reads while file is stable; cache key includes base_path to prevent collisions across instances; add Expiry_Date/Batch lot columns to default stock mappings
- analysis: remove redundant "already has internal names" guard in _clean_and_prepare_data — rename maps already handle this safely via csv_col!=internal_col filter; pre-group order quantities once (O(N)) instead of per-order DataFrame scans (O(N²)); _simulate_stock_allocation now returns final_stock_dict eliminating a separate replay pass; replace pd.Series→to_dict roundtrip with dict(zip()); remove duplicate current_status assignment; reuse order_mask for existence check + status lookup in toggle_order_fulfillment
- pandas_model.py: pre-compute column indices outside hot loop using iat (~5-10x faster than iloc[i]["col"] on large DataFrames)
- tests: update for 3-tuple _simulate_stock_allocation return; replace TTL-sleep test with mtime-based invalidation test
- CLAUDE.md: add Ponytail lazy dev mode section and graphify usage rules

## Summary by Sourcery

Switch Shopify config caching to mtime-based invalidation and streamline stock analysis paths for better performance and lot tracking.

New Features:
- Include Expiry_Date and Batch lot columns in default stock column mappings and migrated configs to support lot tracking by default.

Bug Fixes:
- Prevent cache collisions across ProfileManager instances by scoping config cache keys with base_path.
- Ensure FIFO final stock computation preserves SKUs whose lots sum to zero by seeding from the original stock DataFrame.

Enhancements:
- Replace TTL-based Shopify config cache with mtime-based invalidation to avoid stale reads and unnecessary reloads.
- Optimize FIFO lot construction and stock allocation by avoiding iterrows, pre-grouping order quantities, and reusing masks and precomputed SKU sets.
- Have stock allocation return the final stock dictionary directly, removing the need for a separate replay pass in final stock calculation.
- Speed up GUI row color computation by using precomputed column indices with iat in the hot loop.
- Simplify column mapping logic by always applying default mappings and injecting lot column defaults when missing.

Documentation:
- Document a "Ponytail" lazy senior developer mode and add graphify usage rules to CLAUDE.md.

Tests:
- Update FIFO lot and analysis tests for the new _simulate_stock_allocation return signature and final stock behavior.
- Replace TTL-based cache expiry test with an mtime-based cache invalidation test for ProfileManager.