### PR TITLE
Fix all 23 confirmed bugs behind the xfail test suite, plus 2 more fo…

### DIFF
--- a/shopify_tool/analysis.py
+++ b/shopify_tool/analysis.py
@@ -313,6 +313,17 @@ def _clean_and_prepare_data(
     logger.info(f"Columns existing in DataFrame: {len(columns_to_keep_existing)}")
     orders_clean_df = orders_df[columns_to_keep_existing].copy()
 
+    # CRITICAL: Coerce Quantity to numeric. Without this, a single stray
+    # non-numeric value (e.g. a data-entry typo) leaves the whole column
+    # object-dtype, and a later "> " comparison in _simulate_stock_allocation
+    # crashes with TypeError for the entire batch, not just the bad row.
+    # Invalid/blank values become NaN so they can be explicitly flagged
+    # instead of silently summing to a phantom zero.
+    if "Quantity" in orders_clean_df.columns:
+        orders_clean_df["Quantity"] = pd.to_numeric(
+            orders_clean_df["Quantity"], errors="coerce"
+        )
+
     # Mark rows without SKU but keep them (don't drop)
     orders_clean_df["Has_SKU"] = orders_clean_df["SKU"].notna()
 
@@ -530,6 +541,17 @@ def _simulate_stock_allocation(
         for order_num, grp in orders_for_simulation.groupby("Order_Number")
     }
 
+    # Orders with a NaN Quantity (blank cell or failed numeric coercion) must
+    # not be silently treated as needing zero units -- groupby.sum() skips
+    # NaN, so an order whose only line item is invalid would otherwise look
+    # like a legitimate zero-quantity order and get marked Fulfillable.
+    invalid_qty_rows = orders_for_simulation[orders_for_simulation["Quantity"].isna()]
+    invalid_qty_by_order: Dict[str, List[str]] = (
+        invalid_qty_rows.groupby("Order_Number")["SKU"].apply(list).to_dict()
+        if not invalid_qty_rows.empty
+        else {}
+    )
+
     fulfillment_results = {}
 
     if fifo_lots is None:
@@ -539,6 +561,16 @@ def _simulate_stock_allocation(
         lot_allocations: Dict[str, Dict[str, List[dict]]] = {}
 
         for order_number in prioritized_orders["Order_Number"]:
+            if order_number in invalid_qty_by_order:
+                fulfillment_results[order_number] = {
+                    "fulfillable": False,
+                    "reason": "; ".join(
+                        f"{sku}: Missing/invalid quantity"
+                        for sku in invalid_qty_by_order[order_number]
+                    ),
+                }
+                continue
+
             required_quantities = order_required_quantities.get(order_number)
             if required_quantities is None:
                 continue
@@ -575,6 +607,16 @@ def _simulate_stock_allocation(
         lot_allocations = {}
 
         for order_number in prioritized_orders["Order_Number"]:
+            if order_number in invalid_qty_by_order:
+                fulfillment_results[order_number] = {
+                    "fulfillable": False,
+                    "reason": "; ".join(
+                        f"{sku}: Missing/invalid quantity"
+                        for sku in invalid_qty_by_order[order_number]
+                    ),
+                }
+                continue
+
             required_quantities = order_required_quantities.get(order_number)
             if required_quantities is None:
                 continue

--- a/shopify_tool/barcode_processor.py
+++ b/shopify_tool/barcode_processor.py
@@ -170,8 +170,8 @@ def format_tags_for_barcode(internal_tag: str) -> str:
     try:
         if internal_tag.startswith('[') and internal_tag.endswith(']'):
             tags_list = json.loads(internal_tag)
-            if isinstance(tags_list, list) and tags_list:
-                # Join all tags with pipe separator
+            if isinstance(tags_list, list):
+                # Join all tags with pipe separator (empty list -> "")
                 return '|'.join(str(tag).strip() for tag in tags_list if tag)
     except (json.JSONDecodeError, ValueError):
         pass
@@ -568,7 +568,9 @@ def generate_barcodes_batch(
         if pd.isna(raw_count):
             raw_count = row.get('Quantity', 1)
         try:
-            item_count = int(float(raw_count or 1))
+            # Do not use `raw_count or 1` -- a genuinely-zero item_count is
+            # falsy in Python and would be wrongly coerced to 1.
+            item_count = int(float(raw_count))
         except (ValueError, TypeError):
             item_count = 1
 

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -1367,13 +1367,9 @@ def create_packing_list_report(
         # Update session info if in session mode
         if session_manager and session_path:
             try:
-                session_info = session_manager.get_session_info(session_path)
-                generated_lists = session_info.get("packing_lists_generated", [])
-                if original_filename not in generated_lists:
-                    generated_lists.append(original_filename)
-                    session_manager.update_session_info(
-                        session_path, {"packing_lists_generated": generated_lists}
-                    )
+                if session_manager.append_to_session_list(
+                    session_path, "packing_lists_generated", original_filename
+                ):
                     logger.info(
                         f"Session info updated: added packing list {original_filename}"
                     )
@@ -1491,13 +1487,9 @@ def create_stock_export_report(
         # Update session info if in session mode
         if session_manager and session_path:
             try:
-                session_info = session_manager.get_session_info(session_path)
-                generated_exports = session_info.get("stock_exports_generated", [])
-                if original_filename not in generated_exports:
-                    generated_exports.append(original_filename)
-                    session_manager.update_session_info(
-                        session_path, {"stock_exports_generated": generated_exports}
-                    )
+                if session_manager.append_to_session_list(
+                    session_path, "stock_exports_generated", original_filename
+                ):
                     logger.info(
                         f"Session info updated: added stock export {original_filename}"
                     )
@@ -1585,13 +1577,9 @@ def create_writeoff_report(
         # Update session info if in session mode
         if session_manager and session_path:
             try:
-                session_info = session_manager.get_session_info(session_path)
-                generated_reports = session_info.get("writeoff_reports_generated", [])
-                if original_filename not in generated_reports:
-                    generated_reports.append(original_filename)
-                    session_manager.update_session_info(
-                        session_path, {"writeoff_reports_generated": generated_reports}
-                    )
+                if session_manager.append_to_session_list(
+                    session_path, "writeoff_reports_generated", original_filename
+                ):
                     logger.info(
                         f"Session info updated: added writeoff report {original_filename}"
                     )

--- a/shopify_tool/csv_utils.py
+++ b/shopify_tool/csv_utils.py
@@ -274,16 +274,19 @@ def normalize_sku_for_matching(sku: Any) -> str:
     if not normalized:
         return normalized
 
-    try:
-        # Try to parse as pure number and remove leading zeros
-        # "07" → 7 → "7"
-        # "0042" → 42 → "42"
-        return str(int(float(normalized)))
-    except (ValueError, TypeError):
-        # Not a pure number (alphanumeric), return as-is
-        # "ABC-123" stays "ABC-123"
-        # "01-DM-0379" stays "01-DM-0379" (contains non-numeric)
-        return normalized
+    # Only strip leading zeros for a PURE digit string (optionally signed).
+    # float()/int() would also accept "inf"/"Infinity" (raising an uncaught
+    # OverflowError on int(float("inf"))) and scientific notation like "5E3"
+    # (silently mangled to "5000") -- neither is a real numeric SKU.
+    # "07" → "7", "0042" → "42"
+    if normalized.lstrip('-').isdigit():
+        return str(int(normalized))
+
+    # Not a pure number (alphanumeric), return as-is
+    # "ABC-123" stays "ABC-123"
+    # "01-DM-0379" stays "01-DM-0379" (contains non-numeric)
+    # "inf"/"5E3" stay as-is too (not real numeric SKUs)
+    return normalized
 
 
 def merge_csv_files(

--- a/shopify_tool/groups_manager.py
+++ b/shopify_tool/groups_manager.py
@@ -11,6 +11,7 @@ Key Features:
     - UUID-based group identification
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -305,6 +306,44 @@ class GroupsManager:
         except Exception as e:
             logger.warning(f"Failed to create backup: {e}")
 
+    @contextlib.contextmanager
+    def _locked_groups_rmw(self):
+        """Blocking exclusive lock spanning a groups.json load-modify-save cycle.
+
+        save_groups() only locks around its own write; without this, two
+        near-simultaneous create/update/delete calls can each load the same
+        stale snapshot and the second save silently clobbers the first.
+        """
+        lock_path = self.groups_path.with_suffix(".lock")
+        lock_file = open(lock_path, "a+")
+        try:
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            finally:
+                lock_file.close()
+
+    @staticmethod
+    def _name_collides_with_special_group(groups_data: Dict[str, Any], name: str) -> bool:
+        special_groups = groups_data.get("special_groups", {})
+        return any(
+            special.get("name", "").lower() == name.lower()
+            for special in special_groups.values()
+        )
+
     def create_group(self, name: str, color: str = "#2196F3") -> str:
         """Create new group.
 
@@ -323,41 +362,44 @@ class GroupsManager:
 
         name = name.strip()
 
-        # Load current groups
-        groups_data = self.load_groups()
+        with self._locked_groups_rmw():
+            # Load current groups
+            groups_data = self.load_groups()
 
-        # Check for duplicate name
-        for group in groups_data.get("groups", []):
-            if group.get("name", "").lower() == name.lower():
+            # Check for duplicate name (including built-in special groups)
+            if self._name_collides_with_special_group(groups_data, name):
                 raise GroupsManagerError(f"Group with name '{name}' already exists")
+            for group in groups_data.get("groups", []):
+                if group.get("name", "").lower() == name.lower():
+                    raise GroupsManagerError(f"Group with name '{name}' already exists")
 
-        # Generate UUID
-        group_id = str(uuid.uuid4())
+            # Generate UUID
+            group_id = str(uuid.uuid4())
 
-        # Calculate display_order (append to end)
-        max_order = -1
-        for group in groups_data.get("groups", []):
-            order = group.get("display_order", 0)
-            if order > max_order:
-                max_order = order
-        display_order = max_order + 1
+            # Calculate display_order (append to end)
+            max_order = -1
+            for group in groups_data.get("groups", []):
+                order = group.get("display_order", 0)
+                if order > max_order:
+                    max_order = order
+            display_order = max_order + 1
 
-        # Create new group
-        new_group = {
-            "id": group_id,
-            "name": name,
-            "color": color,
-            "display_order": display_order,
-            "created_at": datetime.now().isoformat()
-        }
+            # Create new group
+            new_group = {
+                "id": group_id,
+                "name": name,
+                "color": color,
+                "display_order": display_order,
+                "created_at": datetime.now().isoformat()
+            }
 
-        groups_data["groups"].append(new_group)
+            groups_data["groups"].append(new_group)
 
-        # Save
-        self.save_groups(groups_data)
-        logger.info(f"Group created: {name} (ID: {group_id})")
+            # Save
+            self.save_groups(groups_data)
+            logger.info(f"Group created: {name} (ID: {group_id})")
 
-        return group_id
+            return group_id
 
     def update_group(self, group_id: str, name: str = None, color: str = None) -> bool:
         """Update existing group.
@@ -373,40 +415,43 @@ class GroupsManager:
         Raises:
             GroupsManagerError: If group doesn't exist or name is duplicate
         """
-        # Load current groups
-        groups_data = self.load_groups()
+        with self._locked_groups_rmw():
+            # Load current groups
+            groups_data = self.load_groups()
 
-        # Find group
-        target_group = None
-        for group in groups_data.get("groups", []):
-            if group.get("id") == group_id:
-                target_group = group
-                break
-
-        if target_group is None:
-            raise GroupsManagerError(f"Group with ID '{group_id}' not found")
-
-        # Check for duplicate name if updating name
-        if name is not None:
-            name = name.strip()
-            if not name:
-                raise GroupsManagerError("Group name cannot be empty")
-
+            # Find group
+            target_group = None
             for group in groups_data.get("groups", []):
-                if group.get("id") != group_id and group.get("name", "").lower() == name.lower():
+                if group.get("id") == group_id:
+                    target_group = group
+                    break
+
+            if target_group is None:
+                raise GroupsManagerError(f"Group with ID '{group_id}' not found")
+
+            # Check for duplicate name if updating name
+            if name is not None:
+                name = name.strip()
+                if not name:
+                    raise GroupsManagerError("Group name cannot be empty")
+
+                if self._name_collides_with_special_group(groups_data, name):
                     raise GroupsManagerError(f"Group with name '{name}' already exists")
+                for group in groups_data.get("groups", []):
+                    if group.get("id") != group_id and group.get("name", "").lower() == name.lower():
+                        raise GroupsManagerError(f"Group with name '{name}' already exists")
 
-            target_group["name"] = name
+                target_group["name"] = name
 
-        # Update color if provided
-        if color is not None:
-            target_group["color"] = color
+            # Update color if provided
+            if color is not None:
+                target_group["color"] = color
 
-        # Save
-        self.save_groups(groups_data)
-        logger.info(f"Group updated: {group_id}")
+            # Save
+            self.save_groups(groups_data)
+            logger.info(f"Group updated: {group_id}")
 
-        return True
+            return True
 
     def delete_group(self, group_id: str, profile_manager = None) -> bool:
         """Delete group and unassign all clients.
@@ -426,38 +471,39 @@ class GroupsManager:
         if group_id in ["pinned", "all"]:
             raise GroupsManagerError(f"Cannot delete special group: {group_id}")
 
-        # Load current groups
-        groups_data = self.load_groups()
+        with self._locked_groups_rmw():
+            # Load current groups
+            groups_data = self.load_groups()
 
-        # Check if group exists
-        group_exists = any(group.get("id") == group_id for group in groups_data.get("groups", []))
-        if not group_exists:
-            raise GroupsManagerError(f"Group with ID '{group_id}' not found")
+            # Check if group exists
+            group_exists = any(group.get("id") == group_id for group in groups_data.get("groups", []))
+            if not group_exists:
+                raise GroupsManagerError(f"Group with ID '{group_id}' not found")
 
-        # Unassign clients from this group
-        if profile_manager:
-            clients_in_group = self.get_clients_in_group(group_id, profile_manager)
+            # Unassign clients from this group
+            if profile_manager:
+                clients_in_group = self.get_clients_in_group(group_id, profile_manager)
 
-            for client_id in clients_in_group:
-                try:
-                    config = profile_manager.load_client_config(client_id)
-                    if config and "ui_settings" in config:
-                        if config["ui_settings"].get("group_id") == group_id:
-                            config["ui_settings"]["group_id"] = None
-                            profile_manager.save_client_config(client_id, config)
-                            logger.info(f"Unassigned CLIENT_{client_id} from group {group_id}")
-                except Exception as e:
-                    logger.error(f"Failed to unassign CLIENT_{client_id}: {e}")
-                    # Continue with other clients
+                for client_id in clients_in_group:
+                    try:
+                        config = profile_manager.load_client_config(client_id)
+                        if config and "ui_settings" in config:
+                            if config["ui_settings"].get("group_id") == group_id:
+                                config["ui_settings"]["group_id"] = None
+                                profile_manager.save_client_config(client_id, config)
+                                logger.info(f"Unassigned CLIENT_{client_id} from group {group_id}")
+                    except Exception as e:
+                        logger.error(f"Failed to unassign CLIENT_{client_id}: {e}")
+                        # Continue with other clients
 
-        # Remove group from groups.json
-        groups_data["groups"] = [g for g in groups_data["groups"] if g.get("id") != group_id]
+            # Remove group from groups.json
+            groups_data["groups"] = [g for g in groups_data["groups"] if g.get("id") != group_id]
 
-        # Save
-        self.save_groups(groups_data)
-        logger.info(f"Group deleted: {group_id}")
+            # Save
+            self.save_groups(groups_data)
+            logger.info(f"Group deleted: {group_id}")
 
-        return True
+            return True
 
     def get_group(self, group_id: str) -> Optional[Dict[str, Any]]:
         """Get group by ID.

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -255,7 +255,7 @@ class ProfileManager:
             clients = []
             for item in self.clients_dir.iterdir():
                 if item.is_dir() and item.name.startswith("CLIENT_"):
-                    client_id = item.name.replace("CLIENT_", "")
+                    client_id = item.name[len("CLIENT_"):]
                     clients.append(client_id)
 
             return sorted(clients)
@@ -381,18 +381,15 @@ class ProfileManager:
         is_v1 = (
             "orders_required" in column_mappings or "stock_required" in column_mappings
         )
+        # A dict that already has 'orders'/'stock' mapping keys is v2-shaped --
+        # it's just missing the 'version' tag (e.g. hand-edited, or written by
+        # an older code path). Its real mapping must be preserved, not
+        # silently discarded for the hardcoded default.
+        looks_like_v2_shape = isinstance(column_mappings, dict) and (
+            "orders" in column_mappings or "stock" in column_mappings
+        )
 
-        if not is_v1:
-            # Unknown format, assume it needs migration
-            logger.warning(
-                f"Unknown column_mappings format for CLIENT_{client_id}, applying default v2"
-            )
-
-        # Migrate to v2 with default Shopify/Bulgarian mappings
-        logger.info(f"Migrating column mappings v1 → v2 for CLIENT_{client_id}")
-
-        # Use default mappings (Shopify orders + Bulgarian stock)
-        new_mappings = {
+        default_mappings = {
             "version": 2,
             "orders": {
                 "Name": "Order_Number",
@@ -415,8 +412,22 @@ class ProfileManager:
             },
         }
 
-        # Replace old mappings with new
-        config["column_mappings"] = new_mappings
+        if is_v1:
+            # True v1 format stores required-column lists, not an actual
+            # field mapping -- the hardcoded default is the only sensible migration.
+            logger.info(f"Migrating column mappings v1 → v2 for CLIENT_{client_id}")
+            config["column_mappings"] = default_mappings
+        elif looks_like_v2_shape:
+            logger.info(
+                f"Stamping missing 'version' on existing column_mappings for CLIENT_{client_id}"
+            )
+            column_mappings["version"] = 2
+            config["column_mappings"] = column_mappings
+        else:
+            logger.warning(
+                f"Unknown column_mappings format for CLIENT_{client_id}, applying default v2"
+            )
+            config["column_mappings"] = default_mappings
 
         # Add migration metadata
         config["_migration_info"] = {
@@ -1108,6 +1119,13 @@ class ProfileManager:
                 that only has quantities on hand doesn't wipe out names saved
                 by an earlier run).
         """
+        if not stock_dict:
+            logger.warning(
+                f"save_inventory_memory called with an empty stock_dict for "
+                f"CLIENT_{client_id}; skipping to avoid erasing the existing snapshot"
+            )
+            return False
+
         # ponytail: read-modify-write; ceiling is concurrent PC writes can still clobber
         # enabled between load and save. Upgrade: hold file lock across load+save.
         # Pass config to skip the extra disk read when the caller already holds it.
@@ -1115,10 +1133,12 @@ class ProfileManager:
             config = self.load_shopify_config(client_id) or {}
         # Use update() so enabled (and any future keys) come from the freshly loaded config
         config.setdefault("inventory_memory", {})
+        from .csv_utils import normalize_sku
+
         updates = {
             # Keep zero-qty SKUs: dropping them shrinks old_skus overlap ratio and can
             # trigger a false 'Wrong client file?' anomaly on the next stock load.
-            "skus": {str(k): float(v) for k, v in stock_dict.items()},
+            "skus": {normalize_sku(k): float(v) for k, v in stock_dict.items()},
             "last_updated": datetime.now().isoformat(timespec="seconds"),
             "total_units": int(sum(v for v in stock_dict.values() if v > 0)),
         }

--- a/shopify_tool/rules.py
+++ b/shopify_tool/rules.py
@@ -100,45 +100,76 @@ def _op_not_equals(series_val, rule_val):
         return series_val != rule_val
 
 
+def _as_str_series(series_val):
+    """Coerce a numeric-dtype Series to string so .str accessors don't crash.
+
+    Non-numeric (object/string) Series are returned unchanged to preserve
+    their existing NaN handling via each operator's na=False.
+    """
+    if pd.api.types.is_numeric_dtype(series_val):
+        return series_val.astype(str)
+    return series_val
+
+
 def _op_contains(series_val, rule_val):
     """Returns True where the series string contains the rule string (case-insensitive)."""
     # Case-insensitive containment check for strings
-    return series_val.str.contains(rule_val, case=False, na=False)
+    return _as_str_series(series_val).str.contains(rule_val, case=False, na=False)
 
 
 def _op_not_contains(series_val, rule_val):
     """Returns True where the series string does not contain the rule string (case-insensitive)."""
-    return ~series_val.str.contains(rule_val, case=False, na=False)
+    return ~_as_str_series(series_val).str.contains(rule_val, case=False, na=False)
+
+
+def _safe_float(value):
+    """Returns float(value), or None if value is blank/non-numeric."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _op_greater_than(series_val, rule_val):
     """Returns True where the series value is greater than the numeric rule value."""
-    return pd.to_numeric(series_val, errors="coerce") > float(rule_val)
+    threshold = _safe_float(rule_val)
+    if threshold is None:
+        return pd.Series([False] * len(series_val), index=series_val.index)
+    return pd.to_numeric(series_val, errors="coerce") > threshold
 
 
 def _op_less_than(series_val, rule_val):
     """Returns True where the series value is less than the numeric rule value."""
-    return pd.to_numeric(series_val, errors="coerce") < float(rule_val)
+    threshold = _safe_float(rule_val)
+    if threshold is None:
+        return pd.Series([False] * len(series_val), index=series_val.index)
+    return pd.to_numeric(series_val, errors="coerce") < threshold
 
 
 def _op_greater_than_or_equal(series_val, rule_val):
     """Returns True where the series value is >= numeric rule value."""
-    return pd.to_numeric(series_val, errors="coerce") >= float(rule_val)
+    threshold = _safe_float(rule_val)
+    if threshold is None:
+        return pd.Series([False] * len(series_val), index=series_val.index)
+    return pd.to_numeric(series_val, errors="coerce") >= threshold
 
 
 def _op_less_than_or_equal(series_val, rule_val):
     """Returns True where the series value is <= numeric rule value."""
-    return pd.to_numeric(series_val, errors="coerce") <= float(rule_val)
+    threshold = _safe_float(rule_val)
+    if threshold is None:
+        return pd.Series([False] * len(series_val), index=series_val.index)
+    return pd.to_numeric(series_val, errors="coerce") <= threshold
 
 
 def _op_starts_with(series_val, rule_val):
     """Returns True where the series string starts with the rule string."""
-    return series_val.str.startswith(rule_val, na=False)
+    return _as_str_series(series_val).str.startswith(rule_val, na=False)
 
 
 def _op_ends_with(series_val, rule_val):
     """Returns True where the series string ends with the rule string."""
-    return series_val.str.endswith(rule_val, na=False)
+    return _as_str_series(series_val).str.endswith(rule_val, na=False)
 
 
 def _op_is_empty(series_val, rule_val):
@@ -333,6 +364,17 @@ def _op_not_in_list(series_val, rule_val):
         2     True
         dtype: bool
     """
+    import logging
+    logger = logging.getLogger(__name__)
+
+    if not rule_val or pd.isna(rule_val):
+        logger.warning("[RULE ENGINE] Empty list value for 'not in list' operator")
+        return pd.Series([False] * len(series_val), index=series_val.index)
+
+    list_values = [v.strip().lower() for v in str(rule_val).split(",") if v.strip()]
+    if not list_values:
+        return pd.Series([False] * len(series_val), index=series_val.index)
+
     return ~_op_in_list(series_val, rule_val)
 
 
@@ -399,6 +441,8 @@ def _op_not_between(series_val, rule_val):
         3     True
         dtype: bool
     """
+    if _parse_range(rule_val) is None:
+        return pd.Series([False] * len(series_val), index=series_val.index)
     return ~_op_between(series_val, rule_val)
 
 
@@ -811,7 +855,7 @@ class RuleEngine:
 
                         for action in actions:
                             action_type = action.get("type", "").upper()
-                            if action_type == "ADD_TAG":
+                            if action_type in ("ADD_TAG", "ADD_ORDER_TAG"):
                                 apply_to_all_actions.append(action)
                             else:
                                 apply_to_first_actions.append(action)
@@ -855,7 +899,7 @@ class RuleEngine:
             for step in rule.get("steps", []):
                 for action in step.get("actions", []):
                     action_type = action.get("type", "").upper()
-                    if action_type in ["ADD_TAG", "ADD_ORDER_TAG"]:
+                    if action_type in ["ADD_TAG", "ADD_ORDER_TAG", "SET_MULTI_TAGS"]:
                         needed_columns.add("Status_Note")
                     elif action_type == "ADD_INTERNAL_TAG":
                         needed_columns.add("Internal_Tags")

--- a/shopify_tool/sequential_order.py
+++ b/shopify_tool/sequential_order.py
@@ -33,6 +33,24 @@ logger = logging.getLogger(__name__)
 SEQUENTIAL_ORDER_VERSION = "1.0"
 
 
+def _natural_sort_key(s):
+    """Convert string to list of strings and numbers for natural sorting."""
+    return [int(text) if text.isdigit() else text.lower()
+            for text in re.split(r'(\d+)', str(s))]
+
+
+def _write_sequential_order_map(json_path: Path, order_map: Dict[str, int]) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "version": SEQUENTIAL_ORDER_VERSION,
+        "generated_at": datetime.now().isoformat(),
+        "total_orders": len(order_map),
+        "order_sequence": order_map,
+    }
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
 def generate_sequential_order_map(
     analysis_results_df: pd.DataFrame,
     session_path: Path,
@@ -62,11 +80,6 @@ def generate_sequential_order_map(
     """
     json_path = session_path / "analysis" / "sequential_order.json"
 
-    # Check if map already exists
-    if json_path.exists() and not force_regenerate:
-        logger.info(f"Sequential order map already exists: {json_path}")
-        return load_sequential_order_map(session_path)
-
     # Filter to Fulfillable orders only
     fulfillable_df = analysis_results_df[
         analysis_results_df['Order_Fulfillment_Status'] == 'Fulfillable'
@@ -75,13 +88,36 @@ def generate_sequential_order_map(
     # Get unique order numbers (drop NaN to avoid JSON serialization failure)
     unique_orders = fulfillable_df['Order_Number'].dropna().unique()
 
-    # Sort with numeric awareness (ORDER-1, ORDER-2, ORDER-10)
-    def natural_sort_key(s):
-        """Convert string to list of strings and numbers for natural sorting."""
-        return [int(text) if text.isdigit() else text.lower()
-                for text in re.split(r'(\d+)', str(s))]
+    # Check if map already exists
+    if json_path.exists() and not force_regenerate:
+        existing_map = load_sequential_order_map(session_path)
 
-    unique_orders_sorted = sorted(unique_orders, key=natural_sort_key)
+        # An order that only became Fulfillable after re-analysis (e.g. a
+        # restock) would otherwise be missing from the persisted map forever,
+        # forcing callers to fall back to a number that can collide with one
+        # already assigned to a different order. Extend the map instead of
+        # returning it verbatim, preserving every existing assignment so
+        # already-printed labels stay valid.
+        new_orders = [o for o in unique_orders if o not in existing_map]
+        if not new_orders:
+            logger.info(f"Sequential order map already exists: {json_path}")
+            return existing_map
+
+        new_orders_sorted = sorted(new_orders, key=_natural_sort_key)
+        next_number = max(existing_map.values(), default=0) + 1
+        updated_map = dict(existing_map)
+        for order_num in new_orders_sorted:
+            updated_map[order_num] = next_number
+            next_number += 1
+
+        _write_sequential_order_map(json_path, updated_map)
+        logger.info(
+            f"Extended sequential order map with {len(new_orders)} newly-fulfillable orders"
+        )
+        return updated_map
+
+    # Sort with numeric awareness (ORDER-1, ORDER-2, ORDER-10)
+    unique_orders_sorted = sorted(unique_orders, key=_natural_sort_key)
 
     # Assign sequential numbers (1-indexed)
     order_map = {
@@ -89,19 +125,7 @@ def generate_sequential_order_map(
         for idx, order_num in enumerate(unique_orders_sorted)
     }
 
-    # Save to JSON
-    json_path.parent.mkdir(parents=True, exist_ok=True)
-
-    data = {
-        "version": SEQUENTIAL_ORDER_VERSION,
-        "generated_at": datetime.now().isoformat(),
-        "total_orders": len(order_map),
-        "order_sequence": order_map
-    }
-
-    with open(json_path, 'w', encoding='utf-8') as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-
+    _write_sequential_order_map(json_path, order_map)
     logger.info(f"Generated sequential order map: {len(order_map)} orders")
 
     return order_map

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -19,6 +19,7 @@ Directory Structure:
         └── stock_exports/          # Stock writeoff exports
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -246,6 +247,37 @@ class SessionManager:
 
         return sessions
 
+    @contextlib.contextmanager
+    def _locked_session_info(self, session_path_obj: Path):
+        """Blocking exclusive lock spanning a session_info.json read-modify-write.
+
+        Without this, two near-simultaneous updates (e.g. packing list and
+        stock export generation both appending to their own list field) each
+        read the same on-disk snapshot before either writes back, and one
+        update silently loses the other's change.
+        """
+        lock_path = session_path_obj / "session_info.json.lock"
+        lock_file = open(lock_path, "a+")
+        try:
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            finally:
+                lock_file.close()
+
     def get_session_info(self, session_path: str) -> Optional[Dict]:
         """Load session metadata from session_info.json.
 
@@ -301,31 +333,33 @@ class SessionManager:
                 f"Invalid status: {status}. Must be one of {self.VALID_STATUSES}"
             )
 
-        session_info = self.get_session_info(session_path)
-        if not session_info:
-            raise SessionManagerError(f"Session not found: {session_path}")
-
-        # Update status
-        session_info["status"] = status
-        session_info["status_updated_at"] = datetime.now().isoformat()
-
-        # Save back
         session_path_obj = Path(session_path)
-        session_info_path = session_path_obj / "session_info.json"
 
-        try:
-            # Remove computed fields
-            session_info.pop("session_path", None)
+        with self._locked_session_info(session_path_obj):
+            session_info = self.get_session_info(session_path)
+            if not session_info:
+                raise SessionManagerError(f"Session not found: {session_path}")
 
-            with open(session_info_path, 'w', encoding='utf-8') as f:
-                json.dump(session_info, f, indent=2)
+            # Update status
+            session_info["status"] = status
+            session_info["status_updated_at"] = datetime.now().isoformat()
 
-            logger.info(f"Session status updated to '{status}': {session_path}")
-            return True
+            # Save back
+            session_info_path = session_path_obj / "session_info.json"
 
-        except Exception as e:
-            logger.error(f"Failed to update session status: {e}")
-            raise SessionManagerError(f"Failed to update session status: {e}")
+            try:
+                # Remove computed fields
+                session_info.pop("session_path", None)
+
+                with open(session_info_path, 'w', encoding='utf-8') as f:
+                    json.dump(session_info, f, indent=2)
+
+                logger.info(f"Session status updated to '{status}': {session_path}")
+                return True
+
+            except Exception as e:
+                logger.error(f"Failed to update session status: {e}")
+                raise SessionManagerError(f"Failed to update session status: {e}")
 
     def update_session_info(self, session_path: str, updates: Dict) -> bool:
         """Update session metadata with arbitrary fields.
@@ -340,31 +374,76 @@ class SessionManager:
         Raises:
             SessionManagerError: If update fails
         """
-        session_info = self.get_session_info(session_path)
-        if not session_info:
-            raise SessionManagerError(f"Session not found: {session_path}")
-
-        # Apply updates
-        session_info.update(updates)
-        session_info["last_updated"] = datetime.now().isoformat()
-
-        # Save back
         session_path_obj = Path(session_path)
-        session_info_path = session_path_obj / "session_info.json"
 
-        try:
-            # Remove computed fields
-            session_info.pop("session_path", None)
+        with self._locked_session_info(session_path_obj):
+            session_info = self.get_session_info(session_path)
+            if not session_info:
+                raise SessionManagerError(f"Session not found: {session_path}")
 
-            with open(session_info_path, 'w', encoding='utf-8') as f:
-                json.dump(session_info, f, indent=2)
+            # Apply updates
+            session_info.update(updates)
+            session_info["last_updated"] = datetime.now().isoformat()
 
-            logger.info(f"Session info updated: {session_path}")
-            return True
+            # Save back
+            session_info_path = session_path_obj / "session_info.json"
 
-        except Exception as e:
-            logger.error(f"Failed to update session info: {e}")
-            raise SessionManagerError(f"Failed to update session info: {e}")
+            try:
+                # Remove computed fields
+                session_info.pop("session_path", None)
+
+                with open(session_info_path, 'w', encoding='utf-8') as f:
+                    json.dump(session_info, f, indent=2)
+
+                logger.info(f"Session info updated: {session_path}")
+                return True
+
+            except Exception as e:
+                logger.error(f"Failed to update session info: {e}")
+                raise SessionManagerError(f"Failed to update session info: {e}")
+
+    def append_to_session_list(self, session_path: str, field: str, value) -> bool:
+        """Atomically append value to a list field in session_info.json.
+
+        update_session_info()'s lock only protects its own read-modify-write;
+        a caller that reads the list itself (e.g. via get_session_info),
+        appends locally, and then calls update_session_info() with the whole
+        new list is still racing every other caller doing the same for a
+        DIFFERENT value on the same field (e.g. two packing lists generated
+        back to back) -- each reads a list that doesn't yet contain the
+        other's addition, and whichever writes last wins. Reading the list
+        fresh inside this method's own lock closes that gap.
+
+        Returns:
+            bool: True if value was appended, False if it was already present
+        """
+        session_path_obj = Path(session_path)
+
+        with self._locked_session_info(session_path_obj):
+            session_info = self.get_session_info(session_path)
+            if not session_info:
+                raise SessionManagerError(f"Session not found: {session_path}")
+
+            current_list = session_info.get(field, [])
+            if value in current_list:
+                return False
+
+            session_info[field] = current_list + [value]
+            session_info["last_updated"] = datetime.now().isoformat()
+
+            session_info_path = session_path_obj / "session_info.json"
+            try:
+                session_info.pop("session_path", None)
+
+                with open(session_info_path, 'w', encoding='utf-8') as f:
+                    json.dump(session_info, f, indent=2)
+
+                logger.info(f"Session info updated: appended '{value}' to '{field}'")
+                return True
+
+            except Exception as e:
+                logger.error(f"Failed to update session info: {e}")
+                raise SessionManagerError(f"Failed to update session info: {e}")
 
     def get_session_subdirectory(self, session_path: str, subdir_name: str) -> Path:
         """Get path to a session subdirectory.
@@ -499,7 +578,14 @@ class SessionManager:
         Raises:
             SessionManagerError: If deletion fails
         """
-        session_path_obj = Path(session_path)
+        session_path_obj = Path(session_path).resolve()
+
+        try:
+            session_path_obj.relative_to(self.sessions_root.resolve())
+        except ValueError:
+            raise SessionManagerError(
+                f"Refusing to delete path outside sessions root: {session_path}"
+            )
 
         if not session_path_obj.exists():
             logger.warning(f"Session not found for deletion: {session_path}")

--- a/shopify_tool/set_decoder.py
+++ b/shopify_tool/set_decoder.py
@@ -82,6 +82,7 @@ def decode_sets_in_orders(
             set_orders_count += 1
 
             # Expand into components
+            valid_components_added = 0
             for component in components:
                 component_sku = component.get("sku")
                 component_qty = component.get("quantity")
@@ -105,6 +106,19 @@ def decode_sets_in_orders(
                 new_row["Original_Quantity"] = quantity
                 new_row["Is_Set_Component"] = True
 
+                expanded_rows.append(new_row)
+                valid_components_added += 1
+
+            if valid_components_added == 0:
+                # Every component failed validation -- keep the original order
+                # line instead of letting it vanish with only a debug log.
+                logger.warning(
+                    f"Set '{sku}' has no valid components after validation, keeping original row"
+                )
+                new_row = row.copy()
+                new_row["Original_SKU"] = sku
+                new_row["Original_Quantity"] = quantity
+                new_row["Is_Set_Component"] = False
                 expanded_rows.append(new_row)
 
         else:

--- a/shopify_tool/stock_export.py
+++ b/shopify_tool/stock_export.py
@@ -58,20 +58,21 @@ def _expand_lot_summary(filtered_items: pd.DataFrame) -> pd.DataFrame:
     """
     lot_rows_data: dict = {}  # (sku, expiry, batch) → total qty
     no_lot_skus: dict = {}  # sku → total qty
-    # The simulation allocates at the (order, SKU) level — all DataFrame rows for the
-    # same (order, SKU) pair carry an identical Lot_Details object representing the full
-    # allocation for that pair.  Without this guard we would count the same allocation
-    # once per duplicate row instead of once per (order, SKU).
-    seen_order_sku: set = set()
+    # The simulation allocates at the (order, SKU) level and stores one Lot_Details
+    # list object per pair (see analysis.py's order_alloc[sku] = sku_alloc); every
+    # DataFrame row for that pair gets the SAME object by reference. Dedupe on
+    # object identity rather than (Order_Number, SKU) -- the latter collapses
+    # distinct allocations whenever Order_Number is blank on more than one row.
+    seen_allocations: set = set()
 
     for _, row in filtered_items.iterrows():
         sku = row["SKU"]
         lot_details = row.get("Lot_Details")
         if lot_details and isinstance(lot_details, list) and len(lot_details) > 0:
-            order_key = (row.get("Order_Number", ""), sku)
-            if order_key in seen_order_sku:
+            alloc_id = id(lot_details)
+            if alloc_id in seen_allocations:
                 continue
-            seen_order_sku.add(order_key)
+            seen_allocations.add(alloc_id)
             for entry in lot_details:
                 expiry = entry.get("expiry") or ""
                 if expiry == "1":

--- a/shopify_tool/weight_calculator.py
+++ b/shopify_tool/weight_calculator.py
@@ -71,7 +71,9 @@ def calc_order_volumetric_weight(order_df: pd.DataFrame, weight_config: Dict) ->
         if not sku or sku == "NO_SKU":
             continue
 
-        qty = float(row.get("Quantity", 1) or 1)
+        # No `or 1` fallback: a genuine Quantity of 0 is falsy in Python and
+        # would otherwise be silently promoted to 1, overcounting weight.
+        qty = float(row.get("Quantity", 1))
         sku_vol_weight = calc_sku_volumetric_weight(sku, weight_config)
         total += qty * sku_vol_weight
 
@@ -212,7 +214,9 @@ def find_min_box_for_order(order_df: pd.DataFrame, weight_config: Dict) -> str:
             has_unknown_dims = True
             continue
 
-        qty = int(float(row.get("Quantity", 1) or 1))
+        # No `or 1` fallback: a genuine Quantity of 0 must contribute zero
+        # items to the box-fit check, not be silently promoted to 1.
+        qty = int(float(row.get("Quantity", 1)))
         for _ in range(qty):
             item_dims_list.append((l, w, h))
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -375,14 +375,6 @@ class TestQuantityRobustness:
     anywhere in the module -- correctness relies entirely on pandas' automatic
     CSV dtype inference, which breaks the moment a single row is malformed."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: one non-numeric Quantity value anywhere in the whole orders "
-               "file (e.g. a stray 'abc' from a data-entry mistake) crashes the "
-               "ENTIRE analysis run with an uncaught TypeError in "
-               "_simulate_stock_allocation ('>' not supported between str and "
-               "int) -- every order in the batch fails, not just the bad row.",
-    )
     def test_single_bad_quantity_value_does_not_crash_whole_batch(self):
         orders = _orders([
             {"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 2},
@@ -392,15 +384,6 @@ class TestQuantityRobustness:
         final_df, *_ = _run(orders, stock)  # currently raises TypeError
         assert final_df[final_df["Order_Number"] == "#1"].iloc[0]["Order_Fulfillment_Status"] == "Fulfillable"
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: a blank/NaN Quantity cell is silently summed as 0 needed "
-               "units (pandas groupby.sum() default skipna=True) instead of "
-               "being rejected/flagged -- the order line is marked Fulfillable "
-               "and consumes zero stock even though the true requested quantity "
-               "is unknown, so a picker never gets told to pack that item and "
-               "no error surfaces anywhere.",
-    )
     def test_blank_quantity_is_flagged_not_silently_treated_as_zero(self):
         orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": None}])
         stock = _stock([{"Артикул": "A1", "Наличност": 10}])

--- a/tests/test_barcode_processor.py
+++ b/tests/test_barcode_processor.py
@@ -60,28 +60,11 @@ class TestFormatTagsForBarcode:
         assert format_tags_for_barcode("nan") == ""
         assert format_tags_for_barcode("None") == ""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: analysis.py initializes EVERY order's Internal_Tags to the "
-               "JSON string '[]' (empty array). format_tags_for_barcode('[]') "
-               "should behave like the no-tags case (blank/falsy) but instead "
-               "falls through to the plain-string fallback branch and returns "
-               "the literal text '[]', which then prints on the barcode label "
-               "for essentially every untagged order.",
-    )
     def test_empty_json_array_returns_blank_not_literal_brackets(self):
         assert format_tags_for_barcode("[]") == ""
 
 
 class TestItemCountZeroFalsyBug:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: generate_barcodes_batch computes "
-               "`int(float(raw_count or 1))` -- Python's `or` treats a "
-               "legitimate item_count of 0 as falsy and silently substitutes 1, "
-               "so a genuinely-zero-item row prints 'SUM: 1' on the label "
-               "instead of 'SUM: 0'.",
-    )
     def test_zero_item_count_is_not_coerced_to_one(self, tmp_path, monkeypatch):
         captured = {}
 

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -56,12 +56,6 @@ class TestNormalizeSkuForMatching:
 
     # --- BUGS found while exercising this function (see also barcode_processor) ---
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: a SKU literally 'inf'/'Infinity'/'-inf' makes float() succeed "
-               "and int(float(...)) raise an uncaught OverflowError instead of "
-               "falling back to the alphanumeric branch like other non-numeric SKUs.",
-    )
     @pytest.mark.parametrize("raw", ["inf", "-inf", "Infinity", "INF"])
     def test_infinity_like_sku_does_not_crash(self, raw):
         # Every other non-numeric SKU (e.g. "ABC-123") is returned unchanged by
@@ -70,12 +64,6 @@ class TestNormalizeSkuForMatching:
         # packing-list filter called it.
         assert normalize_sku_for_matching(raw) == raw
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: scientific-notation-shaped SKUs (e.g. '5E3') are silently "
-               "reinterpreted as numbers via float() and mangled to '5000' instead "
-               "of being treated as an opaque alphanumeric SKU.",
-    )
     def test_scientific_notation_sku_is_not_mangled(self):
         assert normalize_sku_for_matching("5E3") == "5E3"
 

--- a/tests/test_groups_manager.py
+++ b/tests/test_groups_manager.py
@@ -56,26 +56,10 @@ class TestBasicCrud:
 
 
 class TestConfirmedBugs:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: create_group's duplicate-name check only scans "
-               "groups_data['groups'], never special_groups -- "
-               "create_group('Pinned') succeeds and produces a normal group "
-               "whose display name collides with the built-in 'Pinned' group.",
-    )
     def test_create_group_colliding_with_special_group_name_is_rejected(self, groups_manager):
         with pytest.raises(GroupsManagerError):
             groups_manager.create_group("Pinned")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: save_groups()/create_group() only lock around the final "
-               "write, not the preceding load_groups() read -- two near-"
-               "simultaneous create_group() calls both read the same stale "
-               "snapshot, so the second writer's save clobbers the first "
-               "writer's newly-appended group even though create_group() "
-               "returned a success UUID to both callers.",
-    )
     def test_concurrent_create_group_does_not_lose_an_update(self, groups_manager, monkeypatch):
         original_load = groups_manager.load_groups
 

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -107,30 +107,12 @@ class TestInventoryMemoryRoundTrip:
 
     # --- Confirmed bugs ---
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: save_inventory_memory() casts SKU keys with plain str(k), "
-               "never through csv_utils.normalize_sku() (used everywhere else in "
-               "this codebase, e.g. core.py's history SKU normalization). A "
-               "numeric/float SKU key is persisted as '5170.0' instead of "
-               "'5170', so it will never match the normalize_sku()'d SKU that "
-               "comes back from a real stock CSV on the next analysis run.",
-    )
     def test_float_sku_key_is_normalized_like_everywhere_else(self, profile_manager):
         profile_manager.create_client_profile("M", "Client")
         profile_manager.save_inventory_memory("M", {5170.0: 12})
         mem = profile_manager.get_inventory_memory("M")
         assert "5170" in mem["skus"]
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: save_inventory_memory() has no guard against an empty "
-               "stock_dict -- calling it with {} (e.g. because every row's "
-               "Final_Stock was NaN in a degenerate analysis run, see "
-               "core.py:1100-1105) silently overwrites and permanently erases "
-               "a previously-good inventory snapshot instead of being a no-op "
-               "or requiring an explicit confirmation.",
-    )
     def test_saving_empty_stock_dict_does_not_erase_previous_snapshot(self, profile_manager):
         profile_manager.create_client_profile("M", "Client")
         profile_manager.save_inventory_memory("M", {"A1": 5, "B1": 3})
@@ -140,17 +122,6 @@ class TestInventoryMemoryRoundTrip:
 
 
 class TestListClientsBug:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: list_clients() strips the directory prefix with "
-               "item.name.replace('CLIENT_', '') instead of a prefix-only "
-               "strip. validate_client_id() only rejects IDs that START WITH "
-               "'CLIENT_', so an id like 'ACLIENT_B' is legal, creates dir "
-               "'CLIENT_ACLIENT_B', but list_clients() replaces BOTH "
-               "occurrences of the substring and reports it as 'AB' -- a name "
-               "that doesn't round-trip through client_exists()/"
-               "get_client_directory() at all.",
-    )
     def test_client_id_containing_client_substring_round_trips(self, profile_manager):
         profile_manager.create_client_profile("ACLIENT_B", "Test")
         listed = profile_manager.list_clients()
@@ -159,17 +130,6 @@ class TestListClientsBug:
 
 
 class TestColumnMappingsMigrationBug:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: _migrate_column_mappings_v1_to_v2 computes is_v1 to decide "
-               "which log message to print, but then unconditionally overwrites "
-               "config['column_mappings'] with the hardcoded default Shopify/"
-               "Bulgarian template regardless of is_v1's value. Any real, valid "
-               "user-authored column_mappings dict that simply lacks the "
-               "'version' key (e.g. hand-edited, or written by an older code "
-               "path) has its actual orders/stock mapping silently discarded "
-               "and replaced by the wrong default on the very next config load.",
-    )
     def test_unversioned_custom_mapping_is_not_silently_replaced(self, profile_manager):
         profile_manager.create_client_profile("M", "Client")
         config = profile_manager.load_shopify_config("M")

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -123,9 +123,6 @@ class TestConfirmedBugs:
     verified to fail against current shopify_tool/rules.py before being marked
     xfail. These serve as regression markers if/when the bug is fixed."""
 
-    @pytest.mark.xfail(strict=True, reason="BUG: 'contains'/'starts with'/'ends with' "
-                        "raise an uncaught AttributeError on numeric-dtype columns "
-                        "instead of degrading to all-False like other operators.")
     def test_contains_on_numeric_column_does_not_crash(self):
         df = _df({"Quantity": [1, 2, 3]})
         rules = [_rule([{"field": "Quantity", "operator": "contains", "value": "2"}],
@@ -133,9 +130,6 @@ class TestConfirmedBugs:
         out = RuleEngine(rules).apply(df.copy())  # currently raises AttributeError
         assert out["Status_Note"].tolist() == ["", "X", ""]
 
-    @pytest.mark.xfail(strict=True, reason="BUG: 'is greater than'/'is less than'/etc "
-                        "call float(rule_val) unguarded; a blank/non-numeric rule value "
-                        "crashes the whole analysis instead of matching zero rows.")
     def test_greater_than_with_blank_value_does_not_crash(self):
         df = _df({"Final_Stock": [1, 2, 3]})
         rules = [_rule([{"field": "Final_Stock", "operator": "is greater than", "value": ""}],
@@ -143,10 +137,6 @@ class TestConfirmedBugs:
         out = RuleEngine(rules).apply(df.copy())  # currently raises ValueError
         assert out["Status_Note"].tolist() == ["", "", ""]
 
-    @pytest.mark.xfail(strict=True, reason="BUG: 'not between' with a malformed/reversed "
-                        "range string (e.g. start > end) degrades the base 'between' "
-                        "check to all-False, and negating all-False matches EVERY row "
-                        "instead of zero rows.")
     def test_not_between_with_malformed_range_matches_nothing(self):
         df = _df({"Final_Stock": [1, 50, 999]})
         rules = [_rule([{"field": "Final_Stock", "operator": "not between", "value": "100-10"}],
@@ -154,10 +144,6 @@ class TestConfirmedBugs:
         out = RuleEngine(rules).apply(df.copy())
         assert out["Status_Note"].tolist() == ["", "", ""]
 
-    @pytest.mark.xfail(strict=True, reason="BUG: 'not in list' with an empty/blank rule "
-                        "value degrades the base 'in list' check to all-False, and "
-                        "negating all-False matches EVERY row instead of zero rows -- "
-                        "a blank filter value in the UI silently tags the entire dataset.")
     def test_not_in_list_with_empty_value_matches_nothing(self):
         df = _df({"Shipping_Provider": ["DHL", "DPD", "PostOne"]})
         rules = [_rule([{"field": "Shipping_Provider", "operator": "not in list", "value": ""}],
@@ -165,11 +151,6 @@ class TestConfirmedBugs:
         out = RuleEngine(rules).apply(df.copy())
         assert out["Status_Note"].tolist() == ["", "", ""]
 
-    @pytest.mark.xfail(strict=True, reason="BUG: an order-level rule's ADD_ORDER_TAG "
-                        "action only stamps the FIRST row of a multi-line order, not "
-                        "every row -- despite the action name implying order-wide "
-                        "application (only the literal 'ADD_TAG' type gets apply-to-all "
-                        "treatment in the order-level branch).")
     def test_add_order_tag_applies_to_every_row_of_the_order(self):
         df = _df({
             "Order_Number": ["#1", "#1", "#2"],
@@ -184,10 +165,6 @@ class TestConfirmedBugs:
         out = RuleEngine(rules).apply(df.copy())
         assert out["Status_Note"].tolist() == ["GIFT", "GIFT", "GIFT"]
 
-    @pytest.mark.xfail(strict=True, reason="BUG: SET_MULTI_TAGS writes to Status_Note "
-                        "but is missing from _prepare_df_for_actions' needed-columns "
-                        "scan, so a rules config using ONLY SET_MULTI_TAGS crashes with "
-                        "KeyError('Status_Note') when that column doesn't already exist.")
     def test_set_multi_tags_does_not_crash_when_status_note_column_absent(self):
         df = _df({
             "Order_Number": ["#1"], "SKU": ["A"], "Quantity": [1],

--- a/tests/test_sequential_order.py
+++ b/tests/test_sequential_order.py
@@ -41,11 +41,13 @@ class TestGenerateSequentialOrderMap:
         assert data["order_sequence"] == first
         assert data["total_orders"] == 2
 
-        # Second call with a DIFFERENT df must NOT overwrite -- numbering is
-        # meant to be stable across a session so previously printed labels
-        # stay valid.
-        different_df = _analysis_df(["#5", "#6", "#7"])
-        second = generate_sequential_order_map(different_df, tmp_path)
+        # A second call with the SAME orders must reuse the persisted map,
+        # not regenerate it -- numbering is meant to be stable across a
+        # session so previously printed labels stay valid. (The case of a
+        # second call with NEW orders mixed in is covered separately by
+        # TestStaleMapCollisionRisk, which asserts existing numbers are kept
+        # and only genuinely new orders get appended.)
+        second = generate_sequential_order_map(df, tmp_path)
         assert second == first
 
     def test_force_regenerate_overwrites_existing_map(self, tmp_path):
@@ -90,22 +92,15 @@ class TestLoadAndLookup:
 
 
 class TestStaleMapCollisionRisk:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG (design gap): once sequential_order.json exists, "
-               "generate_sequential_order_map() returns the OLD map verbatim "
-               "and never assigns numbers to orders that only became "
-               "Fulfillable after re-analysis (e.g. a restock). Any caller "
-               "that falls back to `idx + 1` for orders missing from the map "
-               "(see barcode_processor.generate_barcodes_batch) can then "
-               "print a sequential number that collides with one already "
-               "assigned to a different order in the persisted map.",
-    )
     def test_new_fulfillable_order_after_restock_gets_a_number(self, tmp_path):
         df_before = _analysis_df(["#1", "#2"])
-        generate_sequential_order_map(df_before, tmp_path)
+        before_map = generate_sequential_order_map(df_before, tmp_path)
 
         # Analysis reruns after a restock: #3 is now also Fulfillable.
         df_after = _analysis_df(["#1", "#2", "#3"])
         order_map = generate_sequential_order_map(df_after, tmp_path)
         assert "#3" in order_map
+        # Existing numbers must not be renumbered -- previously printed
+        # labels for #1/#2 must stay valid.
+        assert order_map["#1"] == before_map["#1"]
+        assert order_map["#2"] == before_map["#2"]

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -68,18 +68,46 @@ class TestDirectoryGetters:
         assert session_manager.get_stock_exports_dir(session_path) == Path(session_path) / "stock_exports"
 
 
+class TestAppendToSessionList:
+    """append_to_session_list closes a race that survives update_session_info's
+    own lock: two callers each reading a stale list via get_session_info and
+    appending locally would still clobber each other on write."""
+
+    def test_appends_new_value(self, session_manager):
+        session_path = session_manager.create_session("M")
+        assert session_manager.append_to_session_list(session_path, "packing_lists_generated", "a.xlsx") is True
+        info = session_manager.get_session_info(session_path)
+        assert info["packing_lists_generated"] == ["a.xlsx"]
+
+    def test_duplicate_value_is_a_noop(self, session_manager):
+        session_path = session_manager.create_session("M")
+        session_manager.append_to_session_list(session_path, "packing_lists_generated", "a.xlsx")
+        assert session_manager.append_to_session_list(session_path, "packing_lists_generated", "a.xlsx") is False
+        info = session_manager.get_session_info(session_path)
+        assert info["packing_lists_generated"] == ["a.xlsx"]
+
+    def test_concurrent_appends_to_same_field_are_not_lost(self, session_manager):
+        import threading
+
+        session_path = session_manager.create_session("M")
+        barrier = threading.Barrier(2)
+
+        def _append(value):
+            barrier.wait()
+            session_manager.append_to_session_list(session_path, "packing_lists_generated", value)
+
+        t1 = threading.Thread(target=_append, args=("a.xlsx",))
+        t2 = threading.Thread(target=_append, args=("b.xlsx",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        info = session_manager.get_session_info(session_path)
+        assert set(info["packing_lists_generated"]) == {"a.xlsx", "b.xlsx"}
+
+
 class TestConfirmedBugs:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: update_session_info() does an unlocked read-modify-write "
-               "(get_session_info -> dict.update -> json.dump) with no file "
-               "lock. Two updates that each read the SAME on-disk snapshot "
-               "before either writes back will lose one of the two changes -- "
-               "this reproduces the exact pattern used by "
-               "core.py/create_stock_export_report and "
-               "create_packing_list_report, which both read-append-write the "
-               "'*_generated' list fields on session_info.json.",
-    )
     def test_two_interleaved_updates_do_not_lose_either_field(self, session_manager):
         import threading
         import time
@@ -118,14 +146,6 @@ class TestConfirmedBugs:
         assert final["packing_lists_generated"] == ["dhl.xlsx"]
         assert final["stock_exports_generated"] == ["export.xls"]
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: delete_session() calls shutil.rmtree(session_path_obj) "
-               "with zero validation that the path resolves under "
-               "self.sessions_root -- any caller passing a path outside the "
-               "sessions tree (e.g. from unsanitized input) can delete "
-               "arbitrary directories.",
-    )
     def test_delete_session_refuses_path_outside_sessions_root(self, session_manager, tmp_path):
         outside_dir = tmp_path / "not_a_session"
         outside_dir.mkdir()

--- a/tests/test_set_decoder.py
+++ b/tests/test_set_decoder.py
@@ -90,13 +90,6 @@ class TestDecodeSetsInOrders:
         result = decode_sets_in_orders(df, set_decoders)
         assert list(result["SKU"]) == ["INNER-SET"]  # NOT expanded to LEAF
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: when every component of a set is invalid (missing SKU or "
-               "non-positive quantity), the whole order line silently vanishes "
-               "from the output instead of being kept as an error/unfulfillable "
-               "row -- the customer's line item disappears with only a debug log.",
-    )
     def test_set_with_all_invalid_components_does_not_drop_the_order_line(self):
         df = _orders([{"Order_Number": "#1", "SKU": "SET-BROKEN", "Quantity": 1}])
         set_decoders = {"SET-BROKEN": [{"sku": "", "quantity": 1}]}

--- a/tests/test_stock_export.py
+++ b/tests/test_stock_export.py
@@ -100,16 +100,6 @@ class TestLotAggregation:
 
 
 class TestConfirmedBugs:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="BUG: _expand_lot_summary dedupes per-(order,SKU) allocations "
-               "using key (Order_Number, SKU) to avoid double-counting a "
-               "duplicated DataFrame row. When Order_Number is blank/missing "
-               "for more than one Fulfillable row sharing a SKU, they all "
-               "collapse to the same ('', SKU) key -- every allocation after "
-               "the first is silently dropped from the write-off export, "
-               "understating the real quantity to deduct from the ERP.",
-    )
     def test_missing_order_number_does_not_drop_distinct_lot_allocations(self, tmp_path):
         df = _analysis_df([
             {"Order_Number": "", "SKU": "A1", "Quantity": 3,

--- a/tests/test_weight_calculator.py
+++ b/tests/test_weight_calculator.py
@@ -1,0 +1,29 @@
+"""Weight/box-fit accuracy for a genuinely-zero Quantity (found while auditing
+for the same `x or 1` falsy-zero bug fixed in barcode_processor.py)."""
+import pandas as pd
+
+from shopify_tool.weight_calculator import (
+    NO_BOX_NEEDED,
+    calc_order_volumetric_weight,
+    find_min_box_for_order,
+)
+
+
+def _weight_config():
+    return {
+        "volumetric_divisor": 6000,
+        "products": {
+            "A1": {"length_cm": 10, "width_cm": 10, "height_cm": 10, "no_packaging": False},
+        },
+        "boxes": [],
+    }
+
+
+class TestZeroQuantityIsNotCoercedToOne:
+    def test_zero_quantity_contributes_no_volumetric_weight(self):
+        order_df = pd.DataFrame([{"SKU": "A1", "Quantity": 0}])
+        assert calc_order_volumetric_weight(order_df, _weight_config()) == 0.0
+
+    def test_zero_quantity_needs_no_box(self):
+        order_df = pd.DataFrame([{"SKU": "A1", "Quantity": 0}])
+        assert find_min_box_for_order(order_df, _weight_config()) == NO_BOX_NEEDED


### PR DESCRIPTION
…und by audit

Un-xfails every strict xfail regression test added in the previous commit by fixing its root cause:

- rules.py: numeric-dtype contains/starts/ends-with crash, unguarded float() in comparison operators, not-between/not-in-list negating an invalid-input sentinel into "matches everything", ADD_ORDER_TAG only tagging the first row of an order, SET_MULTI_TAGS missing from the needed-columns scan
- stock_export.py: lot-allocation dedup key collapsed distinct allocations when Order_Number was blank on more than one row
- analysis.py: a single bad Quantity value crashed the whole batch; blank Quantity was silently treated as 0 instead of flagged
- profile_manager.py: SKU keys not normalized in inventory memory, empty stock_dict erasing a good snapshot, list_clients() substring-replacing 'CLIENT_' instead of prefix-stripping, column_mappings migration discarding a valid unversioned mapping
- set_decoder.py: an order line vanished if every set component was invalid
- session_manager.py: unlocked read-modify-write on session_info.json, delete_session() with no path-containment check
- barcode_processor.py: literal "[]" printed for untagged orders, zero item_count coerced to 1
- groups_manager.py: duplicate-name check missed special groups, race between load and save on concurrent group creation
- sequential_order.py: orders that became Fulfillable after a restock never got a sequential number
- csv_utils.py: normalize_sku_for_matching crashed on "inf"-like SKUs and mangled scientific-notation SKUs

Also found and fixed while auditing for the same bug shapes:
- weight_calculator.py: the same "0 or 1" falsy-zero bug as barcode_processor, in both volumetric weight and box-fit sizing
- Resolved a real conflict between two tests: the pre-existing "map is frozen after first generation" test contradicted the new "newly-fulfillable orders get a number" test; both are now consistent with the actual invariant (existing numbers never change, new ones append)
- core.py read session_info's *_generated lists before calling update_session_info(), so its lock didn't protect concurrent appends to the same field; added SessionManager.append_to_session_list() and switched all three call sites (packing lists, stock exports, writeoff reports) to it

165 -> 196 tests, all passing, 0 xfail remaining.

## Summary by Sourcery

Fix multiple confirmed bugs across rules, sessions, profiles, groups, barcode generation, stock export, set decoding, sequential order numbering, analysis, and CSV SKU handling, removing all strict xfail regressions and making behavior robust under bad input and concurrency.

Bug Fixes:
- Prevent duplicate or colliding group names with special groups and guard group create/update/delete with a read-modify-write file lock to avoid concurrent clobbering.
- Add file-level locking and safe path validation to session_info.json updates and session deletion, and introduce an atomic append_to_session_list API to avoid losing concurrent list updates.
- Normalize client IDs correctly in list_clients, preserve existing unversioned column_mappings rather than overwriting them with defaults, and avoid erasing inventory snapshots or mis-normalizing SKU keys in save_inventory_memory.
- Harden rule operators against numeric columns, malformed ranges, empty list values, and invalid numeric thresholds, and ensure ADD_ORDER_TAG and SET_MULTI_TAGS correctly declare their needed Status_Note column and tag all relevant rows.
- Ensure stock_export lot expansion dedupes by allocation object rather than (order, SKU) so distinct allocations with blank order numbers are retained.
- Make set decoding keep the original order line when all components are invalid instead of dropping it.
- Fix barcode tag formatting to treat JSON empty arrays as no tags and ensure zero item_count is not coerced to one.
- Ensure sequential order maps extend existing maps with newly-fulfillable orders without renumbering existing ones, preventing label collisions.
- Coerce Quantity to numeric, flag orders with missing/invalid quantities as unfulfillable instead of treating them as zero, and avoid whole-batch crashes in analysis.
- Make SKU normalization robust to infinity-like and scientific-notation values, preserving them as-is instead of crashing or mangling.
- Ensure volumetric weight and box-fit calculations respect genuine zero quantities instead of silently treating them as one.

Enhancements:
- Refactor sequential order map generation into reusable helpers for natural sorting and JSON writing, and align tests with the invariant that numbering is stable while new orders append.
- Add targeted tests around session list appends, sequential-order restock behavior, profile inventory memory edge cases, rule engine robustness, SKU normalization, stock export deduping, set decoding, barcode behavior, and weight calculation for zero quantities.