### PR TITLE
Add pytest test suite and fix bugs found while writing it

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -36,7 +36,7 @@ jobs:
         timeout-minutes: 2
         run: CI=1 python run_dev.py
       - name: Run tests (auto-enables once tests/ exists again)
-        run: if [ -d tests ]; then pytest; fi
+        run: if [ -d tests ]; then python -m pytest; fi
 
   build:
     name: Build Executable

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -36,6 +36,8 @@ jobs:
         timeout-minutes: 2
         run: CI=1 python run_dev.py
       - name: Run tests (auto-enables once tests/ exists again)
+        env:
+          QT_QPA_PLATFORM: offscreen
         run: if [ -d tests ]; then python -m pytest; fi
 
   build:

--- a/gui/bulk_operations_toolbar.py
+++ b/gui/bulk_operations_toolbar.py
@@ -150,7 +150,7 @@ class BulkOperationsToolbar(QWidget):
         layout.addWidget(self.selection_label)
 
         select_all_btn = QPushButton("Select All")
-        select_all_btn.setToolTip("Select all visible rows (respects current filter)")
+        select_all_btn.setToolTip("Select all visible rows, plus their full orders")
         select_all_btn.clicked.connect(self.select_all_clicked.emit)
         layout.addWidget(select_all_btn)
 

--- a/gui/selection_helper.py
+++ b/gui/selection_helper.py
@@ -6,7 +6,6 @@ and checkbox state for bulk operations on the Analysis Results table.
 
 from typing import List, Tuple, Set
 import pandas as pd
-from PySide6.QtCore import QModelIndex
 
 
 class SelectionHelper:
@@ -121,21 +120,34 @@ class SelectionHelper:
                 self.checked_rows.add(row)
 
     def select_all(self):
-        """Check all visible rows (respecting current filter).
+        """Check all visible rows (respecting current filter), expanded to
+        every row of the same order.
 
-        Only selects rows that are currently visible through the proxy model.
+        A filter can hide some line items of a multi-item order (e.g. a SKU
+        search). Checking only the visible rows would let a bulk action write
+        a new status/tag to part of an order while leaving its hidden
+        sibling rows on the old value. Every row sharing an Order_Number with
+        a visible row is checked too, mirroring toggle_row()'s expansion.
         """
         self.checked_rows.clear()
 
         if self.proxy_model is None:
             return
 
-        # Iterate through visible proxy rows
+        visible_rows = set()
         for proxy_row in range(self.proxy_model.rowCount()):
             proxy_index = self.proxy_model.index(proxy_row, 0)
             source_index = self.proxy_model.mapToSource(proxy_index)
-            source_row = source_index.row()
-            self.checked_rows.add(source_row)
+            visible_rows.add(source_index.row())
+
+        df = self.main_window.analysis_results_df
+        if df is None or df.empty or "Order_Number" not in df.columns:
+            self.checked_rows = visible_rows
+            return
+
+        visible_indexes = [row for row in visible_rows if row in df.index]
+        visible_orders = df.loc[visible_indexes, "Order_Number"].unique()
+        self.checked_rows = set(df[df["Order_Number"].isin(visible_orders)].index)
 
     def clear_selection(self):
         """Uncheck all rows."""

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -646,9 +646,13 @@ def _load_and_validate_files(
             inv_mem = config.get("_inventory_memory", {})
             if inv_mem.get("enabled"):
                 skus = inv_mem.get("skus") or {}
+                names = inv_mem.get("names") or {}
                 stock_df = pd.DataFrame(
-                    [{"SKU": sku, "Stock": qty} for sku, qty in skus.items()],
-                    columns=["SKU", "Stock"],
+                    [
+                        {"SKU": sku, "Product_Name": names.get(sku), "Stock": qty}
+                        for sku, qty in skus.items()
+                    ],
+                    columns=["SKU", "Product_Name", "Stock"],
                 )
                 config["_stock_from_memory"] = True
                 logger.info(f"Loaded {len(stock_df)} SKUs from inventory memory")
@@ -1104,7 +1108,21 @@ def _save_results_and_reports(
                     .apply(lambda x: max(0.0, float(x)))
                     .to_dict()
                 )
-                profile_manager.save_inventory_memory(client_id, final_stock_dict, config=full_config)
+                # Carry the display name along so the next run's memory-reconstructed
+                # stock_df doesn't show "N/A" in Warehouse_Name for every SKU.
+                # Only pass a non-empty dict -- an empty/None dict means "leave
+                # previously-saved names alone" (see save_inventory_memory), so a
+                # degraded run with no real names never wipes out good ones.
+                names_dict = None
+                if "Warehouse_Name" in final_df.columns:
+                    names_dict = {
+                        sku: name
+                        for sku, name in final_df.groupby("SKU")["Warehouse_Name"].first().items()
+                        if name and name != "N/A"
+                    } or None
+                profile_manager.save_inventory_memory(
+                    client_id, final_stock_dict, config=full_config, names_dict=names_dict
+                )
                 logger.info(f"Inventory memory updated: {len(final_stock_dict)} SKUs")
         except Exception as e:
             logger.warning(f"Failed to save inventory memory: {e}")

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -721,17 +721,24 @@ class ProfileManager:
         Returns:
             bool: True if migration was performed, False if already present
         """
-        if "inventory_memory" in config:
-            return False
+        if "inventory_memory" not in config:
+            config["inventory_memory"] = {
+                "enabled": False,
+                "skus": {},
+                "names": {},
+                "last_updated": None,
+                "total_units": 0,
+            }
+            logger.info(f"Added default 'inventory_memory' for CLIENT_{client_id}")
+            return True
 
-        config["inventory_memory"] = {
-            "enabled": False,
-            "skus": {},
-            "last_updated": None,
-            "total_units": 0,
-        }
-        logger.info(f"Added default 'inventory_memory' for CLIENT_{client_id}")
-        return True
+        # Backfill 'names' for configs saved before per-SKU name tracking existed.
+        if "names" not in config["inventory_memory"]:
+            config["inventory_memory"]["names"] = {}
+            logger.info(f"Backfilled 'inventory_memory.names' for CLIENT_{client_id}")
+            return True
+
+        return False
 
     @staticmethod
     def _create_default_shopify_config(client_id: str, client_name: str) -> Dict:
@@ -852,6 +859,7 @@ class ProfileManager:
             "inventory_memory": {
                 "enabled": False,
                 "skus": {},
+                "names": {},
                 "last_updated": None,
                 "total_units": 0,
             },
@@ -1089,8 +1097,17 @@ class ProfileManager:
 
     # --- Set/Bundle Management Methods ---
 
-    def save_inventory_memory(self, client_id: str, stock_dict: dict, config: dict = None) -> bool:
-        """Persist final stock snapshot to shopify_config inventory_memory section."""
+    def save_inventory_memory(
+        self, client_id: str, stock_dict: dict, config: dict = None, names_dict: dict = None
+    ) -> bool:
+        """Persist final stock snapshot to shopify_config inventory_memory section.
+
+        Args:
+            names_dict: Optional {sku: warehouse_display_name}. When omitted,
+                the previously-saved names are left untouched (so a caller
+                that only has quantities on hand doesn't wipe out names saved
+                by an earlier run).
+        """
         # ponytail: read-modify-write; ceiling is concurrent PC writes can still clobber
         # enabled between load and save. Upgrade: hold file lock across load+save.
         # Pass config to skip the extra disk read when the caller already holds it.
@@ -1098,13 +1115,16 @@ class ProfileManager:
             config = self.load_shopify_config(client_id) or {}
         # Use update() so enabled (and any future keys) come from the freshly loaded config
         config.setdefault("inventory_memory", {})
-        config["inventory_memory"].update({
+        updates = {
             # Keep zero-qty SKUs: dropping them shrinks old_skus overlap ratio and can
             # trigger a false 'Wrong client file?' anomaly on the next stock load.
             "skus": {str(k): float(v) for k, v in stock_dict.items()},
             "last_updated": datetime.now().isoformat(timespec="seconds"),
             "total_units": int(sum(v for v in stock_dict.values() if v > 0)),
-        })
+        }
+        if names_dict is not None:
+            updates["names"] = {str(k): str(v) for k, v in names_dict.items()}
+        config["inventory_memory"].update(updates)
         return self.save_shopify_config(client_id, config)
 
     def get_inventory_memory(self, client_id: str) -> dict:

--- a/shopify_tool/stock_export.py
+++ b/shopify_tool/stock_export.py
@@ -356,17 +356,15 @@ def merge_session_stock_exports(
 
     combined = pd.concat(all_dfs, ignore_index=True)
 
-    has_lot_details = (
-        "Lot_Details" in combined.columns
-        and combined["Lot_Details"].notna().any()
-    )
-
-    if has_lot_details:
-        result = _expand_lot_summary(combined)
-        if result.empty:
-            return _empty_export_df()
-        return result.sort_values("Артикул").reset_index(drop=True)
-
+    # Always total by SKU alone here, even when individual sessions used lot
+    # tracking (Lot_Details/Годност/Партида): sessions in this merge are
+    # already fulfilled/closed, so the specific batch each one drew from is
+    # historical record-keeping, not something a cross-session total can
+    # attribute to one row anyway. Per-lot precision for a single session's
+    # own write-off still comes from create_stock_export(), which is
+    # unaffected by this function. Splitting the SAME SKU across multiple
+    # rows here (one per distinct expiry/batch) previously contradicted this
+    # function's own contract of "grouped by SKU... summed across sessions".
     sku_summary = (
         combined.groupby("SKU")["Quantity"]
         .sum()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+"""Shared fixtures for the backend test suite.
+
+Column names mirror the DEFAULT Shopify/Bulgarian-ERP mapping hardcoded in
+shopify_tool.analysis._clean_and_prepare_data (used when column_mappings=None),
+so fixtures exercise the exact same path production runs through.
+"""
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def profile_manager(tmp_path):
+    """Real ProfileManager rooted at a throwaway tmp_path -- exercises the
+    actual file-locking/JSON read-write code path, not a mock."""
+    from shopify_tool.profile_manager import ProfileManager
+    ProfileManager._config_cache.clear()  # class-level cache; avoid cross-test leakage
+    return ProfileManager(base_path=str(tmp_path))
+
+
+@pytest.fixture
+def orders_df_factory():
+    """Build a raw orders DataFrame using real Shopify CSV export column names.
+
+    Each row is one line item. Pass rows as dicts; missing keys default sensibly.
+    Order-level columns (Name/Shipping Method/...) should be set only on an
+    order's first row and left blank on subsequent rows to mimic Shopify's
+    forward-fill export format -- pass explicit values on every row if you don't
+    want to rely on ffill.
+    """
+    def _make(rows):
+        defaults = {
+            "Name": "",
+            "Lineitem sku": "",
+            "Lineitem quantity": 1,
+            "Lineitem name": "",
+            "Shipping Method": "Standard",
+            "Shipping Country": "DE",
+            "Tags": "",
+            "Notes": "",
+        }
+        full_rows = [{**defaults, **row} for row in rows]
+        return pd.DataFrame(full_rows)
+    return _make
+
+
+@pytest.fixture
+def stock_df_factory():
+    """Build a raw stock DataFrame using real Bulgarian-ERP CSV column names."""
+    def _make(rows):
+        defaults = {"Артикул": "", "Име": "", "Наличност": 0}
+        full_rows = [{**defaults, **row} for row in rows]
+        return pd.DataFrame(full_rows)
+    return _make
+
+
+@pytest.fixture
+def empty_history_df():
+    return pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+
+
+@pytest.fixture
+def simple_orders_df(orders_df_factory):
+    """One single-item order, one two-item order."""
+    return orders_df_factory([
+        {"Name": "#1001", "Lineitem sku": "A1", "Lineitem quantity": 2},
+        {"Name": "#1002", "Lineitem sku": "B1", "Lineitem quantity": 1},
+        {"Name": "#1002", "Lineitem sku": "B2", "Lineitem quantity": 3},
+    ])
+
+
+@pytest.fixture
+def simple_stock_df(stock_df_factory):
+    return stock_df_factory([
+        {"Артикул": "A1", "Име": "Widget A1", "Наличност": 10},
+        {"Артикул": "B1", "Име": "Widget B1", "Наличност": 10},
+        {"Артикул": "B2", "Име": "Widget B2", "Наличност": 10},
+    ])

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,408 @@
+"""Core fulfillment simulation accuracy (priority #1: order dataframe accuracy).
+
+Uses the REAL default Shopify/Bulgarian-ERP column names (column_mappings=None)
+so these tests exercise exactly the code path production traffic takes.
+"""
+import pandas as pd
+import pytest
+
+from shopify_tool import analysis
+
+
+def _orders(rows):
+    defaults = {"Name": "", "Lineitem sku": "", "Lineitem quantity": 1, "Shipping Method": "Standard"}
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+def _stock(rows):
+    defaults = {"Артикул": "", "Име": "", "Наличност": 0}
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+def _history(rows=None):
+    rows = rows or []
+    return pd.DataFrame(rows, columns=["Order_Number", "Execution_Date"])
+
+
+def _run(orders_df, stock_df, history_df=None, **kwargs):
+    if history_df is None:
+        history_df = _history()
+    return analysis.run_analysis(stock_df, orders_df, history_df, **kwargs)
+
+
+class TestBasicFulfillment:
+    def test_sufficient_stock_is_fulfillable_and_deducts_exactly(self):
+        orders = _orders([{"Name": "#1001", "Lineitem sku": "A1", "Lineitem quantity": 3}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, _present, _missing, _stats = _run(orders, stock)
+        row = final_df.iloc[0]
+        assert row["Order_Fulfillment_Status"] == "Fulfillable"
+        assert row["Stock"] == 10
+        assert row["Final_Stock"] == 7
+
+    def test_insufficient_stock_is_not_fulfillable_with_reason(self):
+        orders = _orders([{"Name": "#1001", "Lineitem sku": "A1", "Lineitem quantity": 5}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 3}])
+        final_df, *_ = _run(orders, stock)
+        row = final_df.iloc[0]
+        assert row["Order_Fulfillment_Status"] == "Not Fulfillable"
+        assert "Insufficient stock" in row["System_note"]
+        assert row["Final_Stock"] == 3  # untouched -- order wasn't fulfilled
+
+    def test_zero_stock_reason_says_out_of_stock(self):
+        orders = _orders([{"Name": "#1001", "Lineitem sku": "A1", "Lineitem quantity": 1}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 0}])
+        final_df, *_ = _run(orders, stock)
+        assert "Out of stock" in final_df.iloc[0]["System_note"]
+
+    def test_sku_absent_from_stock_file_entirely_is_not_fulfillable(self):
+        orders = _orders([{"Name": "#1001", "Lineitem sku": "GHOST", "Lineitem quantity": 1}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        assert final_df.iloc[0]["Order_Fulfillment_Status"] == "Not Fulfillable"
+
+    def test_all_or_nothing_partial_order_not_fulfillable(self):
+        # Order needs A1(ok) + A2(short) -- whole order must fail, not partially ship.
+        orders = _orders([
+            {"Name": "#1001", "Lineitem sku": "A1", "Lineitem quantity": 1},
+            {"Name": "#1001", "Lineitem sku": "A2", "Lineitem quantity": 5},
+        ])
+        stock = _stock([
+            {"Артикул": "A1", "Наличност": 10},
+            {"Артикул": "A2", "Наличност": 1},
+        ])
+        final_df, *_ = _run(orders, stock)
+        assert (final_df["Order_Fulfillment_Status"] == "Not Fulfillable").all()
+        # Neither SKU should have been decremented since the order didn't ship.
+        assert final_df[final_df["SKU"] == "A1"].iloc[0]["Final_Stock"] == 10
+
+
+class TestPrioritization:
+    def test_multi_first_favors_multi_item_order_over_earlier_single_item_order(self):
+        # Only 5 units of A1 exist. #1001 (single item, needs 5) is numerically first,
+        # but #1002 (2-item order, needs 5 of A1 + 1 of B1) should win under multi_first.
+        orders = _orders([
+            {"Name": "#1001", "Lineitem sku": "A1", "Lineitem quantity": 5},
+            {"Name": "#1002", "Lineitem sku": "A1", "Lineitem quantity": 5},
+            {"Name": "#1002", "Lineitem sku": "B1", "Lineitem quantity": 1},
+        ])
+        stock = _stock([
+            {"Артикул": "A1", "Наличност": 5},
+            {"Артикул": "B1", "Наличност": 5},
+        ])
+        final_df, *_ = _run(orders, stock, mode="multi_first")
+        status_by_order = final_df.groupby("Order_Number")["Order_Fulfillment_Status"].first()
+        assert status_by_order["#1002"] == "Fulfillable"
+        assert status_by_order["#1001"] == "Not Fulfillable"
+
+    def test_fifo_mode_favors_older_order_number_regardless_of_item_count(self):
+        orders = _orders([
+            {"Name": "#1001", "Lineitem sku": "A1", "Lineitem quantity": 5},
+            {"Name": "#1002", "Lineitem sku": "A1", "Lineitem quantity": 5},
+            {"Name": "#1002", "Lineitem sku": "B1", "Lineitem quantity": 1},
+        ])
+        stock = _stock([
+            {"Артикул": "A1", "Наличност": 5},
+            {"Артикул": "B1", "Наличност": 5},
+        ])
+        final_df, *_ = _run(orders, stock, mode="fifo")
+        status_by_order = final_df.groupby("Order_Number")["Order_Fulfillment_Status"].first()
+        assert status_by_order["#1001"] == "Fulfillable"
+        assert status_by_order["#1002"] == "Not Fulfillable"
+
+    def test_priority_tie_break_uses_numeric_not_lexicographic_order_sort(self):
+        # Only 1 unit total; #9 and #10 both single-item -- numeric sort must pick #9
+        # first (lexicographic sort would incorrectly rank "#10" before "#9").
+        orders = _orders([
+            {"Name": "#10", "Lineitem sku": "A1", "Lineitem quantity": 1},
+            {"Name": "#9", "Lineitem sku": "A1", "Lineitem quantity": 1},
+        ])
+        stock = _stock([{"Артикул": "A1", "Наличност": 1}])
+        final_df, *_ = _run(orders, stock, mode="fifo")
+        status_by_order = final_df.groupby("Order_Number")["Order_Fulfillment_Status"].first()
+        assert status_by_order["#9"] == "Fulfillable"
+        assert status_by_order["#10"] == "Not Fulfillable"
+
+
+class TestSkuNormalizationAcrossFiles:
+    def test_float_artifact_sku_matches_between_orders_and_stock(self):
+        # Orders CSV keeps SKU string "5170"; stock CSV has it exported as a
+        # bare number that pandas would read as float unless dtype forced --
+        # normalize_sku must make both converge so the merge doesn't silently
+        # produce a stock-less (Not Fulfillable) result for a real match.
+        orders = _orders([{"Name": "#1", "Lineitem sku": "5170", "Lineitem quantity": 1}])
+        stock = _stock([{"Артикул": 5170.0, "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        assert final_df.iloc[0]["Order_Fulfillment_Status"] == "Fulfillable"
+        assert final_df.iloc[0]["SKU"] == "5170"
+
+    def test_leading_zero_sku_preserved_and_matched(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": "07", "Lineitem quantity": 1}])
+        stock = _stock([{"Артикул": "07", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        assert final_df.iloc[0]["SKU"] == "07"
+        assert final_df.iloc[0]["Order_Fulfillment_Status"] == "Fulfillable"
+
+
+class TestNoSkuHandling:
+    def test_blank_sku_row_marked_not_fulfillable_and_tagged(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": None, "Lineitem quantity": 1}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        row = final_df.iloc[0]
+        assert row["SKU"] == "NO_SKU"
+        assert row["Order_Fulfillment_Status"] == "Not Fulfillable"
+        assert "[NO_SKU]" in row["System_note"]
+
+    def test_no_sku_row_does_not_double_deduct_sibling_row_stock(self):
+        orders = _orders([
+            {"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 2},
+            {"Name": "#1", "Lineitem sku": None, "Lineitem quantity": 1},  # e.g. a shipping fee line
+        ])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        a1_row = final_df[final_df["SKU"] == "A1"].iloc[0]
+        no_sku_row = final_df[final_df["SKU"] == "NO_SKU"].iloc[0]
+        # NO_SKU rows are excluded from stock simulation entirely (they're
+        # metadata lines, not pickable items), so A1 is deducted by exactly its
+        # own quantity -- no phantom deduction from the NO_SKU line.
+        assert a1_row["Final_Stock"] == 8
+        # Documents actual (non-obvious) behavior: the Not-Fulfillable override
+        # for missing-SKU rows is applied PER ROW, not propagated to the whole
+        # order -- a real, stock-sufficient item on the same order still ships.
+        assert a1_row["Order_Fulfillment_Status"] == "Fulfillable"
+        assert no_sku_row["Order_Fulfillment_Status"] == "Not Fulfillable"
+
+
+class TestRepeatDetection:
+    def test_order_executed_yesterday_is_marked_repeat_with_default_window(self):
+        import datetime
+        yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+        orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 1}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        history = _history([{"Order_Number": "#1", "Execution_Date": yesterday}])
+        final_df, *_ = _run(orders, stock, history, repeat_window_days=1)
+        assert final_df.iloc[0]["System_note"] == "Repeat"
+
+    def test_order_executed_today_is_not_marked_repeat_with_default_window(self):
+        import datetime
+        today = datetime.datetime.now().strftime("%Y-%m-%d")
+        orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 1}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        history = _history([{"Order_Number": "#1", "Execution_Date": today}])
+        final_df, *_ = _run(orders, stock, history, repeat_window_days=1)
+        assert final_df.iloc[0]["System_note"] != "Repeat"
+
+    def test_unrelated_order_number_not_flagged(self):
+        import datetime
+        yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+        orders = _orders([{"Name": "#2", "Lineitem sku": "A1", "Lineitem quantity": 1}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        history = _history([{"Order_Number": "#1", "Execution_Date": yesterday}])
+        final_df, *_ = _run(orders, stock, history, repeat_window_days=1)
+        assert final_df.iloc[0]["System_note"] != "Repeat"
+
+
+class TestSetDecoderIntegration:
+    def test_set_expands_and_deducts_component_stock_not_set_sku(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": "KIT", "Lineitem quantity": 2}])
+        stock = _stock([
+            {"Артикул": "HAT", "Наличност": 10},
+            {"Артикул": "GLOVES", "Наличност": 10},
+        ])
+        column_mappings = {
+            "orders": {"Name": "Order_Number", "Lineitem sku": "SKU", "Lineitem quantity": "Quantity", "Shipping Method": "Shipping_Method"},
+            "stock": {"Артикул": "SKU", "Име": "Product_Name", "Наличност": "Stock"},
+            "set_decoders": {"KIT": [{"sku": "HAT", "quantity": 1}, {"sku": "GLOVES", "quantity": 3}]},
+        }
+        final_df, *_ = analysis.run_analysis(stock, orders, _history(), column_mappings=column_mappings)
+        assert set(final_df["SKU"]) == {"HAT", "GLOVES"}
+        hat = final_df[final_df["SKU"] == "HAT"].iloc[0]
+        gloves = final_df[final_df["SKU"] == "GLOVES"].iloc[0]
+        assert hat["Quantity"] == 2 and hat["Final_Stock"] == 8
+        assert gloves["Quantity"] == 6 and gloves["Final_Stock"] == 4
+        assert hat["Order_Fulfillment_Status"] == "Fulfillable"
+
+
+class TestCourierMapping:
+    @pytest.mark.parametrize("method, expected", [
+        ("DHL Express", "DHL"),
+        ("dpd classic", "DPD"),
+        ("International Shipping", "PostOne"),
+        ("Local Pickup", "Local Pickup"),
+    ])
+    def test_legacy_fallback_rules(self, method, expected):
+        assert analysis._generalize_shipping_method(method, None) == expected
+
+    def test_new_format_pattern_mapping(self):
+        mappings = {"DHL": {"patterns": ["dhl", "dhl express"]}}
+        assert analysis._generalize_shipping_method("DHL Express 24h", mappings) == "DHL"
+
+    def test_nan_method_returns_unknown(self):
+        assert analysis._generalize_shipping_method(float("nan"), None) == "Unknown"
+
+    def test_blank_method_returns_unknown(self):
+        assert analysis._generalize_shipping_method("   ", None) == "Unknown"
+
+
+class TestRecalculateStatistics:
+    def test_counts_and_write_off_totals(self):
+        orders = _orders([
+            {"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 2},
+            {"Name": "#2", "Lineitem sku": "A1", "Lineitem quantity": 5},
+        ])
+        stock = _stock([{"Артикул": "A1", "Наличност": 3}])
+        final_df, *_ = _run(orders, stock)
+        stats = analysis.recalculate_statistics(final_df)
+        assert stats["total_orders_completed"] == 1
+        assert stats["total_orders_not_completed"] == 1
+        assert stats["total_items_to_write_off"] == 2
+        assert stats["total_items_not_to_write_off"] == 5
+
+    def test_missing_required_column_raises(self):
+        with pytest.raises(ValueError):
+            analysis.recalculate_statistics(pd.DataFrame({"foo": [1]}))
+
+    def test_courier_stats_grouped_correctly(self):
+        orders = _orders([
+            {"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 1, "Shipping Method": "DHL Express"},
+            {"Name": "#2", "Lineitem sku": "A1", "Lineitem quantity": 1, "Shipping Method": "DPD"},
+        ])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        stats = analysis.recalculate_statistics(final_df)
+        couriers = {c["courier_id"]: c["orders_assigned"] for c in stats["couriers_stats"]}
+        assert couriers == {"DHL": 1, "DPD": 1}
+
+
+class TestToggleOrderFulfillment:
+    def _base_df(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 3}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        return final_df
+
+    def test_unfulfill_returns_stock(self):
+        df = self._base_df()
+        assert df.iloc[0]["Order_Fulfillment_Status"] == "Fulfillable"
+        assert df.iloc[0]["Final_Stock"] == 7
+        ok, err, updated = analysis.toggle_order_fulfillment(df, "#1")
+        assert ok is True
+        assert err is None
+        assert updated.iloc[0]["Order_Fulfillment_Status"] == "Not Fulfillable"
+        assert updated.iloc[0]["Final_Stock"] == 10
+
+    def test_force_fulfill_succeeds_when_stock_available(self):
+        orders = _orders([
+            {"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 20},  # unfulfillable
+        ])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        assert final_df.iloc[0]["Order_Fulfillment_Status"] == "Not Fulfillable"
+
+        # Top up final stock manually (simulating another order freeing stock) then force-fulfill.
+        final_df.loc[final_df["SKU"] == "A1", "Final_Stock"] = 25
+        ok, _err, updated = analysis.toggle_order_fulfillment(final_df, "#1")
+        assert ok is True
+        assert updated.iloc[0]["Order_Fulfillment_Status"] == "Fulfillable"
+        assert updated.iloc[0]["Final_Stock"] == 5
+
+    def test_force_fulfill_fails_cleanly_when_stock_insufficient(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 20}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        ok, err, updated = analysis.toggle_order_fulfillment(final_df, "#1")
+        assert ok is False
+        assert "Insufficient stock" in err
+        assert updated.iloc[0]["Order_Fulfillment_Status"] == "Not Fulfillable"
+        assert updated.iloc[0]["Final_Stock"] == 10  # unchanged
+
+    def test_unknown_order_number_returns_false(self):
+        df = self._base_df()
+        ok, err, _updated = analysis.toggle_order_fulfillment(df, "#DOES-NOT-EXIST")
+        assert ok is False
+        assert "not found" in err.lower()
+
+    def test_none_dataframe_returns_false(self):
+        ok, _err, _updated = analysis.toggle_order_fulfillment(None, "#1")
+        assert ok is False
+
+
+class TestFifoLotAllocation:
+    def _stock_with_lots(self, rows):
+        defaults = {"Артикул": "", "Годност": "", "Партида": "", "Наличност": 0}
+        return pd.DataFrame([{**defaults, **r} for r in rows])
+
+    def test_earliest_expiry_lot_consumed_first(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 5}])
+        stock = self._stock_with_lots([
+            {"Артикул": "A1", "Годност": "270101", "Наличност": 10},  # 2027-01-01, later
+            {"Артикул": "A1", "Годност": "260601", "Наличност": 10},  # 2026-06-01, earlier
+        ])
+        final_df, *_ = _run(orders, stock)
+        row = final_df.iloc[0]
+        assert row["Order_Fulfillment_Status"] == "Fulfillable"
+        lot_details = row["Lot_Details"]
+        assert lot_details[0]["expiry"] == "260601"
+        assert lot_details[0]["qty_allocated"] == 5
+
+    def test_order_spans_multiple_lots_when_first_lot_insufficient(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 8}])
+        stock = self._stock_with_lots([
+            {"Артикул": "A1", "Годност": "260601", "Наличност": 5},
+            {"Артикул": "A1", "Годност": "270101", "Наличност": 5},
+        ])
+        final_df, *_ = _run(orders, stock)
+        lot_details = final_df.iloc[0]["Lot_Details"]
+        assert len(lot_details) == 2
+        assert sum(l["qty_allocated"] for l in lot_details) == 8
+        assert lot_details[0]["expiry"] == "260601" and lot_details[0]["qty_allocated"] == 5
+        assert lot_details[1]["expiry"] == "270101" and lot_details[1]["qty_allocated"] == 3
+
+    def test_total_stock_aggregated_across_lots_for_display(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 1}])
+        stock = self._stock_with_lots([
+            {"Артикул": "A1", "Годност": "260601", "Наличност": 5},
+            {"Артикул": "A1", "Годност": "270101", "Наличност": 5},
+        ])
+        final_df, *_ = _run(orders, stock)
+        assert final_df.iloc[0]["Stock"] == 10
+
+
+class TestQuantityRobustness:
+    """Confirmed bugs: analysis._clean_and_prepare_data's docstring claims it
+    "Convert[s] numeric columns (Quantity, Stock)" but no such conversion exists
+    anywhere in the module -- correctness relies entirely on pandas' automatic
+    CSV dtype inference, which breaks the moment a single row is malformed."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: one non-numeric Quantity value anywhere in the whole orders "
+               "file (e.g. a stray 'abc' from a data-entry mistake) crashes the "
+               "ENTIRE analysis run with an uncaught TypeError in "
+               "_simulate_stock_allocation ('>' not supported between str and "
+               "int) -- every order in the batch fails, not just the bad row.",
+    )
+    def test_single_bad_quantity_value_does_not_crash_whole_batch(self):
+        orders = _orders([
+            {"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 2},
+            {"Name": "#2", "Lineitem sku": "A1", "Lineitem quantity": "abc"},
+        ])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)  # currently raises TypeError
+        assert final_df[final_df["Order_Number"] == "#1"].iloc[0]["Order_Fulfillment_Status"] == "Fulfillable"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: a blank/NaN Quantity cell is silently summed as 0 needed "
+               "units (pandas groupby.sum() default skipna=True) instead of "
+               "being rejected/flagged -- the order line is marked Fulfillable "
+               "and consumes zero stock even though the true requested quantity "
+               "is unknown, so a picker never gets told to pack that item and "
+               "no error surfaces anywhere.",
+    )
+    def test_blank_quantity_is_flagged_not_silently_treated_as_zero(self):
+        orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": None}])
+        stock = _stock([{"Артикул": "A1", "Наличност": 10}])
+        final_df, *_ = _run(orders, stock)
+        assert final_df.iloc[0]["Order_Fulfillment_Status"] == "Not Fulfillable"

--- a/tests/test_barcode_processor.py
+++ b/tests/test_barcode_processor.py
@@ -1,0 +1,134 @@
+"""Barcode content accuracy (priority: barcode generation accuracy).
+
+generate_barcode_label() itself renders a PNG image (not asserted pixel-by-pixel
+here); what's tested is the text/data that ends up ON the label -- the part
+that must be byte-accurate: the Code-128 payload and the info-panel fields.
+"""
+import pandas as pd
+import pytest
+from barcode.codex import Code128
+
+from shopify_tool.barcode_processor import (
+    InvalidOrderNumberError,
+    format_tags_for_barcode,
+    generate_barcode_label,
+    generate_barcodes_batch,
+    sanitize_order_number,
+)
+
+
+class TestSanitizeOrderNumber:
+    @pytest.mark.parametrize("raw, expected", [
+        ("#1029392", "#1029392"),
+        ("BG-10129", "BG-10129"),
+        ("ORDER_001", "ORDER_001"),
+        ("#12 34", "#1234"),      # internal space stripped
+        ("Ord#5!", "Ord#5"),      # punctuation stripped
+    ])
+    def test_preserves_shopify_safe_characters(self, raw, expected):
+        assert sanitize_order_number(raw) == expected
+
+    def test_empty_raises(self):
+        with pytest.raises(InvalidOrderNumberError):
+            sanitize_order_number("")
+
+    def test_all_symbols_raises(self):
+        with pytest.raises(InvalidOrderNumberError):
+            sanitize_order_number("!!!***")
+
+
+class TestSanitizedNumberEncodesFaithfullyInCode128:
+    """The whole point of sanitize_order_number is that what gets barcode-encoded
+    is EXACTLY what the packer will read back -- verify via python-barcode's own
+    get_fullcode(), which is the actual payload the scanner will decode."""
+
+    @pytest.mark.parametrize("raw", ["#1029392", "BG-10129", "ORDER_001", "12345"])
+    def test_fullcode_matches_sanitized_input_exactly(self, raw):
+        safe = sanitize_order_number(raw)
+        assert Code128(safe).get_fullcode() == safe
+
+
+class TestFormatTagsForBarcode:
+    def test_json_array_joined_with_pipe(self):
+        assert format_tags_for_barcode('["GIFT+1", "GIFT+2"]') == "GIFT+1|GIFT+2"
+
+    def test_plain_string_passthrough(self):
+        assert format_tags_for_barcode("Priority") == "Priority"
+
+    def test_empty_and_sentinel_values_return_blank(self):
+        assert format_tags_for_barcode("") == ""
+        assert format_tags_for_barcode("nan") == ""
+        assert format_tags_for_barcode("None") == ""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: analysis.py initializes EVERY order's Internal_Tags to the "
+               "JSON string '[]' (empty array). format_tags_for_barcode('[]') "
+               "should behave like the no-tags case (blank/falsy) but instead "
+               "falls through to the plain-string fallback branch and returns "
+               "the literal text '[]', which then prints on the barcode label "
+               "for essentially every untagged order.",
+    )
+    def test_empty_json_array_returns_blank_not_literal_brackets(self):
+        assert format_tags_for_barcode("[]") == ""
+
+
+class TestItemCountZeroFalsyBug:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: generate_barcodes_batch computes "
+               "`int(float(raw_count or 1))` -- Python's `or` treats a "
+               "legitimate item_count of 0 as falsy and silently substitutes 1, "
+               "so a genuinely-zero-item row prints 'SUM: 1' on the label "
+               "instead of 'SUM: 0'.",
+    )
+    def test_zero_item_count_is_not_coerced_to_one(self, tmp_path, monkeypatch):
+        captured = {}
+
+        def fake_generate_barcode_label(*, item_count, **kwargs):
+            captured["item_count"] = item_count
+            return {"success": True, "error": None}
+
+        monkeypatch.setattr(
+            "shopify_tool.barcode_processor.generate_barcode_label",
+            fake_generate_barcode_label,
+        )
+        df = pd.DataFrame([{
+            "Order_Number": "#1", "Shipping_Provider": "DHL",
+            "Destination_Country": "DE", "Internal_Tags": "[]", "item_count": 0,
+        }])
+        generate_barcodes_batch(df, tmp_path)
+        assert captured["item_count"] == 0
+
+
+class TestGenerateBarcodeLabelIntegration:
+    """Smoke test the real PNG generation path (no image-content assertions,
+    just: does it run, and does the returned metadata match input)."""
+
+    def test_generates_png_and_reports_success(self, tmp_path):
+        result = generate_barcode_label(
+            order_number="#1029392",
+            sequential_num=7,
+            courier="DHL",
+            country="DE",
+            tag="",
+            item_count=3,
+            output_dir=tmp_path,
+        )
+        assert result["success"] is True
+        assert result["file_path"].exists()
+        assert result["sequential_num"] == 7
+        assert result["item_count"] == 3
+
+    def test_invalid_order_number_reports_failure_not_exception(self, tmp_path):
+        result = generate_barcode_label(
+            order_number="!!!",
+            sequential_num=1,
+            courier="DHL",
+            country="DE",
+            tag="",
+            item_count=1,
+            output_dir=tmp_path,
+        )
+        assert result["success"] is False
+        assert result["file_path"] is None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,41 @@
+"""core.py orchestration accuracy (priority: inventory memory accuracy)."""
+import pandas as pd
+
+from shopify_tool import core
+
+_ORDERS_MAPPING = {
+    "Name": "Order_Number", "Lineitem sku": "SKU",
+    "Lineitem quantity": "Quantity", "Shipping Method": "Shipping_Method",
+}
+
+
+class TestInventoryMemoryStockReconstruction:
+    def test_reconstructed_stock_has_sku_product_name_and_stock_columns(self):
+        orders_df = pd.DataFrame([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 2, "Shipping Method": "Standard"}])
+        config = {
+            "test_orders_df": orders_df,
+            "_inventory_memory": {"enabled": True, "skus": {"A1": 8.0}},
+            "column_mappings": {"orders": _ORDERS_MAPPING, "stock": {}},
+        }
+        _orders, stock_df = core._load_and_validate_files(
+            None, None, ",", ",", config
+        )
+        assert list(stock_df.columns) == ["SKU", "Product_Name", "Stock"]
+        assert stock_df.iloc[0]["SKU"] == "A1"
+        assert stock_df.iloc[0]["Stock"] == 8.0
+
+    def test_reconstructed_stock_preserves_warehouse_name(self):
+        from shopify_tool import analysis
+
+        orders_df = pd.DataFrame([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 2, "Shipping Method": "Standard"}])
+        config = {
+            "test_orders_df": orders_df,
+            # A real inventory-memory snapshot should be able to carry the
+            # last-known product name alongside the quantity.
+            "_inventory_memory": {"enabled": True, "skus": {"A1": 8.0}, "names": {"A1": "Widget A1"}},
+            "column_mappings": {"orders": _ORDERS_MAPPING, "stock": {}},
+        }
+        _orders_clean, stock_df = core._load_and_validate_files(None, None, ",", ",", config)
+        history_df = pd.DataFrame({"Order_Number": [], "Execution_Date": []})
+        final_df, *_ = analysis.run_analysis(stock_df, orders_df, history_df)
+        assert final_df.iloc[0]["Warehouse_Name"] == "Widget A1"

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -1,0 +1,153 @@
+"""SKU normalization and order-number sort accuracy (priority: order/SKU accuracy)."""
+import pandas as pd
+import pytest
+
+from shopify_tool.csv_utils import (
+    discover_additional_columns,
+    merge_csv_files,
+    normalize_sku,
+    normalize_sku_for_matching,
+    order_number_sort_key,
+)
+
+
+class TestNormalizeSku:
+    @pytest.mark.parametrize("raw, expected", [
+        (5170.0, "5170"),
+        ("5170.0", "5170"),
+        ("5170", "5170"),
+        (" 5170 ", "5170"),
+        ("ABC-123", "ABC-123"),
+        ("07", "07"),          # leading zero preserved
+        ("07.0", "07"),        # leading zero preserved even through float artifact
+        (None, ""),
+        ("", ""),
+        ("   ", ""),
+    ])
+    def test_matches_documented_examples(self, raw, expected):
+        assert normalize_sku(raw) == expected
+
+    def test_nan_returns_empty_string(self):
+        assert normalize_sku(float("nan")) == ""
+
+    def test_pd_na_returns_empty_string(self):
+        assert normalize_sku(pd.NA) == ""
+
+
+class TestNormalizeSkuForMatching:
+    @pytest.mark.parametrize("raw, expected", [
+        (7, "7"),
+        ("07", "7"),
+        ("07.0", "7"),
+        ("0042", "42"),
+        ("ABC-123", "ABC-123"),
+        ("01-DM-0379", "01-DM-0379"),
+    ])
+    def test_matches_documented_examples(self, raw, expected):
+        assert normalize_sku_for_matching(raw) == expected
+
+    def test_leading_zero_skus_are_interchangeable(self):
+        """The whole point of this function: '07', '7', 7 must collide."""
+        assert (
+            normalize_sku_for_matching("07")
+            == normalize_sku_for_matching("7")
+            == normalize_sku_for_matching(7)
+        )
+
+    # --- BUGS found while exercising this function (see also barcode_processor) ---
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: a SKU literally 'inf'/'Infinity'/'-inf' makes float() succeed "
+               "and int(float(...)) raise an uncaught OverflowError instead of "
+               "falling back to the alphanumeric branch like other non-numeric SKUs.",
+    )
+    @pytest.mark.parametrize("raw", ["inf", "-inf", "Infinity", "INF"])
+    def test_infinity_like_sku_does_not_crash(self, raw):
+        # Every other non-numeric SKU (e.g. "ABC-123") is returned unchanged by
+        # the except-branch; a SKU that happens to spell "inf" should behave the
+        # same way, not raise OverflowError and take down whatever exclude-SKU /
+        # packing-list filter called it.
+        assert normalize_sku_for_matching(raw) == raw
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: scientific-notation-shaped SKUs (e.g. '5E3') are silently "
+               "reinterpreted as numbers via float() and mangled to '5000' instead "
+               "of being treated as an opaque alphanumeric SKU.",
+    )
+    def test_scientific_notation_sku_is_not_mangled(self):
+        assert normalize_sku_for_matching("5E3") == "5E3"
+
+
+class TestOrderNumberSortKey:
+    def test_extracts_last_digit_run(self):
+        assert order_number_sort_key("#1009") == 1009
+        assert order_number_sort_key("#1010") == 1010
+
+    def test_no_digits_returns_zero(self):
+        assert order_number_sort_key("ORDER-ABC") == 0
+
+    def test_numeric_not_lexicographic_ordering(self):
+        orders = ["#9", "#10", "#2", "#1"]
+        assert sorted(orders, key=order_number_sort_key) == ["#1", "#2", "#9", "#10"]
+
+    def test_uses_last_digit_run_when_multiple_present(self):
+        # e.g. a SKU-suffixed or dated order id -- last run is the actual sequence
+        assert order_number_sort_key("ORD-2026-045") == 45
+
+
+class TestDiscoverAdditionalColumns:
+    def test_finds_unmapped_columns(self):
+        config = {"orders": {"Name": "Order_Number", "SKU": "SKU"}}
+        df = pd.DataFrame({"Name": [1], "SKU": ["A"], "Email": ["x@y.com"]})
+        result = discover_additional_columns(df, config, [])
+        assert result == [{
+            "csv_name": "Email",
+            "internal_name": "Email",
+            "enabled": False,
+            "is_order_level": True,
+            "exists_in_df": True,
+        }]
+
+    def test_skips_columns_colliding_with_critical_internal_names(self):
+        # A CSV column literally named "Quantity" that isn't in the mapping
+        # would collide with the critical internal name -- must be skipped,
+        # not silently aliased over the real Quantity column.
+        config = {"orders": {"Name": "Order_Number"}}
+        df = pd.DataFrame({"Name": [1], "Quantity": [5]})
+        result = discover_additional_columns(df, config, [])
+        assert result == []
+
+    def test_retains_previously_configured_column_missing_from_current_csv(self):
+        config = {"orders": {"Name": "Order_Number"}}
+        df = pd.DataFrame({"Name": [1]})
+        existing = [{"csv_name": "Old_Col", "internal_name": "Old_Col", "enabled": True, "is_order_level": True}]
+        result = discover_additional_columns(df, config, existing)
+        assert result == [{
+            "csv_name": "Old_Col",
+            "internal_name": "Old_Col",
+            "enabled": True,
+            "is_order_level": True,
+            "exists_in_df": False,
+        }]
+
+
+class TestMergeCsvFiles:
+    def test_merges_and_dedupes_on_keys(self, tmp_path):
+        f1 = tmp_path / "a.csv"
+        f2 = tmp_path / "b.csv"
+        f1.write_text("Name,Lineitem sku\n#1,A1\n#2,A2\n", encoding="utf-8")
+        f2.write_text("Name,Lineitem sku\n#2,A2\n#3,A3\n", encoding="utf-8")  # #2 duplicated
+
+        merged = merge_csv_files(
+            [str(f1), str(f2)],
+            delimiter=",",
+            remove_duplicates=True,
+            duplicate_keys=["Name", "Lineitem sku"],
+        )
+        assert sorted(merged["Name"].tolist()) == ["#1", "#2", "#3"]
+
+    def test_empty_file_list_raises(self):
+        with pytest.raises(ValueError):
+            merge_csv_files([], delimiter=",")

--- a/tests/test_groups_manager.py
+++ b/tests/test_groups_manager.py
@@ -1,0 +1,102 @@
+"""Client group config accuracy (part of priority 6: app config accuracy)."""
+import threading
+import time
+
+import pytest
+
+from shopify_tool.groups_manager import GroupsManager, GroupsManagerError
+
+
+@pytest.fixture
+def groups_manager(tmp_path):
+    return GroupsManager(base_path=str(tmp_path))
+
+
+class TestBasicCrud:
+    def test_create_then_list_round_trips(self, groups_manager):
+        gid = groups_manager.create_group("Wholesale", color="#FF0000")
+        groups = groups_manager.list_groups()
+        assert len(groups) == 1
+        assert groups[0]["id"] == gid
+        assert groups[0]["name"] == "Wholesale"
+        assert groups[0]["color"] == "#FF0000"
+
+    def test_duplicate_name_rejected(self, groups_manager):
+        groups_manager.create_group("Wholesale")
+        with pytest.raises(GroupsManagerError):
+            groups_manager.create_group("wholesale")  # case-insensitive collision
+
+    def test_empty_name_rejected(self, groups_manager):
+        with pytest.raises(GroupsManagerError):
+            groups_manager.create_group("   ")
+
+    def test_display_order_appends_to_end(self, groups_manager):
+        groups_manager.create_group("A")
+        groups_manager.create_group("B")
+        groups = groups_manager.list_groups()
+        orders = sorted(g["display_order"] for g in groups)
+        assert orders == [0, 1]
+
+    def test_delete_special_group_blocked(self, groups_manager):
+        with pytest.raises(GroupsManagerError):
+            groups_manager.delete_group("pinned")
+        with pytest.raises(GroupsManagerError):
+            groups_manager.delete_group("all")
+
+    def test_update_special_group_raises_not_found(self, groups_manager):
+        # 'pinned'/'all' live in a different JSON key than 'groups', so update
+        # can never find them by id -- pinning this as the documented safe
+        # (if accidental) behavior.
+        with pytest.raises(GroupsManagerError, match="not found"):
+            groups_manager.update_group("pinned", name="Hacked")
+
+    def test_update_unknown_group_raises(self, groups_manager):
+        with pytest.raises(GroupsManagerError):
+            groups_manager.update_group("does-not-exist", name="X")
+
+
+class TestConfirmedBugs:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: create_group's duplicate-name check only scans "
+               "groups_data['groups'], never special_groups -- "
+               "create_group('Pinned') succeeds and produces a normal group "
+               "whose display name collides with the built-in 'Pinned' group.",
+    )
+    def test_create_group_colliding_with_special_group_name_is_rejected(self, groups_manager):
+        with pytest.raises(GroupsManagerError):
+            groups_manager.create_group("Pinned")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: save_groups()/create_group() only lock around the final "
+               "write, not the preceding load_groups() read -- two near-"
+               "simultaneous create_group() calls both read the same stale "
+               "snapshot, so the second writer's save clobbers the first "
+               "writer's newly-appended group even though create_group() "
+               "returned a success UUID to both callers.",
+    )
+    def test_concurrent_create_group_does_not_lose_an_update(self, groups_manager, monkeypatch):
+        original_load = groups_manager.load_groups
+
+        def slow_load():
+            data = original_load()
+            time.sleep(0.05)  # widen the read-then-write race window deterministically
+            return data
+
+        monkeypatch.setattr(groups_manager, "load_groups", slow_load)
+
+        results = {}
+
+        def _create(name):
+            results[name] = groups_manager.create_group(name)
+
+        t1 = threading.Thread(target=_create, args=("Foo",))
+        t2 = threading.Thread(target=_create, args=("Bar",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        names = {g["name"] for g in groups_manager.list_groups()}
+        assert names == {"Foo", "Bar"}

--- a/tests/test_packing_lists.py
+++ b/tests/test_packing_lists.py
@@ -1,0 +1,128 @@
+"""Packing list export accuracy: output must exactly reflect the analysis
+DataFrame (priority: packing list / export generation accuracy)."""
+import pandas as pd
+
+from shopify_tool.packing_lists import create_packing_list
+
+
+def _analysis_df(rows):
+    """Build a final_df-shaped DataFrame with sane defaults for every row."""
+    defaults = {
+        "Order_Number": "#1", "SKU": "A1", "Product_Name": "Widget",
+        "Warehouse_Name": "Widget WH", "Quantity": 1, "Stock": 10, "Final_Stock": 9,
+        "Order_Fulfillment_Status": "Fulfillable", "Shipping_Provider": "DHL",
+        "Destination_Country": "DE", "Lot_Details": None,
+    }
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+def _read_output(path):
+    return pd.read_excel(path)
+
+
+class TestFilteringAndExclusion:
+    def test_only_fulfillable_rows_included(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Order_Fulfillment_Status": "Fulfillable"},
+            {"Order_Number": "#2", "SKU": "A2", "Order_Fulfillment_Status": "Not Fulfillable"},
+        ])
+        out = tmp_path / "list.xlsx"
+        create_packing_list(df, str(out))
+        result = _read_output(out)
+        assert list(result["Order_Number"]) == ["#1"]
+
+    def test_custom_filter_by_provider(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Shipping_Provider": "DHL"},
+            {"Order_Number": "#2", "SKU": "A2", "Shipping_Provider": "DPD"},
+        ])
+        out = tmp_path / "dhl_only.xlsx"
+        create_packing_list(df, str(out), filters=[{"field": "Shipping_Provider", "operator": "==", "value": "DHL"}])
+        result = _read_output(out)
+        assert list(result["Order_Number"]) == ["#1"]
+
+    def test_exclude_skus_matches_leading_zero_variants(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "07"},
+            {"Order_Number": "#1", "SKU": "A2"},
+        ])
+        out = tmp_path / "excl.xlsx"
+        create_packing_list(df, str(out), exclude_skus=["7"])  # "7" should match SKU "07"
+        result = _read_output(out)
+        assert list(result["SKU"]) == ["A2"]
+
+    def test_no_matching_rows_does_not_create_file(self, tmp_path):
+        df = _analysis_df([{"Order_Number": "#1", "SKU": "A1", "Order_Fulfillment_Status": "Not Fulfillable"}])
+        out = tmp_path / "empty.xlsx"
+        create_packing_list(df, str(out))
+        assert not out.exists()
+
+
+class TestSortOrder:
+    def test_sorted_by_provider_priority_then_numeric_order_then_sku(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "#10", "SKU": "Z", "Shipping_Provider": "DPD"},
+            {"Order_Number": "#9", "SKU": "A", "Shipping_Provider": "DHL"},
+            {"Order_Number": "#9", "SKU": "B", "Shipping_Provider": "DHL"},
+            {"Order_Number": "#1", "SKU": "Y", "Shipping_Provider": "PostOne"},
+        ])
+        out = tmp_path / "sorted.xlsx"
+        create_packing_list(df, str(out))
+        result = _read_output(out)
+        # DHL (priority 0) rows first, sorted by numeric order# then SKU;
+        # then PostOne (1); DPD (2) last -- NOT insertion order, NOT lexicographic "#10" < "#9".
+        assert list(zip(result["Order_Number"].astype(str), result["SKU"])) == [
+            ("#9", "A"), ("#9", "B"), ("#1", "Y"), ("#10", "Z"),
+        ]
+
+
+class TestDestinationCountryDedup:
+    def test_country_shown_only_on_first_row_of_order(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Destination_Country": "DE"},
+            {"Order_Number": "#1", "SKU": "A2", "Destination_Country": "DE"},
+        ])
+        out = tmp_path / "dedup.xlsx"
+        create_packing_list(df, str(out))
+        result = _read_output(out)
+        country_col = result.columns[0]  # first column = Destination_Country (renamed header)
+        values = result[country_col].fillna("").tolist()
+        assert values[0] == "DE"
+        assert values[1] == ""
+
+
+class TestWarehouseNameFallback:
+    def test_falls_back_to_product_name_when_warehouse_name_missing(self, tmp_path):
+        df = _analysis_df([{"Order_Number": "#1", "SKU": "A1", "Product_Name": "Fallback Name"}])
+        df = df.drop(columns=["Warehouse_Name"])
+        out = tmp_path / "fallback.xlsx"
+        create_packing_list(df, str(out))
+        result = _read_output(out)
+        # Warehouse_Name column header is renamed to the output filename per the
+        # export's metadata-embedding scheme -- assert by position instead.
+        warehouse_col_idx = 3  # Destination_Country, Order_Number, SKU, Warehouse_Name, ...
+        assert result.iloc[0, warehouse_col_idx] == "Fallback Name"
+
+
+class TestLotExpansion:
+    def test_multi_lot_row_expands_and_quantities_sum_to_original(self, tmp_path):
+        lot_details = [
+            {"expiry": "260601", "batch": None, "qty_allocated": 3},
+            {"expiry": "270101", "batch": None, "qty_allocated": 2},
+        ]
+        df = _analysis_df([{"Order_Number": "#1", "SKU": "A1", "Quantity": 5, "Lot_Details": lot_details}])
+        out = tmp_path / "lots.xlsx"
+        create_packing_list(df, str(out))
+        result = _read_output(out)
+        assert len(result) == 2
+        assert result["Quantity"].sum() == 5
+        assert set(result["Lot_Expiry"].astype(str)) == {"260601", "270101"}
+
+    def test_lot_sentinel_expiry_one_renders_as_blank(self, tmp_path):
+        lot_details = [{"expiry": "1", "batch": "1", "qty_allocated": 4}]
+        df = _analysis_df([{"Order_Number": "#1", "SKU": "A1", "Quantity": 4, "Lot_Details": lot_details}])
+        out = tmp_path / "sentinel.xlsx"
+        create_packing_list(df, str(out))
+        result = _read_output(out)
+        assert result.iloc[0]["Lot_Expiry"] in ("", None) or pd.isna(result.iloc[0]["Lot_Expiry"])
+        assert result.iloc[0]["Lot_Batch"] in ("", None) or pd.isna(result.iloc[0]["Lot_Batch"])

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -1,0 +1,180 @@
+"""Client/app configuration + inventory memory accuracy (priorities 5 & 6)."""
+import json
+
+import pytest
+
+from shopify_tool.profile_manager import ProfileManager
+
+
+class TestValidateClientId:
+    @pytest.mark.parametrize("client_id", ["M", "CLIENT1", "A_B_C"])
+    def test_valid_ids_accepted(self, client_id):
+        ok, _msg = ProfileManager.validate_client_id(client_id)
+        assert ok is True
+
+    def test_rejects_client_prefix(self):
+        ok, _msg = ProfileManager.validate_client_id("CLIENT_FOO")
+        assert ok is False
+
+    def test_rejects_empty(self):
+        ok, _msg = ProfileManager.validate_client_id("")
+        assert ok is False
+
+    def test_rejects_too_long(self):
+        ok, _msg = ProfileManager.validate_client_id("X" * 21)
+        assert ok is False
+
+    def test_rejects_special_characters(self):
+        ok, _msg = ProfileManager.validate_client_id("BAD-ID!")
+        assert ok is False
+
+
+class TestClientProfileCreation:
+    def test_create_then_load_round_trips(self, profile_manager):
+        profile_manager.create_client_profile("M", "My Client")
+        config = profile_manager.load_shopify_config("M")
+        assert config["client_id"] == "M"
+        assert config["client_name"] == "My Client"
+        assert config["inventory_memory"] == {
+            "enabled": False, "skus": {}, "names": {}, "last_updated": None, "total_units": 0,
+        }
+
+    def test_duplicate_creation_returns_false_not_exception(self, profile_manager):
+        profile_manager.create_client_profile("M", "First")
+        result = profile_manager.create_client_profile("M", "Second")
+        assert result is False
+
+    def test_load_missing_client_returns_none(self, profile_manager):
+        assert profile_manager.load_shopify_config("GHOST") is None
+        assert profile_manager.load_client_config("GHOST") is None
+
+
+class TestInventoryMemoryRoundTrip:
+    def test_save_then_get_round_trips_values_as_float(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        profile_manager.save_inventory_memory("M", {"A1": 5, "B1": 3})
+        mem = profile_manager.get_inventory_memory("M")
+        assert mem["skus"] == {"A1": 5.0, "B1": 3.0}
+
+    def test_total_units_sums_only_positive_values(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        profile_manager.save_inventory_memory("M", {"A1": 5, "B1": -3, "C1": 0})
+        mem = profile_manager.get_inventory_memory("M")
+        assert mem["total_units"] == 5
+
+    def test_names_dict_round_trips(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        profile_manager.save_inventory_memory("M", {"A1": 5}, names_dict={"A1": "Widget A1"})
+        mem = profile_manager.get_inventory_memory("M")
+        assert mem["names"] == {"A1": "Widget A1"}
+
+    def test_omitting_names_dict_preserves_previously_saved_names(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        profile_manager.save_inventory_memory("M", {"A1": 5}, names_dict={"A1": "Widget A1"})
+        # A later save that only has quantities (e.g. a run whose stock source
+        # had no Product_Name column) must not wipe out the name already on file.
+        profile_manager.save_inventory_memory("M", {"A1": 6})
+        mem = profile_manager.get_inventory_memory("M")
+        assert mem["names"] == {"A1": "Widget A1"}
+        assert mem["skus"] == {"A1": 6.0}
+
+    def test_default_inventory_memory_schema_includes_names(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        mem = profile_manager.get_inventory_memory("M")
+        assert mem["names"] == {}
+
+    def test_loading_pre_upgrade_config_backfills_names_on_disk(self, profile_manager):
+        # Simulates a real client directory saved before per-SKU name tracking
+        # existed: inventory_memory is present but has no 'names' key.
+        profile_manager.create_client_profile("M", "Client")
+        config_path = profile_manager.get_client_directory("M") / "shopify_config.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        config["inventory_memory"] = {
+            "enabled": False, "skus": {"A1": 5.0}, "last_updated": None, "total_units": 5,
+        }
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+
+        loaded = profile_manager.load_shopify_config("M")
+        assert loaded["inventory_memory"]["names"] == {}
+        assert loaded["inventory_memory"]["skus"] == {"A1": 5.0}
+
+        # Backfill must have been persisted, not just patched in memory.
+        on_disk = json.loads(config_path.read_text(encoding="utf-8"))
+        assert on_disk["inventory_memory"]["names"] == {}
+
+    def test_missing_client_memory_returns_empty_dict(self, profile_manager):
+        assert profile_manager.get_inventory_memory("GHOST") == {}
+
+    # --- Confirmed bugs ---
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: save_inventory_memory() casts SKU keys with plain str(k), "
+               "never through csv_utils.normalize_sku() (used everywhere else in "
+               "this codebase, e.g. core.py's history SKU normalization). A "
+               "numeric/float SKU key is persisted as '5170.0' instead of "
+               "'5170', so it will never match the normalize_sku()'d SKU that "
+               "comes back from a real stock CSV on the next analysis run.",
+    )
+    def test_float_sku_key_is_normalized_like_everywhere_else(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        profile_manager.save_inventory_memory("M", {5170.0: 12})
+        mem = profile_manager.get_inventory_memory("M")
+        assert "5170" in mem["skus"]
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: save_inventory_memory() has no guard against an empty "
+               "stock_dict -- calling it with {} (e.g. because every row's "
+               "Final_Stock was NaN in a degenerate analysis run, see "
+               "core.py:1100-1105) silently overwrites and permanently erases "
+               "a previously-good inventory snapshot instead of being a no-op "
+               "or requiring an explicit confirmation.",
+    )
+    def test_saving_empty_stock_dict_does_not_erase_previous_snapshot(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        profile_manager.save_inventory_memory("M", {"A1": 5, "B1": 3})
+        profile_manager.save_inventory_memory("M", {})
+        mem = profile_manager.get_inventory_memory("M")
+        assert mem["skus"] == {"A1": 5.0, "B1": 3.0}
+
+
+class TestListClientsBug:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: list_clients() strips the directory prefix with "
+               "item.name.replace('CLIENT_', '') instead of a prefix-only "
+               "strip. validate_client_id() only rejects IDs that START WITH "
+               "'CLIENT_', so an id like 'ACLIENT_B' is legal, creates dir "
+               "'CLIENT_ACLIENT_B', but list_clients() replaces BOTH "
+               "occurrences of the substring and reports it as 'AB' -- a name "
+               "that doesn't round-trip through client_exists()/"
+               "get_client_directory() at all.",
+    )
+    def test_client_id_containing_client_substring_round_trips(self, profile_manager):
+        profile_manager.create_client_profile("ACLIENT_B", "Test")
+        listed = profile_manager.list_clients()
+        assert "ACLIENT_B" in listed
+        assert profile_manager.client_exists(listed[0]) is True
+
+
+class TestColumnMappingsMigrationBug:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: _migrate_column_mappings_v1_to_v2 computes is_v1 to decide "
+               "which log message to print, but then unconditionally overwrites "
+               "config['column_mappings'] with the hardcoded default Shopify/"
+               "Bulgarian template regardless of is_v1's value. Any real, valid "
+               "user-authored column_mappings dict that simply lacks the "
+               "'version' key (e.g. hand-edited, or written by an older code "
+               "path) has its actual orders/stock mapping silently discarded "
+               "and replaced by the wrong default on the very next config load.",
+    )
+    def test_unversioned_custom_mapping_is_not_silently_replaced(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        config = profile_manager.load_shopify_config("M")
+        config["column_mappings"] = {"orders": {"MyCol": "SKU"}, "stock": {"X": "Stock"}}
+        profile_manager.save_shopify_config("M", config)
+
+        reloaded = profile_manager.load_shopify_config("M")
+        assert reloaded["column_mappings"]["orders"] == {"MyCol": "SKU"}

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,201 @@
+"""RuleEngine correctness (priority: rules accuracy).
+
+Column fixtures use internal (post-analysis) column names since RuleEngine
+operates on the final_df produced by shopify_tool.analysis.run_analysis.
+"""
+import pandas as pd
+import pytest
+
+from shopify_tool.rules import RuleEngine
+from shopify_tool.tag_manager import parse_tags
+
+
+def _df(rows):
+    return pd.DataFrame(rows)
+
+
+def _rule(conditions, actions, match="ALL", level="article", priority=None, name="r"):
+    rule = {"name": name, "level": level, "steps": [
+        {"conditions": conditions, "match": match, "actions": actions}
+    ]}
+    if priority is not None:
+        rule["priority"] = priority
+    return rule
+
+
+class TestOperatorsCorrectBehavior:
+    def test_equals_numeric(self):
+        df = _df({"Quantity": [1, 2, 3]})
+        rules = [_rule([{"field": "Quantity", "operator": "equals", "value": 2}],
+                        [{"type": "ADD_TAG", "value": "TWO"}])]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", "TWO", ""]
+
+    def test_contains_case_insensitive_on_string_column(self):
+        df = _df({"Product_Name": ["Red Hat", "blue hat", "Scarf"]})
+        rules = [_rule([{"field": "Product_Name", "operator": "contains", "value": "HAT"}],
+                        [{"type": "ADD_TAG", "value": "HAT_ITEM"}])]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["HAT_ITEM", "HAT_ITEM", ""]
+
+    def test_in_list_case_insensitive_and_trimmed(self):
+        df = _df({"Shipping_Provider": ["DHL", " dpd ", "PostOne"]})
+        rules = [_rule([{"field": "Shipping_Provider", "operator": "in list", "value": "dhl, DPD"}],
+                        [{"type": "ADD_TAG", "value": "PRIORITY_COURIER"}])]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["PRIORITY_COURIER", "PRIORITY_COURIER", ""]
+
+    def test_between_numeric(self):
+        df = _df({"Final_Stock": [1, 5, 10, 50]})
+        rules = [_rule([{"field": "Final_Stock", "operator": "between", "value": "5-10"}],
+                        [{"type": "ADD_TAG", "value": "MID"}])]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", "MID", "MID", ""]
+
+    def test_is_empty_and_is_not_empty(self):
+        df = _df({"Notes": ["", "hello", None]})
+        rules = [_rule([{"field": "Notes", "operator": "is empty", "value": "x"}],
+                        [{"type": "ADD_TAG", "value": "EMPTY"}])]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["EMPTY", "", "EMPTY"]
+
+    def test_match_any_vs_all(self):
+        df = _df({"A": [1, 1, 0], "B": [0, 1, 0]})
+        any_rule = [_rule(
+            [{"field": "A", "operator": "equals", "value": 1}, {"field": "B", "operator": "equals", "value": 1}],
+            [{"type": "ADD_TAG", "value": "MATCH"}], match="ANY",
+        )]
+        out = RuleEngine(any_rule).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["MATCH", "MATCH", ""]
+
+    def test_unrecognized_operator_condition_is_skipped_not_fatal(self):
+        # Per _get_matching_rows: field/operator not found -> condition skipped,
+        # remaining conditions still apply (documented current behavior).
+        df = _df({"A": [1, 2]})
+        rules = [_rule(
+            [{"field": "A", "operator": "not_a_real_operator", "value": 1},
+             {"field": "A", "operator": "equals", "value": 1}],
+            [{"type": "ADD_TAG", "value": "X"}], match="ALL",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["X", ""]
+
+
+class TestRulePriorityAndAccumulation:
+    def test_lower_priority_number_runs_first_and_tags_accumulate(self):
+        df = _df({"Quantity": [5]})
+        rules = [
+            _rule([{"field": "Quantity", "operator": "equals", "value": 5}],
+                  [{"type": "ADD_TAG", "value": "SECOND"}], priority=2, name="second"),
+            _rule([{"field": "Quantity", "operator": "equals", "value": 5}],
+                  [{"type": "ADD_TAG", "value": "FIRST"}], priority=1, name="first"),
+        ]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out.loc[0, "Status_Note"] == "FIRST, SECOND"
+
+    def test_later_rule_set_status_overwrites_earlier_one(self):
+        df = _df({"Quantity": [5], "Order_Fulfillment_Status": ["Fulfillable"]})
+        rules = [
+            _rule([{"field": "Quantity", "operator": "equals", "value": 5}],
+                  [{"type": "SET_STATUS", "value": "A"}], priority=1),
+            _rule([{"field": "Quantity", "operator": "equals", "value": 5}],
+                  [{"type": "SET_STATUS", "value": "B"}], priority=2),
+        ]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out.loc[0, "Order_Fulfillment_Status"] == "B"
+
+    def test_add_internal_tag_deduplicates_via_tag_manager(self):
+        df = _df({"Quantity": [1], "Internal_Tags": ["[]"]})
+        rules = [_rule([{"field": "Quantity", "operator": "equals", "value": 1}],
+                        [{"type": "ADD_INTERNAL_TAG", "value": "GIFT"}])]
+        out = RuleEngine(RuleEngine(rules).rules).apply(df.copy())  # apply twice via re-run
+        out = RuleEngine(rules).apply(out)
+        assert parse_tags(out.loc[0, "Internal_Tags"]) == ["GIFT"]
+
+    def test_empty_rules_list_is_noop(self):
+        df = _df({"Quantity": [1, 2]})
+        out = RuleEngine([]).apply(df.copy())
+        pd.testing.assert_frame_equal(out, df)
+
+
+class TestConfirmedBugs:
+    """Each test encodes the behavior a reasonable user would expect; all were
+    verified to fail against current shopify_tool/rules.py before being marked
+    xfail. These serve as regression markers if/when the bug is fixed."""
+
+    @pytest.mark.xfail(strict=True, reason="BUG: 'contains'/'starts with'/'ends with' "
+                        "raise an uncaught AttributeError on numeric-dtype columns "
+                        "instead of degrading to all-False like other operators.")
+    def test_contains_on_numeric_column_does_not_crash(self):
+        df = _df({"Quantity": [1, 2, 3]})
+        rules = [_rule([{"field": "Quantity", "operator": "contains", "value": "2"}],
+                        [{"type": "ADD_TAG", "value": "X"}])]
+        out = RuleEngine(rules).apply(df.copy())  # currently raises AttributeError
+        assert out["Status_Note"].tolist() == ["", "X", ""]
+
+    @pytest.mark.xfail(strict=True, reason="BUG: 'is greater than'/'is less than'/etc "
+                        "call float(rule_val) unguarded; a blank/non-numeric rule value "
+                        "crashes the whole analysis instead of matching zero rows.")
+    def test_greater_than_with_blank_value_does_not_crash(self):
+        df = _df({"Final_Stock": [1, 2, 3]})
+        rules = [_rule([{"field": "Final_Stock", "operator": "is greater than", "value": ""}],
+                        [{"type": "ADD_TAG", "value": "X"}])]
+        out = RuleEngine(rules).apply(df.copy())  # currently raises ValueError
+        assert out["Status_Note"].tolist() == ["", "", ""]
+
+    @pytest.mark.xfail(strict=True, reason="BUG: 'not between' with a malformed/reversed "
+                        "range string (e.g. start > end) degrades the base 'between' "
+                        "check to all-False, and negating all-False matches EVERY row "
+                        "instead of zero rows.")
+    def test_not_between_with_malformed_range_matches_nothing(self):
+        df = _df({"Final_Stock": [1, 50, 999]})
+        rules = [_rule([{"field": "Final_Stock", "operator": "not between", "value": "100-10"}],
+                        [{"type": "ADD_TAG", "value": "FLAGGED"}])]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", "", ""]
+
+    @pytest.mark.xfail(strict=True, reason="BUG: 'not in list' with an empty/blank rule "
+                        "value degrades the base 'in list' check to all-False, and "
+                        "negating all-False matches EVERY row instead of zero rows -- "
+                        "a blank filter value in the UI silently tags the entire dataset.")
+    def test_not_in_list_with_empty_value_matches_nothing(self):
+        df = _df({"Shipping_Provider": ["DHL", "DPD", "PostOne"]})
+        rules = [_rule([{"field": "Shipping_Provider", "operator": "not in list", "value": ""}],
+                        [{"type": "ADD_TAG", "value": "FLAGGED"}])]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", "", ""]
+
+    @pytest.mark.xfail(strict=True, reason="BUG: an order-level rule's ADD_ORDER_TAG "
+                        "action only stamps the FIRST row of a multi-line order, not "
+                        "every row -- despite the action name implying order-wide "
+                        "application (only the literal 'ADD_TAG' type gets apply-to-all "
+                        "treatment in the order-level branch).")
+    def test_add_order_tag_applies_to_every_row_of_the_order(self):
+        df = _df({
+            "Order_Number": ["#1", "#1", "#2"],
+            "SKU": ["A", "B", "C"],
+            "Quantity": [1, 1, 1],
+            "Order_Fulfillment_Status": ["Fulfillable"] * 3,
+        })
+        rules = [_rule(
+            [{"field": "Order_Fulfillment_Status", "operator": "equals", "value": "Fulfillable"}],
+            [{"type": "ADD_ORDER_TAG", "value": "GIFT"}], level="order",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["GIFT", "GIFT", "GIFT"]
+
+    @pytest.mark.xfail(strict=True, reason="BUG: SET_MULTI_TAGS writes to Status_Note "
+                        "but is missing from _prepare_df_for_actions' needed-columns "
+                        "scan, so a rules config using ONLY SET_MULTI_TAGS crashes with "
+                        "KeyError('Status_Note') when that column doesn't already exist.")
+    def test_set_multi_tags_does_not_crash_when_status_note_column_absent(self):
+        df = _df({
+            "Order_Number": ["#1"], "SKU": ["A"], "Quantity": [1],
+            "Order_Fulfillment_Status": ["Fulfillable"],
+        })
+        rules = [_rule(
+            [{"field": "Order_Fulfillment_Status", "operator": "equals", "value": "Fulfillable"}],
+            [{"type": "SET_MULTI_TAGS", "tags": ["A", "B"]}],
+        )]
+        out = RuleEngine(rules).apply(df.copy())  # currently raises KeyError
+        assert "A" in out.loc[0, "Status_Note"]

--- a/tests/test_selection_helper.py
+++ b/tests/test_selection_helper.py
@@ -1,0 +1,58 @@
+"""Bulk-selection order-completeness (user-reported bug, fixed: bulk status
+change via a filtered "Select All" used to only touch the visible/matching
+rows, not every row of the orders they belong to -- leaving
+Order_Fulfillment_Status inconsistent across an order's own line items)."""
+import pandas as pd
+import pytest
+
+from gui.pandas_model import FulfillmentFilterProxy, PandasModel
+from gui.selection_helper import SelectionHelper
+
+
+class _FakeMainWindow:
+    def __init__(self, df):
+        self.analysis_results_df = df
+
+
+def _multi_item_orders_df():
+    return pd.DataFrame([
+        {"Order_Number": "#1", "SKU": "A1", "Quantity": 2, "Order_Fulfillment_Status": "Fulfillable"},
+        {"Order_Number": "#1", "SKU": "B1", "Quantity": 1, "Order_Fulfillment_Status": "Fulfillable"},
+        {"Order_Number": "#2", "SKU": "A1", "Quantity": 3, "Order_Fulfillment_Status": "Fulfillable"},
+    ])
+
+
+@pytest.fixture
+def proxy_filtered_to_sku_a1(qtbot):
+    df = _multi_item_orders_df()
+    model = PandasModel(df)
+    proxy = FulfillmentFilterProxy()
+    proxy.setSourceModel(model)
+    sku_col = df.columns.get_loc("SKU")
+    proxy.set_text_filter("A1", df_col=sku_col)
+    return df, proxy
+
+
+class TestToggleRowExpandsToWholeOrder:
+    def test_toggle_row_checks_every_row_of_the_order(self, qtbot):
+        df = _multi_item_orders_df()
+        helper = SelectionHelper(None, None, _FakeMainWindow(df))
+        # Row 0 is order #1's A1 line; toggling it must also check row 1 (order
+        # #1's B1 line), even though only row 0 was clicked.
+        helper.toggle_row(0)
+        assert helper.checked_rows == {0, 1}
+
+
+class TestSelectAllConfirmedBug:
+    def test_select_all_under_filter_still_covers_whole_orders(self, proxy_filtered_to_sku_a1):
+        df, proxy = proxy_filtered_to_sku_a1
+        # Sanity: the filter really did hide order #1's B1 row.
+        assert proxy.rowCount() == 2  # only the two A1 rows (order #1 and #2)
+
+        helper = SelectionHelper(None, proxy, _FakeMainWindow(df))
+        helper.select_all()
+
+        # Order #1 has two line items (A1 + B1); selecting "all" under a SKU
+        # filter should still select the WHOLE order, not just the row that
+        # happened to match the filter. Order #2's single A1 row stays too.
+        assert helper.checked_rows == {0, 1, 2}

--- a/tests/test_sequential_order.py
+++ b/tests/test_sequential_order.py
@@ -1,0 +1,111 @@
+"""Reference/sequential number generation accuracy (priority: reference number accuracy)."""
+import json
+
+import pandas as pd
+import pytest
+
+from shopify_tool.sequential_order import (
+    generate_sequential_order_map,
+    get_sequential_number,
+    load_sequential_order_map,
+    regenerate_sequential_order_map,
+)
+
+
+def _analysis_df(order_numbers, statuses=None):
+    statuses = statuses or ["Fulfillable"] * len(order_numbers)
+    return pd.DataFrame({
+        "Order_Number": order_numbers,
+        "Order_Fulfillment_Status": statuses,
+    })
+
+
+class TestGenerateSequentialOrderMap:
+    def test_assigns_one_indexed_sequence_in_natural_order(self, tmp_path):
+        df = _analysis_df(["#9", "#10", "#2", "#1"])
+        order_map = generate_sequential_order_map(df, tmp_path)
+        assert order_map == {"#1": 1, "#2": 2, "#9": 3, "#10": 4}
+
+    def test_excludes_not_fulfillable_orders(self, tmp_path):
+        df = _analysis_df(["#1", "#2"], statuses=["Fulfillable", "Not Fulfillable"])
+        order_map = generate_sequential_order_map(df, tmp_path)
+        assert order_map == {"#1": 1}
+
+    def test_persists_to_json_and_is_reused_on_second_call(self, tmp_path):
+        df = _analysis_df(["#1", "#2"])
+        first = generate_sequential_order_map(df, tmp_path)
+
+        json_path = tmp_path / "analysis" / "sequential_order.json"
+        assert json_path.exists()
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        assert data["order_sequence"] == first
+        assert data["total_orders"] == 2
+
+        # Second call with a DIFFERENT df must NOT overwrite -- numbering is
+        # meant to be stable across a session so previously printed labels
+        # stay valid.
+        different_df = _analysis_df(["#5", "#6", "#7"])
+        second = generate_sequential_order_map(different_df, tmp_path)
+        assert second == first
+
+    def test_force_regenerate_overwrites_existing_map(self, tmp_path):
+        df = _analysis_df(["#1", "#2"])
+        generate_sequential_order_map(df, tmp_path)
+        new_df = _analysis_df(["#5", "#6", "#7"])
+        result = regenerate_sequential_order_map(new_df, tmp_path)
+        assert result == {"#5": 1, "#6": 2, "#7": 3}
+
+    def test_deduplicates_repeated_order_numbers(self, tmp_path):
+        # Multi-line orders repeat the Order_Number across rows.
+        df = _analysis_df(["#1", "#1", "#2"])
+        order_map = generate_sequential_order_map(df, tmp_path)
+        assert order_map == {"#1": 1, "#2": 2}
+
+    def test_drops_nan_order_numbers(self, tmp_path):
+        df = _analysis_df(["#1", float("nan")])
+        order_map = generate_sequential_order_map(df, tmp_path)
+        assert order_map == {"#1": 1}
+
+
+class TestLoadAndLookup:
+    def test_load_missing_file_returns_empty_dict(self, tmp_path):
+        assert load_sequential_order_map(tmp_path) == {}
+
+    def test_get_sequential_number_roundtrip(self, tmp_path):
+        df = _analysis_df(["#1", "#2"])
+        generate_sequential_order_map(df, tmp_path)
+        assert get_sequential_number("#1", tmp_path) == 1
+        assert get_sequential_number("#2", tmp_path) == 2
+
+    def test_get_sequential_number_for_unknown_order_returns_none(self, tmp_path):
+        df = _analysis_df(["#1"])
+        generate_sequential_order_map(df, tmp_path)
+        assert get_sequential_number("#999", tmp_path) is None
+
+    def test_corrupt_json_returns_empty_dict_not_exception(self, tmp_path):
+        json_path = tmp_path / "analysis" / "sequential_order.json"
+        json_path.parent.mkdir(parents=True)
+        json_path.write_text("{not valid json", encoding="utf-8")
+        assert load_sequential_order_map(tmp_path) == {}
+
+
+class TestStaleMapCollisionRisk:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG (design gap): once sequential_order.json exists, "
+               "generate_sequential_order_map() returns the OLD map verbatim "
+               "and never assigns numbers to orders that only became "
+               "Fulfillable after re-analysis (e.g. a restock). Any caller "
+               "that falls back to `idx + 1` for orders missing from the map "
+               "(see barcode_processor.generate_barcodes_batch) can then "
+               "print a sequential number that collides with one already "
+               "assigned to a different order in the persisted map.",
+    )
+    def test_new_fulfillable_order_after_restock_gets_a_number(self, tmp_path):
+        df_before = _analysis_df(["#1", "#2"])
+        generate_sequential_order_map(df_before, tmp_path)
+
+        # Analysis reruns after a restock: #3 is now also Fulfillable.
+        df_after = _analysis_df(["#1", "#2", "#3"])
+        order_map = generate_sequential_order_map(df_after, tmp_path)
+        assert "#3" in order_map

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,136 @@
+"""Session lifecycle & session_info.json accuracy (part of priority 6: app config)."""
+from pathlib import Path
+
+import pytest
+
+from shopify_tool.session_manager import SessionManager, SessionManagerError
+
+
+@pytest.fixture
+def session_manager(profile_manager):
+    profile_manager.create_client_profile("M", "Test Client")
+    return SessionManager(profile_manager)
+
+
+class TestSessionCreation:
+    def test_create_session_builds_expected_subdirs(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        for subdir in SessionManager.SESSION_SUBDIRS:
+            assert (session_path / subdir).is_dir()
+        assert (session_path / "session_info.json").exists()
+
+    def test_create_session_for_unknown_client_raises(self, session_manager):
+        with pytest.raises(SessionManagerError):
+            session_manager.create_session("GHOST")
+
+    def test_second_session_same_day_increments_suffix(self, session_manager):
+        first = Path(session_manager.create_session("M"))
+        second = Path(session_manager.create_session("M"))
+        assert first != second
+        n1 = int(first.name.rsplit("_", 1)[1])
+        n2 = int(second.name.rsplit("_", 1)[1])
+        assert n2 == n1 + 1
+
+    def test_session_info_initial_status_is_active(self, session_manager):
+        session_path = session_manager.create_session("M")
+        info = session_manager.get_session_info(session_path)
+        assert info["status"] == "active"
+        assert info["client_id"] == "M"
+        assert info["analysis_completed"] is False
+
+
+class TestSessionInfoUpdates:
+    def test_update_session_info_merges_fields(self, session_manager):
+        session_path = session_manager.create_session("M")
+        session_manager.update_session_info(session_path, {"comments": "hello"})
+        info = session_manager.get_session_info(session_path)
+        assert info["comments"] == "hello"
+        assert info["status"] == "active"  # untouched fields survive
+
+    def test_update_session_status_validates_status(self, session_manager):
+        session_path = session_manager.create_session("M")
+        assert session_manager.update_session_status(session_path, "completed") is True
+        info = session_manager.get_session_info(session_path)
+        assert info["status"] == "completed"
+
+    def test_get_session_info_missing_file_returns_none(self, session_manager, tmp_path):
+        empty_dir = tmp_path / "not_a_real_session"
+        empty_dir.mkdir()
+        assert session_manager.get_session_info(str(empty_dir)) is None
+
+
+class TestDirectoryGetters:
+    def test_subdirectory_getters_point_inside_session(self, session_manager):
+        session_path = session_manager.create_session("M")
+        assert session_manager.get_input_dir(session_path) == Path(session_path) / "input"
+        assert session_manager.get_analysis_dir(session_path) == Path(session_path) / "analysis"
+        assert session_manager.get_packing_lists_dir(session_path) == Path(session_path) / "packing_lists"
+        assert session_manager.get_stock_exports_dir(session_path) == Path(session_path) / "stock_exports"
+
+
+class TestConfirmedBugs:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: update_session_info() does an unlocked read-modify-write "
+               "(get_session_info -> dict.update -> json.dump) with no file "
+               "lock. Two updates that each read the SAME on-disk snapshot "
+               "before either writes back will lose one of the two changes -- "
+               "this reproduces the exact pattern used by "
+               "core.py/create_stock_export_report and "
+               "create_packing_list_report, which both read-append-write the "
+               "'*_generated' list fields on session_info.json.",
+    )
+    def test_two_interleaved_updates_do_not_lose_either_field(self, session_manager):
+        import threading
+        import time
+
+        session_path = session_manager.create_session("M")
+
+        # update_session_info() reads session_info.json, mutates in memory, then
+        # writes it back -- with no lock spanning that read-modify-write. Widen
+        # the window deterministically so two concurrent single-field updates
+        # (exactly the pattern core.py uses for packing_lists_generated /
+        # stock_exports_generated) actually interleave instead of serializing
+        # by accident.
+        original_get_info = session_manager.get_session_info
+
+        def slow_get_info(path):
+            info = original_get_info(path)
+            time.sleep(0.05)
+            return info
+
+        barrier = threading.Barrier(2)
+
+        def _update(field, value):
+            session_manager.get_session_info = slow_get_info
+            barrier.wait()
+            session_manager.update_session_info(session_path, {field: value})
+
+        t1 = threading.Thread(target=_update, args=("packing_lists_generated", ["dhl.xlsx"]))
+        t2 = threading.Thread(target=_update, args=("stock_exports_generated", ["export.xls"]))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        session_manager.get_session_info = original_get_info
+
+        final = session_manager.get_session_info(session_path)
+        assert final["packing_lists_generated"] == ["dhl.xlsx"]
+        assert final["stock_exports_generated"] == ["export.xls"]
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: delete_session() calls shutil.rmtree(session_path_obj) "
+               "with zero validation that the path resolves under "
+               "self.sessions_root -- any caller passing a path outside the "
+               "sessions tree (e.g. from unsanitized input) can delete "
+               "arbitrary directories.",
+    )
+    def test_delete_session_refuses_path_outside_sessions_root(self, session_manager, tmp_path):
+        outside_dir = tmp_path / "not_a_session"
+        outside_dir.mkdir()
+        (outside_dir / "important.txt").write_text("do not delete me")
+
+        with pytest.raises(SessionManagerError):
+            session_manager.delete_session(str(outside_dir))
+        assert outside_dir.exists()

--- a/tests/test_set_decoder.py
+++ b/tests/test_set_decoder.py
@@ -1,0 +1,147 @@
+"""Set/bundle decode accuracy (priority: set decode accuracy)."""
+import pandas as pd
+import pytest
+
+from shopify_tool.set_decoder import (
+    decode_sets_in_orders,
+    export_sets_to_csv,
+    import_sets_from_csv,
+)
+
+
+def _orders(rows):
+    return pd.DataFrame(rows)
+
+
+class TestDecodeSetsInOrders:
+    def test_regular_sku_passes_through_with_tracking_columns(self):
+        df = _orders([{"Order_Number": "#1", "SKU": "A1", "Quantity": 2}])
+        result = decode_sets_in_orders(df, {})
+        assert result.loc[0, "SKU"] == "A1"
+        assert result.loc[0, "Quantity"] == 2
+        assert result.loc[0, "Original_SKU"] == "A1"
+        assert result.loc[0, "Original_Quantity"] == 2
+        assert result.loc[0, "Is_Set_Component"] == False
+
+    def test_set_expands_into_components_with_multiplied_quantity(self):
+        df = _orders([{"Order_Number": "#1", "SKU": "SET-A", "Quantity": 2}])
+        set_decoders = {
+            "SET-A": [
+                {"sku": "HAT", "quantity": 1},
+                {"sku": "GLOVES", "quantity": 3},
+            ]
+        }
+        result = decode_sets_in_orders(df, set_decoders)
+        assert len(result) == 2
+
+        hat = result[result["SKU"] == "HAT"].iloc[0]
+        assert hat["Quantity"] == 2 * 1
+        assert hat["Original_SKU"] == "SET-A"
+        assert hat["Original_Quantity"] == 2
+        assert hat["Is_Set_Component"] == True
+
+        gloves = result[result["SKU"] == "GLOVES"].iloc[0]
+        assert gloves["Quantity"] == 2 * 3
+
+    def test_mixed_set_and_regular_items(self):
+        df = _orders([
+            {"Order_Number": "#1", "SKU": "SET-A", "Quantity": 1},
+            {"Order_Number": "#1", "SKU": "PLAIN", "Quantity": 5},
+        ])
+        set_decoders = {"SET-A": [{"sku": "COMP", "quantity": 2}]}
+        result = decode_sets_in_orders(df, set_decoders)
+        assert len(result) == 2
+        assert set(result["SKU"]) == {"COMP", "PLAIN"}
+        plain = result[result["SKU"] == "PLAIN"].iloc[0]
+        assert plain["Quantity"] == 5
+        assert plain["Is_Set_Component"] == False
+
+    def test_component_with_zero_quantity_is_skipped(self):
+        df = _orders([{"Order_Number": "#1", "SKU": "SET-A", "Quantity": 1}])
+        set_decoders = {"SET-A": [
+            {"sku": "GOOD", "quantity": 1},
+            {"sku": "BAD", "quantity": 0},
+        ]}
+        result = decode_sets_in_orders(df, set_decoders)
+        assert list(result["SKU"]) == ["GOOD"]
+
+    def test_no_set_decoders_is_noop_passthrough(self):
+        df = _orders([{"Order_Number": "#1", "SKU": "A1", "Quantity": 4}])
+        result = decode_sets_in_orders(df, {})
+        assert list(result["SKU"]) == ["A1"]
+        assert list(result["Quantity"]) == [4]
+
+    def test_empty_dataframe_returns_empty_with_tracking_columns(self):
+        df = pd.DataFrame({"SKU": [], "Quantity": []})
+        result = decode_sets_in_orders(df, {"SET-A": [{"sku": "X", "quantity": 1}]})
+        assert result.empty
+        assert "Original_SKU" in result.columns
+        assert "Is_Set_Component" in result.columns
+
+    def test_nested_sets_are_not_recursively_expanded(self):
+        """Characterizes current behavior: a component that is itself a set SKU
+        is NOT further expanded -- decode_sets_in_orders makes a single pass.
+        If nested-set support is ever added intentionally, update this test."""
+        df = _orders([{"Order_Number": "#1", "SKU": "OUTER", "Quantity": 1}])
+        set_decoders = {
+            "OUTER": [{"sku": "INNER-SET", "quantity": 1}],
+            "INNER-SET": [{"sku": "LEAF", "quantity": 1}],
+        }
+        result = decode_sets_in_orders(df, set_decoders)
+        assert list(result["SKU"]) == ["INNER-SET"]  # NOT expanded to LEAF
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: when every component of a set is invalid (missing SKU or "
+               "non-positive quantity), the whole order line silently vanishes "
+               "from the output instead of being kept as an error/unfulfillable "
+               "row -- the customer's line item disappears with only a debug log.",
+    )
+    def test_set_with_all_invalid_components_does_not_drop_the_order_line(self):
+        df = _orders([{"Order_Number": "#1", "SKU": "SET-BROKEN", "Quantity": 1}])
+        set_decoders = {"SET-BROKEN": [{"sku": "", "quantity": 1}]}
+        result = decode_sets_in_orders(df, set_decoders)
+        # Expect the order line to survive in some form (e.g. as the original
+        # set SKU) rather than disappearing entirely.
+        assert len(result) == 1
+
+
+class TestImportExportSetsRoundTrip:
+    def test_export_then_import_round_trip(self, tmp_path):
+        set_decoders = {
+            "SET-A": [{"sku": "COMP-1", "quantity": 1}, {"sku": "COMP-2", "quantity": 2}],
+            "SET-B": [{"sku": "COMP-3", "quantity": 1}],
+        }
+        csv_path = tmp_path / "sets.csv"
+        export_sets_to_csv(set_decoders, str(csv_path))
+        result = import_sets_from_csv(str(csv_path))
+        assert result == set_decoders
+
+    def test_import_rejects_missing_columns(self, tmp_path):
+        csv_path = tmp_path / "bad.csv"
+        csv_path.write_text("Set_SKU,Component_SKU\nSET-A,COMP-1\n", encoding="utf-8")
+        with pytest.raises(ValueError):
+            import_sets_from_csv(str(csv_path))
+
+    def test_import_rejects_non_positive_quantity(self, tmp_path):
+        csv_path = tmp_path / "bad.csv"
+        csv_path.write_text(
+            "Set_SKU,Component_SKU,Component_Quantity\nSET-A,COMP-1,0\n", encoding="utf-8"
+        )
+        with pytest.raises(ValueError):
+            import_sets_from_csv(str(csv_path))
+
+    def test_import_dedupes_duplicate_pairs_keeping_last(self, tmp_path):
+        csv_path = tmp_path / "dupe.csv"
+        csv_path.write_text(
+            "Set_SKU,Component_SKU,Component_Quantity\n"
+            "SET-A,COMP-1,1\n"
+            "SET-A,COMP-1,9\n",
+            encoding="utf-8",
+        )
+        result = import_sets_from_csv(str(csv_path))
+        assert result == {"SET-A": [{"sku": "COMP-1", "quantity": 9}]}
+
+    def test_export_empty_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            export_sets_to_csv({}, str(tmp_path / "out.csv"))

--- a/tests/test_stock_export.py
+++ b/tests/test_stock_export.py
@@ -1,0 +1,162 @@
+"""Stock write-off export accuracy (priority: export generation accuracy).
+
+Output columns are positional (Артикул, blank spacer, Мярка, Брой, Годност,
+Партида) -- the warehouse ERP auto-detects them by position, so tests read
+back by column index rather than by header name.
+"""
+import pandas as pd
+import pytest
+
+from shopify_tool.stock_export import create_stock_export, merge_session_stock_exports
+
+COL_SKU, COL_BLANK, COL_UNIT, COL_QTY, COL_EXPIRY, COL_BATCH = range(6)
+
+
+def _analysis_df(rows):
+    defaults = {
+        "Order_Number": "#1", "SKU": "A1", "Quantity": 1,
+        "Order_Fulfillment_Status": "Fulfillable", "Lot_Details": None,
+    }
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+def _read(path):
+    return pd.read_excel(path, header=0, engine="xlrd")
+
+
+class TestBasicExport:
+    def test_only_fulfillable_rows_summed_by_sku(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Quantity": 3, "Order_Fulfillment_Status": "Fulfillable"},
+            {"Order_Number": "#2", "SKU": "A1", "Quantity": 2, "Order_Fulfillment_Status": "Fulfillable"},
+            {"Order_Number": "#3", "SKU": "A1", "Quantity": 100, "Order_Fulfillment_Status": "Not Fulfillable"},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out))
+        result = _read(out)
+        assert len(result) == 1
+        assert result.iloc[0, COL_SKU] == "A1"
+        assert result.iloc[0, COL_QTY] == 5
+
+    def test_canonical_column_layout(self, tmp_path):
+        df = _analysis_df([{"SKU": "A1", "Quantity": 1}])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out))
+        result = _read(out)
+        assert result.iloc[0, COL_UNIT] == "брой"
+
+    def test_multiple_skus_each_get_own_row(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Quantity": 3},
+            {"Order_Number": "#1", "SKU": "A2", "Quantity": 5},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out))
+        result = _read(out)
+        totals = dict(zip(result.iloc[:, COL_SKU], result.iloc[:, COL_QTY]))
+        assert totals == {"A1": 3, "A2": 5}
+
+    def test_custom_filter_applied(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Quantity": 3, "Shipping_Provider": "DHL"},
+            {"Order_Number": "#2", "SKU": "A2", "Quantity": 5, "Shipping_Provider": "DPD"},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out), filters=[{"field": "Shipping_Provider", "operator": "==", "value": "DHL"}])
+        result = _read(out)
+        assert list(result.iloc[:, COL_SKU]) == ["A1"]
+
+    def test_empty_result_still_writes_canonical_headers(self, tmp_path):
+        df = _analysis_df([{"Order_Fulfillment_Status": "Not Fulfillable"}])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out))
+        result = _read(out)
+        assert result.empty
+        assert list(result.columns)[COL_UNIT] == "Мярка"
+
+
+class TestLotAggregation:
+    def test_lot_details_aggregated_per_expiry_batch(self, tmp_path):
+        lot_details = [
+            {"expiry": "260601", "batch": "B1", "qty_allocated": 3},
+            {"expiry": "270101", "batch": "B2", "qty_allocated": 2},
+        ]
+        df = _analysis_df([{"Order_Number": "#1", "SKU": "A1", "Quantity": 5, "Lot_Details": lot_details}])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out))
+        result = _read(out)
+        assert len(result) == 2
+        assert result.iloc[:, COL_QTY].sum() == 5
+        assert set(result.iloc[:, COL_EXPIRY].astype(str)) == {"260601", "270101"}
+
+    def test_lot_sentinel_one_renders_blank(self, tmp_path):
+        lot_details = [{"expiry": "1", "batch": "1", "qty_allocated": 4}]
+        df = _analysis_df([{"Order_Number": "#1", "SKU": "A1", "Quantity": 4, "Lot_Details": lot_details}])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out))
+        result = _read(out)
+        expiry_val = result.iloc[0, COL_EXPIRY]
+        assert expiry_val == "" or pd.isna(expiry_val)
+
+
+class TestConfirmedBugs:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="BUG: _expand_lot_summary dedupes per-(order,SKU) allocations "
+               "using key (Order_Number, SKU) to avoid double-counting a "
+               "duplicated DataFrame row. When Order_Number is blank/missing "
+               "for more than one Fulfillable row sharing a SKU, they all "
+               "collapse to the same ('', SKU) key -- every allocation after "
+               "the first is silently dropped from the write-off export, "
+               "understating the real quantity to deduct from the ERP.",
+    )
+    def test_missing_order_number_does_not_drop_distinct_lot_allocations(self, tmp_path):
+        df = _analysis_df([
+            {"Order_Number": "", "SKU": "A1", "Quantity": 3,
+             "Lot_Details": [{"expiry": "260601", "batch": None, "qty_allocated": 3}]},
+            {"Order_Number": "", "SKU": "A1", "Quantity": 2,
+             "Lot_Details": [{"expiry": "270101", "batch": None, "qty_allocated": 2}]},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out))
+        result = _read(out)
+        assert result.iloc[:, COL_QTY].sum() == 5  # currently only 3 (first row wins)
+
+
+class TestMergeSessionStockExportsBug:
+    """User-reported, fixed: merging stock exports from multiple sessions
+    (session browser's "merge stock exports" action) used to not sum matching
+    SKUs into one row -- the same SKU could appear on several rows."""
+
+    def _write_session(self, session_dir, rows):
+        analysis_dir = session_dir / "analysis"
+        analysis_dir.mkdir(parents=True)
+        df = pd.DataFrame([{
+            "Order_Number": "#1", "SKU": "A1", "Quantity": 1,
+            "Order_Fulfillment_Status": "Fulfillable", "Lot_Details": None,
+            **row,
+        } for row in rows])
+        df.to_pickle(analysis_dir / "current_state.pkl")
+
+    def test_same_sku_without_lot_tracking_sums_into_one_row(self, tmp_path):
+        s1, s2 = tmp_path / "s1", tmp_path / "s2"
+        self._write_session(s1, [{"SKU": "A1", "Quantity": 3}])
+        self._write_session(s2, [{"SKU": "A1", "Quantity": 2}])
+        result = merge_session_stock_exports([s1, s2], client_id="TEST")
+        assert len(result[result.iloc[:, COL_SKU] == "A1"]) == 1
+        assert result.iloc[0, COL_QTY] == 5
+
+    def test_same_sku_from_different_lots_across_sessions_still_summed(self, tmp_path):
+        s1, s2 = tmp_path / "s1", tmp_path / "s2"
+        self._write_session(s1, [{
+            "SKU": "A1", "Quantity": 3,
+            "Lot_Details": [{"expiry": "260601", "batch": "B1", "qty_allocated": 3}],
+        }])
+        self._write_session(s2, [{
+            "SKU": "A1", "Quantity": 2,
+            "Lot_Details": [{"expiry": "270101", "batch": "B2", "qty_allocated": 2}],
+        }])
+        result = merge_session_stock_exports([s1, s2], client_id="TEST")
+        a1_rows = result[result.iloc[:, COL_SKU] == "A1"]
+        assert len(a1_rows) == 1
+        assert a1_rows.iloc[0, COL_QTY] == 5


### PR DESCRIPTION
Builds a real test suite from scratch (conftest.py + 13 test files, ~2000 lines) using real fixtures against tmp_path instead of mocks, per CLAUDE.md's stated direction of replacing the previous "no tests" state.

While writing tests, found and fixed 4 production bugs, each with a regression test:
- selection_helper.select_all() only checked filter-visible rows, leaving hidden sibling line-items of a multi-item order unchecked during a bulk action; now expands to full orders like toggle_row().
- inventory_memory now persists a per-SKU names dict alongside quantities, so stock reconstructed from memory doesn't show "N/A" for Warehouse_Name; includes schema migration/backfill for existing configs.
- merge_session_stock_exports() always totals by SKU now instead of branching into per-lot rows, since sessions being merged are already closed and cross-session lot attribution isn't meaningful.

8 additional pre-existing bugs discovered along the way (SKU normalization gaps, unlocked read-modify-write races, a path-handling gap in delete_session, etc.) are documented as strict xfail tests with root-cause reasons rather than fixed out of scope.

## Summary by Sourcery

Add a real pytest-based backend test suite and align core inventory memory, selection, and export behaviors with intended production semantics.

New Features:
- Introduce a comprehensive pytest test suite covering analysis, rules, stock exports, packing lists, barcode processing, inventory memory, sessions, sets, CSV utilities, selection behavior, and sequential numbering.

Bug Fixes:
- Ensure inventory memory schema includes per-SKU display names and backfills missing names for existing client configs so reconstructed stock retains Warehouse_Name.
- Update bulk selection to expand filtered "Select All" operations to all line items belonging to the same orders, preventing partial-order status changes.
- Change merged session stock exports to always aggregate quantities by SKU across sessions instead of splitting rows per lot, matching the documented merge contract.

Enhancements:
- Extend inventory memory persistence to optionally store and preserve per-SKU warehouse display names alongside quantities, and use them when reconstructing stock data.
- Refine the selection UI tooltip text to describe full-order selection behavior.
- Improve core stock reconstruction from inventory memory to emit SKU, Product_Name, and Stock columns consistent with downstream analysis expectations.

Tests:
- Add extensive regression and xfail tests across core modules to encode current behavior, document known bugs, and prevent future regressions in analysis, rules, stock export, packing lists, barcode labels, profile/session/groups management, CSV utilities, and set decoding.