### PR TITLE
ci: harden lint/test gate, add shared/ drift check

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -46,11 +46,14 @@ jobs:
     steps:
       - name: Check out this repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Check out packing-tool (canonical shared/ source)
         uses: actions/checkout@v4
         with:
           repository: cognitiveghost/packing-tool
           path: packing-tool-ref
+          persist-credentials: false
       - name: Diff shared/ against packing-tool/shared/
         run: |
           if ! diff -r shared packing-tool-ref/shared; then

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -31,7 +31,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Lint (ruff)
-        run: ruff check .
+        run: ruff check . --exclude shared
       - name: Smoke test (headless import + construct MainWindow)
         timeout-minutes: 2
         run: CI=1 python run_dev.py

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -31,14 +31,32 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Lint (ruff)
-        run: ruff check . || true
+        run: ruff check .
       - name: Smoke test (headless import + construct MainWindow)
         timeout-minutes: 2
         run: CI=1 python run_dev.py
-      - name: Run tests (auto-enables once tests/ exists again)
+      - name: Run tests
         env:
           QT_QPA_PLATFORM: offscreen
-        run: if [ -d tests ]; then python -m pytest; fi
+        run: python -m pytest
+
+  shared-sync-check:
+    name: Check shared/ matches packing-tool (canonical source)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out this repo
+        uses: actions/checkout@v4
+      - name: Check out packing-tool (canonical shared/ source)
+        uses: actions/checkout@v4
+        with:
+          repository: cognitiveghost/packing-tool
+          path: packing-tool-ref
+      - name: Diff shared/ against packing-tool/shared/
+        run: |
+          if ! diff -r shared packing-tool-ref/shared; then
+            echo "::error::shared/ has drifted from packing-tool/shared/ (the canonical source). Run scripts/sync_shared.py and commit the result."
+            exit 1
+          fi
 
   build:
     name: Build Executable

--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -11,6 +11,7 @@ from gui.tag_categories_dialog import TagCategoriesDialog
 from gui.worker import Worker
 from shopify_tool import core, packing_lists, stock_export
 from shopify_tool.analysis import toggle_order_fulfillment
+from shopify_tool.profile_manager import ProfileManagerError
 from shopify_tool.session_manager import SessionManagerError
 
 
@@ -110,21 +111,21 @@ class ActionsHandler(QObject):
             )
 
         except SessionManagerError as e:
-            self.log.error(
-                f"Session manager error creating session: {e}", exc_info=True
+            self.log.exception(
+                "Session manager error creating session"
             )
             QMessageBox.critical(
                 self.mw, "Session Error", f"Could not create a new session.\n\n{e}"
             )
         except (OSError, PermissionError) as e:
-            self.log.error(f"File system error creating session: {e}", exc_info=True)
+            self.log.exception("File system error creating session")
             QMessageBox.critical(
                 self.mw,
                 "File System Error",
                 f"Could not create session due to file system error.\n\n{e}",
             )
         except Exception as e:
-            self.log.error(f"Unexpected error creating new session: {e}", exc_info=True)
+            self.log.exception("Unexpected error creating new session")
             QMessageBox.critical(
                 self.mw,
                 "Unexpected Error",
@@ -268,9 +269,9 @@ class ActionsHandler(QObject):
                     f"Statistics recorded: {orders_count} orders, {items_count} items, {fulfillable_orders} fulfillable"
                 )
 
-            except Exception as e:
+            except Exception:
                 # Don't fail the analysis if stats recording fails
-                self.log.error(f"Failed to record statistics: {e}", exc_info=True)
+                self.log.exception("Failed to record statistics")
                 # Continue with normal flow
             # ========================================
             # END STATISTICS RECORDING
@@ -307,10 +308,9 @@ class ActionsHandler(QObject):
             error (tuple): A tuple containing the exception type, value, and
                 traceback.
         """
-        exctype, value, tb = error
+        _exctype, value, tb = error
         self.log.error(
             f"An unexpected error occurred in a background task: {value}\n{tb}",
-            exc_info=True,
         )
         msg = f"An unexpected error occurred in a background task:\n{value}\n\nTraceback:\n{tb}"
         QMessageBox.critical(self.mw, "Task Exception", msg)
@@ -330,7 +330,7 @@ class ActionsHandler(QObject):
             )
 
             if not fresh_config:
-                raise Exception("Failed to load configuration")
+                raise ProfileManagerError("Failed to load configuration")
 
         except Exception as e:
             QMessageBox.critical(
@@ -378,7 +378,7 @@ class ActionsHandler(QObject):
                 self.log.info("Settings updated and files re-validated successfully")
 
             except Exception as e:
-                self.log.error(f"Error updating config after save: {e}", exc_info=True)
+                self.log.exception("Error updating config after save")
                 QMessageBox.warning(
                     self.mw,
                     "Warning",
@@ -434,7 +434,7 @@ class ActionsHandler(QObject):
                     self.mw.tag_delegate.tag_categories = updated_categories
 
             except Exception as e:
-                self.log.error(f"Error saving tag categories: {e}", exc_info=True)
+                self.log.exception("Error saving tag categories")
                 QMessageBox.critical(
                     self.mw, "Save Error", f"Failed to save tag categories:\n{e!s}"
                 )
@@ -483,7 +483,7 @@ class ActionsHandler(QObject):
             )
 
             if not fresh_config:
-                raise Exception("Failed to load configuration")
+                raise ProfileManagerError("Failed to load configuration")
 
             # Update main window config
             self.mw.active_profile_config = fresh_config
@@ -611,7 +611,7 @@ class ActionsHandler(QObject):
 
         return {
             "session_id": session_id,
-            "created_at": datetime.now().isoformat(),
+            "created_at": datetime.now().astimezone().isoformat(),
             "total_orders": len(orders_data),
             "total_items": int(df["Quantity"].sum())
             if "Quantity" in df.columns
@@ -661,7 +661,7 @@ class ActionsHandler(QObject):
                     base_filename = f"{report_name}.xlsx"
                 else:
                     # Add timestamp for stock exports and writeoff reports
-                    datestamp = datetime.now().strftime("%Y-%m-%d")
+                    datestamp = datetime.now().astimezone().strftime("%Y-%m-%d")
                     base_filename = f"{report_name}_{datestamp}.xls"
 
             # Ensure correct extension
@@ -764,8 +764,8 @@ class ActionsHandler(QObject):
                             "Skipping JSON creation - no data after filtering and exclude_skus"
                         )
 
-                except Exception as e:
-                    self.log.error(f"Failed to create JSON: {e}", exc_info=True)
+                except Exception:
+                    self.log.exception("Failed to create JSON")
                     # Don't fail the whole report if JSON fails
 
             elif report_type == "stock_exports":
@@ -842,8 +842,8 @@ class ActionsHandler(QObject):
                     # Don't fail the report if statistics update fails
 
         except Exception as e:
-            self.log.error(
-                f"Failed to generate report '{report_name}': {e}", exc_info=True
+            self.log.exception(
+                f"Failed to generate report '{report_name}'"
             )
             QMessageBox.critical(
                 self.mw,
@@ -882,7 +882,7 @@ class ActionsHandler(QObject):
             writeoff_dir.mkdir(parents=True, exist_ok=True)
 
             # Generate filename with timestamp
-            timestamp = datetime.now().strftime("%Y-%m-%d")
+            timestamp = datetime.now().astimezone().strftime("%Y-%m-%d")
             output_file = writeoff_dir / f"writeoff_{timestamp}.xls"
 
             # Get tag categories
@@ -904,7 +904,7 @@ class ActionsHandler(QObject):
             self.mw.log_activity("Report", "Generated writeoff report")
 
         except Exception as e:
-            self.log.error(f"Failed to generate writeoff report: {e}", exc_info=True)
+            self.log.exception("Failed to generate writeoff report")
             QMessageBox.critical(
                 self.mw,
                 "Generation Failed",
@@ -1173,7 +1173,7 @@ class ActionsHandler(QObject):
                 stock_df["SKU"] = stock_df["SKU"].apply(normalize_sku)
 
         except Exception as e:
-            self.log.error(f"Failed to load stock file: {e}", exc_info=True)
+            self.log.exception("Failed to load stock file")
             QMessageBox.critical(
                 self.mw,
                 "Error Loading Stock",
@@ -1413,8 +1413,8 @@ class ActionsHandler(QObject):
             try:
                 with open(additions_file, "r", encoding="utf-8") as f:
                     additions = json.load(f)
-            except Exception as e:
-                self.log.error(f"Failed to load manual additions: {e}", exc_info=True)
+            except Exception:
+                self.log.exception("Failed to load manual additions")
                 additions = []
         else:
             additions = []
@@ -1426,7 +1426,7 @@ class ActionsHandler(QObject):
                 "sku": product_data["sku"],
                 "product_name": product_data["product_name"],
                 "quantity": product_data["quantity"],
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now().astimezone().isoformat(),
             }
         )
 
@@ -1435,8 +1435,8 @@ class ActionsHandler(QObject):
             with open(additions_file, "w", encoding="utf-8") as f:
                 json.dump(additions, f, indent=2, ensure_ascii=False)
             self.log.info(f"Saved manual addition to {additions_file}")
-        except Exception as e:
-            self.log.error(f"Failed to save manual additions: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to save manual additions")
 
     def _update_undo_button(self):
         """Update undo button state and tooltip."""
@@ -1677,7 +1677,7 @@ class ActionsHandler(QObject):
             self.mw,
             "Select Tag to Remove",
             "Choose tag to remove from selected orders:",
-            sorted(list(all_tags)),
+            sorted(all_tags),
             0,
             False,
         )
@@ -2065,7 +2065,7 @@ class ActionsHandler(QObject):
             )
         except Exception as e:
             QMessageBox.critical(self.mw, "Save Error", str(e))
-            self.log.error(f"Failed to save combined stock export: {e}", exc_info=True)
+            self.log.exception("Failed to save combined stock export")
 
     def bulk_export_selection(self, format_type: str):
         """Export selected rows to file.
@@ -2131,4 +2131,4 @@ class ActionsHandler(QObject):
             QMessageBox.critical(
                 self.mw, "Export Failed", f"Failed to export selection:\n{e!s}"
             )
-            self.log.error(f"Bulk export failed: {e}", exc_info=True)
+            self.log.exception("Bulk export failed")

--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -1,20 +1,17 @@
-import os
 import logging
+import os
 from datetime import datetime
+
 import pandas as pd
-
 from PySide6.QtCore import QObject, Signal
-from PySide6.QtWidgets import QMessageBox, QInputDialog
+from PySide6.QtWidgets import QInputDialog, QMessageBox
 
-from gui.worker import Worker
-from shopify_tool import core
-from shopify_tool.analysis import toggle_order_fulfillment
-from shopify_tool import packing_lists
-from shopify_tool import stock_export
-from shopify_tool.session_manager import SessionManagerError
 from gui.settings_window_pyside import SettingsWindow
-from gui.report_selection_dialog import ReportSelectionDialog
 from gui.tag_categories_dialog import TagCategoriesDialog
+from gui.worker import Worker
+from shopify_tool import core, packing_lists, stock_export
+from shopify_tool.analysis import toggle_order_fulfillment
+from shopify_tool.session_manager import SessionManagerError
 
 
 class ActionsHandler(QObject):
@@ -67,8 +64,8 @@ class ActionsHandler(QObject):
 
         try:
             # Show progress dialog during session creation (can be slow on UNC paths)
-            from PySide6.QtWidgets import QProgressDialog
             from PySide6.QtCore import Qt
+            from PySide6.QtWidgets import QProgressDialog
 
             progress = QProgressDialog("Creating new session...", None, 0, 0, self.mw)
             progress.setWindowModality(Qt.WindowModal)
@@ -222,8 +219,8 @@ class ActionsHandler(QObject):
             # NEW: RECORD STATISTICS TO SERVER
             # ========================================
             try:
-                from shared.stats_manager import StatsManager
                 from shared.session_id import derive_session_id
+                from shared.stats_manager import StatsManager
 
                 self.log.info("Recording analysis statistics to server...")
 
@@ -290,8 +287,8 @@ class ActionsHandler(QObject):
             QMessageBox.information(
                 self.mw,
                 "Analysis Complete",
-                f"Analysis completed successfully!\n\n"
-                f"Results are now visible in the Analysis Results tab.",
+                "Analysis completed successfully!\n\n"
+                "Results are now visible in the Analysis Results tab.",
             )
         else:
             self.log.error(f"Analysis failed: {result_msg}")
@@ -337,12 +334,11 @@ class ActionsHandler(QObject):
 
         except Exception as e:
             QMessageBox.critical(
-                self.mw, "Error", f"Failed to load settings:\n{str(e)}"
+                self.mw, "Error", f"Failed to load settings:\n{e!s}"
             )
             return
 
         # Open settings with fresh data
-        from gui.settings_window_pyside import SettingsWindow
 
         settings_win = SettingsWindow(
             client_id=self.mw.current_client_id,
@@ -386,7 +382,7 @@ class ActionsHandler(QObject):
                 QMessageBox.warning(
                     self.mw,
                     "Warning",
-                    f"Settings were saved, but failed to reload configuration:\n{str(e)}\n\n"
+                    f"Settings were saved, but failed to reload configuration:\n{e!s}\n\n"
                     "Please restart the application.",
                 )
 
@@ -440,7 +436,7 @@ class ActionsHandler(QObject):
             except Exception as e:
                 self.log.error(f"Error saving tag categories: {e}", exc_info=True)
                 QMessageBox.critical(
-                    self.mw, "Save Error", f"Failed to save tag categories:\n{str(e)}"
+                    self.mw, "Save Error", f"Failed to save tag categories:\n{e!s}"
                 )
 
         dialog.categories_updated.connect(on_categories_updated)
@@ -496,7 +492,7 @@ class ActionsHandler(QObject):
             QMessageBox.critical(
                 self.mw,
                 "Configuration Error",
-                f"Failed to load client configuration:\n{str(e)}",
+                f"Failed to load client configuration:\n{e!s}",
             )
             return
 
@@ -600,6 +596,7 @@ class ActionsHandler(QObject):
             dict: JSON structure for Packing Tool
         """
         from datetime import datetime
+
         from shopify_tool.core import build_packing_order_data
 
         orders_data = []
@@ -630,8 +627,8 @@ class ActionsHandler(QObject):
             report_config (dict): Report configuration with name, filters, etc.
             session_path (Path): Current session directory
         """
-        from pathlib import Path
         import json
+        from pathlib import Path
 
         report_name = report_config.get("name", "Unknown")
         self.log.info(f"Generating {report_type}: {report_name}")
@@ -681,7 +678,7 @@ class ActionsHandler(QObject):
             # GENERATE REPORT USING PROPER MODULES
             # ========================================
             if report_type == "packing_lists":
-                self.log.info(f"Creating packing list using packing_lists module")
+                self.log.info("Creating packing list using packing_lists module")
 
                 # Get exclude_skus from config
                 exclude_skus = report_config.get("exclude_skus", [])
@@ -697,7 +694,7 @@ class ActionsHandler(QObject):
                 elif not isinstance(exclude_skus, list):
                     exclude_skus = []
                     self.log.warning(
-                        f"[EXCLUDE_SKUS] Unexpected type, reset to empty list"
+                        "[EXCLUDE_SKUS] Unexpected type, reset to empty list"
                     )
 
                 self.log.info(
@@ -764,7 +761,7 @@ class ActionsHandler(QObject):
                         )
                     else:
                         self.log.warning(
-                            f"Skipping JSON creation - no data after filtering and exclude_skus"
+                            "Skipping JSON creation - no data after filtering and exclude_skus"
                         )
 
                 except Exception as e:
@@ -772,7 +769,7 @@ class ActionsHandler(QObject):
                     # Don't fail the whole report if JSON fails
 
             elif report_type == "stock_exports":
-                self.log.info(f"Creating stock export using stock_export module")
+                self.log.info("Creating stock export using stock_export module")
 
                 # Get writeoff setting from report_config
                 apply_writeoff = report_config.get("apply_writeoff", False)
@@ -851,13 +848,13 @@ class ActionsHandler(QObject):
             QMessageBox.critical(
                 self.mw,
                 "Generation Failed",
-                f"Failed to generate report '{report_name}':\n\n{str(e)}",
+                f"Failed to generate report '{report_name}':\n\n{e!s}",
             )
 
     def generate_writeoff_report(self):
         """Generate writeoff report directly (single button, no dialog)."""
-        from pathlib import Path
         from datetime import datetime
+        from pathlib import Path
 
         self.log.info("Generating writeoff report")
 
@@ -911,7 +908,7 @@ class ActionsHandler(QObject):
             QMessageBox.critical(
                 self.mw,
                 "Generation Failed",
-                f"Failed to generate writeoff report:\n\n{str(e)}",
+                f"Failed to generate writeoff report:\n\n{e!s}",
             )
 
     def toggle_fulfillment_status_for_order(self, order_number):
@@ -1120,8 +1117,9 @@ class ActionsHandler(QObject):
 
     def show_add_product_dialog(self):
         """Show dialog to add product to order."""
-        from gui.add_product_dialog import AddProductDialog
         from PySide6.QtWidgets import QDialog
+
+        from gui.add_product_dialog import AddProductDialog
 
         # Validate prerequisites
         if (
@@ -1305,7 +1303,7 @@ class ActionsHandler(QObject):
             [self.mw.analysis_results_df, pd.DataFrame([new_row])], ignore_index=True
         )
 
-        self.log.info(f"Row added to analysis_results_df")
+        self.log.info("Row added to analysis_results_df")
 
         # Step 6: Recalculate fulfillment for THIS ORDER ONLY
         self._recalculate_order_fulfillment(order_num)
@@ -2005,9 +2003,11 @@ class ActionsHandler(QObject):
         Args:
             session_paths: List of session directory path strings.
         """
-        from PySide6.QtWidgets import QFileDialog, QMessageBox
-        from shopify_tool.stock_export import merge_session_stock_exports
         from pathlib import Path
+
+        from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+        from shopify_tool.stock_export import merge_session_stock_exports
 
         if not self.mw.current_client_id:
             QMessageBox.warning(self.mw, "Error", "No client selected.")
@@ -2073,8 +2073,9 @@ class ActionsHandler(QObject):
         Args:
             format_type: 'xlsx' or 'csv'
         """
-        from PySide6.QtWidgets import QFileDialog
         from pathlib import Path
+
+        from PySide6.QtWidgets import QFileDialog
 
         selected_df = self.mw.selection_helper.get_selected_orders_data()
 
@@ -2128,6 +2129,6 @@ class ActionsHandler(QObject):
 
         except Exception as e:
             QMessageBox.critical(
-                self.mw, "Export Failed", f"Failed to export selection:\n{str(e)}"
+                self.mw, "Export Failed", f"Failed to export selection:\n{e!s}"
             )
             self.log.error(f"Bulk export failed: {e}", exc_info=True)

--- a/gui/add_product_dialog.py
+++ b/gui/add_product_dialog.py
@@ -9,14 +9,22 @@ This dialog allows users to add products to existing orders with:
 - Live stock display
 """
 
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout,
-    QLineEdit, QSpinBox, QLabel, QPushButton,
-    QGroupBox, QMessageBox, QCompleter, QWidget
-)
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QIcon
 import logging
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCompleter,
+    QDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
 
 from gui.theme_manager import get_theme_manager
 

--- a/gui/background_worker.py
+++ b/gui/background_worker.py
@@ -17,9 +17,10 @@ Critical Pattern (prevents crashes from commit #216):
     4. Handle timeout gracefully (terminate if needed)
 """
 
-from PySide6.QtCore import QThread, Signal
 import logging
 import warnings
+
+from PySide6.QtCore import QThread, Signal
 
 logger = logging.getLogger(__name__)
 

--- a/gui/background_worker.py
+++ b/gui/background_worker.py
@@ -128,16 +128,16 @@ class BackgroundWorker(QThread):
             warnings.simplefilter("ignore")
             try:
                 self.finished_with_data.disconnect()
-            except Exception:
-                pass
+            except Exception as disconnect_exc:
+                logger.debug(f"finished_with_data already disconnected: {disconnect_exc}")
             try:
                 self.error_occurred.disconnect()
-            except Exception:
-                pass
+            except Exception as disconnect_exc:
+                logger.debug(f"error_occurred already disconnected: {disconnect_exc}")
             try:
                 self.progress_updated.disconnect()
-            except Exception:
-                pass
+            except Exception as disconnect_exc:
+                logger.debug(f"progress_updated already disconnected: {disconnect_exc}")
 
         # 2. Only shut down the thread if it's actually running
         if self.isRunning():

--- a/gui/barcode_generator_widget.py
+++ b/gui/barcode_generator_widget.py
@@ -312,7 +312,7 @@ class BarcodeGeneratorWidget(QWidget):
 
         except Exception as e:
             self.order_count_label.setText(f"Error reading packing list: {e!s}")
-            self.log.error(f"Failed to read packing list {packing_list_file}: {e}", exc_info=True)
+            self.log.exception(f"Failed to read packing list {packing_list_file}")
             return
 
         # Setup output directory
@@ -323,7 +323,7 @@ class BarcodeGeneratorWidget(QWidget):
         self.output_dir_label.setText(str(self.barcodes_dir))
 
         # Setup history manager
-        history_file = self.barcodes_dir / "barcode_history.json"        # History removed - using logs only
+        self.barcodes_dir / "barcode_history.json"        # History removed - using logs only
 
         # Enable generation if we have orders
         self.generate_btn.setEnabled(order_count > 0)
@@ -491,7 +491,7 @@ class BarcodeGeneratorWidget(QWidget):
 
     def _on_generation_error(self, error_info):
         """Handle generation error."""
-        exctype, value, traceback_str = error_info
+        _exctype, value, traceback_str = error_info
 
         self.status_label.setText("Generation failed")
         self.status_label.setStyleSheet("color: red; font-weight: bold;")
@@ -534,8 +534,8 @@ class BarcodeGeneratorWidget(QWidget):
             url = QUrl.fromLocalFile(str(pdf_path))
             QDesktopServices.openUrl(url)
 
-        except Exception as e:
-            self.log.error(f"Auto PDF generation failed: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Auto PDF generation failed")
 
     def _cleanup_png_files(self, results):
         """Remove PNG files after PDF generation (PDF-only mode)."""
@@ -552,8 +552,8 @@ class BarcodeGeneratorWidget(QWidget):
 
             self.log.info(f"Cleaned up {len(results)} PNG files (PDF-only mode)")
 
-        except Exception as e:
-            self.log.error(f"PNG cleanup failed: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("PNG cleanup failed")
 
 
     def _open_barcodes_folder(self):

--- a/gui/barcode_generator_widget.py
+++ b/gui/barcode_generator_widget.py
@@ -10,24 +10,27 @@ Features:
 - Export to PDF
 """
 
-import os
 import logging
 from pathlib import Path
-from datetime import datetime
 
 import pandas as pd
-
+from PySide6.QtCore import Qt, QThreadPool, QUrl, Signal
+from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QPushButton,
-    QLabel, QProgressBar, QTableWidget, QComboBox, QCheckBox,
-    QMessageBox, QTableWidgetItem, QHeaderView, QFileDialog
+    QCheckBox,
+    QComboBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtCore import Qt, QThreadPool, Signal
-from PySide6.QtGui import QPixmap, QDesktopServices
-from PySide6.QtCore import QUrl
 
-from gui.worker import Worker
 from gui.theme_manager import get_theme_manager
+from gui.worker import Worker
 
 
 class BarcodeGeneratorWidget(QWidget):
@@ -308,7 +311,7 @@ class BarcodeGeneratorWidget(QWidget):
             self.order_count_label.setText(f"{order_count} orders ready for barcode generation")
 
         except Exception as e:
-            self.order_count_label.setText(f"Error reading packing list: {str(e)}")
+            self.order_count_label.setText(f"Error reading packing list: {e!s}")
             self.log.error(f"Failed to read packing list {packing_list_file}: {e}", exc_info=True)
             return
 
@@ -511,6 +514,7 @@ class BarcodeGeneratorWidget(QWidget):
         """Generate PDF automatically after barcode generation."""
         try:
             from pathlib import Path
+
             from shopify_tool.barcode_processor import generate_barcodes_pdf
 
             # Convert string paths back to Path objects

--- a/gui/bulk_operations_toolbar.py
+++ b/gui/bulk_operations_toolbar.py
@@ -4,11 +4,16 @@ This module provides the BulkOperationsToolbar widget that contains buttons
 for performing mass operations on selected rows in the Analysis Results table.
 """
 
+from PySide6.QtCore import QPoint, QRect, QSize, Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget, QLayout, QLabel, QPushButton,
-    QToolButton, QMenu, QFrame
+    QFrame,
+    QLabel,
+    QLayout,
+    QMenu,
+    QPushButton,
+    QToolButton,
+    QWidget,
 )
-from PySide6.QtCore import Signal, Qt, QRect, QSize, QPoint
 
 from gui.theme_manager import get_theme_manager
 

--- a/gui/checkbox_delegate.py
+++ b/gui/checkbox_delegate.py
@@ -4,9 +4,14 @@ This module provides a custom delegate that renders a checkbox in the first
 column of the Analysis Results table for bulk selection functionality.
 """
 
-from PySide6.QtWidgets import QStyledItemDelegate, QStyleOptionButton, QApplication, QStyle
-from PySide6.QtCore import Qt, QRect, QEvent
+from PySide6.QtCore import QEvent, QRect
 from PySide6.QtGui import QPainter
+from PySide6.QtWidgets import (
+    QApplication,
+    QStyle,
+    QStyledItemDelegate,
+    QStyleOptionButton,
+)
 
 
 class CheckboxDelegate(QStyledItemDelegate):

--- a/gui/client_card.py
+++ b/gui/client_card.py
@@ -5,10 +5,12 @@ badges, and visual indicators for active state.
 """
 
 import logging
-from typing import Dict, Any, Optional
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QMessageBox
-from PySide6.QtCore import Signal, Qt, QPoint
+from typing import Any
+
+from PySide6.QtCore import QPoint, Qt, Signal
 from PySide6.QtGui import QMouseEvent
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QMessageBox, QVBoxLayout, QWidget
+
 from gui.theme_manager import get_theme_manager
 
 logger = logging.getLogger(__name__)
@@ -41,8 +43,8 @@ class ClientCard(QWidget):
         self,
         client_id: str,
         client_name: str,
-        metadata: Dict[str, Any],
-        ui_settings: Dict[str, Any],
+        metadata: dict[str, Any],
+        ui_settings: dict[str, Any],
         is_active: bool = False,
         parent=None
     ):
@@ -205,7 +207,7 @@ class ClientCard(QWidget):
 
         super().mousePressEvent(event)
 
-    def update_metadata(self, metadata: Dict[str, Any]):
+    def update_metadata(self, metadata: dict[str, Any]):
         """Update metadata and refresh display.
 
         Args:
@@ -222,7 +224,7 @@ class ClientCard(QWidget):
         total_sessions = metadata.get("total_sessions", 0)
         self.sessions_label.setText(f"Sessions: {total_sessions}")
 
-    def update_ui_settings(self, ui_settings: Dict[str, Any]):
+    def update_ui_settings(self, ui_settings: dict[str, Any]):
         """Update UI settings and refresh display.
 
         Args:

--- a/gui/client_reports_widget.py
+++ b/gui/client_reports_widget.py
@@ -11,16 +11,28 @@ Current sub-tabs:
 import logging
 from datetime import datetime
 
+from PySide6.QtCore import QDate, Qt, QThreadPool
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QTabWidget, QDateEdit, QTableWidget, QTableWidgetItem,
-    QSplitter, QHeaderView, QFileDialog, QMessageBox, QFrame,
-    QGroupBox, QSizePolicy,
+    QDateEdit,
+    QFileDialog,
+    QFrame,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtCore import Qt, QDate, QThreadPool
 
-from gui.worker import Worker
 from gui.theme_manager import get_theme_manager
+from gui.worker import Worker
 
 logger = logging.getLogger(__name__)
 

--- a/gui/client_reports_widget.py
+++ b/gui/client_reports_widget.py
@@ -266,8 +266,10 @@ class LabelPrintingTab(QWidget):
 
         qdate_from = self._date_from.date()
         qdate_to = self._date_to.date()
-        start_dt = datetime(qdate_from.year(), qdate_from.month(), qdate_from.day())
-        end_dt = datetime(qdate_to.year(), qdate_to.month(), qdate_to.day())
+        # Deliberately naive: date-only picker input, StatsManager.get_label_print_history
+        # is built to accept naive dates alongside its aware stored timestamps.
+        start_dt = datetime(qdate_from.year(), qdate_from.month(), qdate_from.day())  # noqa: DTZ001
+        end_dt = datetime(qdate_to.year(), qdate_to.month(), qdate_to.day())  # noqa: DTZ001
 
         def _load():
             from shared.stats_manager import StatsManager
@@ -360,7 +362,7 @@ class LabelPrintingTab(QWidget):
             return
 
         from datetime import date as _date
-        default_name = f"label_report_{client_id}_{_date.today().isoformat()}.xlsx"
+        default_name = f"label_report_{client_id}_{_date.today().isoformat()}.xlsx"  # noqa: DTZ011 -- local calendar day for a filename, not an instant
         file_path, _ = QFileDialog.getSaveFileName(
             self, "Export Label Report", default_name, "Excel Files (*.xlsx)"
         )

--- a/gui/client_settings_dialog.py
+++ b/gui/client_settings_dialog.py
@@ -199,7 +199,7 @@ class ClientCreationDialog(QDialog):
                 f"Failed to create client profile:\n{e!s}"
             )
         except Exception as e:
-            logger.error(f"Unexpected error creating client: {e}", exc_info=True)
+            logger.exception("Unexpected error creating client")
             QMessageBox.critical(
                 self,
                 "Error",
@@ -286,7 +286,7 @@ class ClientSelectorWidget(QWidget):
                 self._on_client_changed(self.client_combo.currentText())
 
         except Exception as e:
-            logger.error(f"Failed to refresh clients: {e}", exc_info=True)
+            logger.exception("Failed to refresh clients")
             QMessageBox.warning(
                 self,
                 "Error",
@@ -633,7 +633,7 @@ class ClientSettingsDialog(QDialog):
                 )
 
         except Exception as e:
-            logger.error(f"Failed to save client settings: {e}", exc_info=True)
+            logger.exception("Failed to save client settings")
             QMessageBox.critical(
                 self,
                 "Error",

--- a/gui/client_settings_dialog.py
+++ b/gui/client_settings_dialog.py
@@ -5,20 +5,34 @@ tabbed interface for Basic Info, Appearance, Statistics, and Advanced settings.
 """
 
 import logging
-from typing import Dict, Any, Optional
-from PySide6.QtWidgets import (
-    QWidget, QHBoxLayout, QLabel, QComboBox, QPushButton, QMessageBox,
-    QDialog, QVBoxLayout, QLineEdit, QDialogButtonBox, QFormLayout,
-    QTabWidget, QCheckBox, QColorDialog, QTextEdit
-)
+
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QColorDialog,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
 
-from shopify_tool.profile_manager import ProfileManager, ValidationError, ProfileManagerError
-from shopify_tool.groups_manager import GroupsManager
-from gui.wheel_ignore_combobox import WheelIgnoreComboBox
 from gui.theme_manager import get_theme_manager
-
+from gui.wheel_ignore_combobox import WheelIgnoreComboBox
+from shopify_tool.groups_manager import GroupsManager
+from shopify_tool.profile_manager import (
+    ProfileManager,
+    ProfileManagerError,
+    ValidationError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +43,7 @@ class ClientCreationDialog(QDialog):
     def __init__(
         self,
         profile_manager: ProfileManager,
-        groups_manager: Optional[GroupsManager] = None,
+        groups_manager: GroupsManager | None = None,
         parent=None
     ):
         super().__init__(parent)
@@ -182,14 +196,14 @@ class ClientCreationDialog(QDialog):
             QMessageBox.critical(
                 self,
                 "Error",
-                f"Failed to create client profile:\n{str(e)}"
+                f"Failed to create client profile:\n{e!s}"
             )
         except Exception as e:
             logger.error(f"Unexpected error creating client: {e}", exc_info=True)
             QMessageBox.critical(
                 self,
                 "Error",
-                f"An unexpected error occurred:\n{str(e)}"
+                f"An unexpected error occurred:\n{e!s}"
             )
 
 
@@ -276,7 +290,7 @@ class ClientSelectorWidget(QWidget):
             QMessageBox.warning(
                 self,
                 "Error",
-                f"Failed to load clients from server:\n{str(e)}"
+                f"Failed to load clients from server:\n{e!s}"
             )
 
     def _on_client_changed(self, client_id: str):
@@ -332,7 +346,7 @@ class ClientSettingsDialog(QDialog):
         self,
         client_id: str,
         profile_manager: ProfileManager,
-        groups_manager: Optional[GroupsManager] = None,
+        groups_manager: GroupsManager | None = None,
         parent=None
     ):
         """Initialize ClientSettingsDialog.
@@ -623,5 +637,5 @@ class ClientSettingsDialog(QDialog):
             QMessageBox.critical(
                 self,
                 "Error",
-                f"An error occurred while saving:\n{str(e)}"
+                f"An error occurred while saving:\n{e!s}"
             )

--- a/gui/client_sidebar.py
+++ b/gui/client_sidebar.py
@@ -8,20 +8,34 @@ This widget provides a sidebar for client navigation with:
 """
 
 import logging
-from typing import Dict, List, Optional
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QScrollArea, QMenu, QMessageBox, QApplication
-)
-from PySide6.QtCore import Signal, Qt, QPropertyAnimation, QEasingCurve, QSettings, QPoint
-from PySide6.QtGui import QPainter, QColor, QPen
 
-from shopify_tool.profile_manager import ProfileManager
-from shopify_tool.groups_manager import GroupsManager
+from PySide6.QtCore import (
+    QEasingCurve,
+    QPoint,
+    QPropertyAnimation,
+    QSettings,
+    Qt,
+    Signal,
+)
+from PySide6.QtGui import QColor, QPainter, QPen
+from PySide6.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QMenu,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
 from gui.client_card import ClientCard
+from gui.client_settings_dialog import ClientCreationDialog, ClientSettingsDialog
 from gui.groups_management_dialog import GroupsManagementDialog
-from gui.client_settings_dialog import ClientSettingsDialog, ClientCreationDialog
 from gui.theme_manager import get_theme_manager
+from shopify_tool.groups_manager import GroupsManager
+from shopify_tool.profile_manager import ProfileManager
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +186,7 @@ class ClientSidebar(QWidget):
         self.active_client_id = None
 
         # Track all ClientCard instances (for highlighting across sections)
-        self.client_cards: Dict[str, List[ClientCard]] = {}
+        self.client_cards: dict[str, list[ClientCard]] = {}
 
         self.setFixedWidth(self.EXPANDED_WIDTH)
 
@@ -278,6 +292,7 @@ class ClientSidebar(QWidget):
     def refresh(self):
         """Refresh client list and rebuild sections with performance logging."""
         import time
+
         from PySide6.QtCore import Qt
 
         theme = get_theme_manager().get_current_theme()
@@ -374,12 +389,12 @@ class ClientSidebar(QWidget):
         except Exception as e:
             self.setUpdatesEnabled(True)
             logger.error(f"Failed to refresh sidebar: {e}", exc_info=True)
-            QMessageBox.warning(self, "Refresh Error", f"Failed to refresh sidebar:\n{str(e)}")
+            QMessageBox.warning(self, "Refresh Error", f"Failed to refresh sidebar:\n{e!s}")
         finally:
             # Restore cursor after refresh completes (success or error)
             QApplication.restoreOverrideCursor()
 
-    def _create_pinned_section(self, all_clients: List[str], config: Dict) -> SectionWidget:
+    def _create_pinned_section(self, all_clients: list[str], config: dict) -> SectionWidget:
         """Create Pinned section.
 
         Args:
@@ -408,7 +423,7 @@ class ClientSidebar(QWidget):
         group_id: str,
         group_name: str,
         group_color: str,
-        all_clients: List[str]
+        all_clients: list[str]
     ) -> SectionWidget:
         """Create custom group section.
 
@@ -432,7 +447,7 @@ class ClientSidebar(QWidget):
 
         return section
 
-    def _create_all_section(self, clients: List[str], config: Dict) -> SectionWidget:
+    def _create_all_section(self, clients: list[str], config: dict) -> SectionWidget:
         """Create All Clients section.
 
         Args:
@@ -493,7 +508,7 @@ class ClientSidebar(QWidget):
 
         return card
 
-    def _get_section_client_ids(self, section: SectionWidget) -> List[str]:
+    def _get_section_client_ids(self, section: SectionWidget) -> list[str]:
         """Get list of client IDs in a section.
 
         Args:
@@ -677,7 +692,7 @@ class ClientSidebar(QWidget):
 
         except Exception as e:
             logger.error(f"Failed to toggle pin: {e}", exc_info=True)
-            QMessageBox.warning(self, "Error", f"Failed to toggle pin:\n{str(e)}")
+            QMessageBox.warning(self, "Error", f"Failed to toggle pin:\n{e!s}")
 
     def _edit_client(self, client_id: str):
         """Open edit dialog for client.
@@ -696,7 +711,7 @@ class ClientSidebar(QWidget):
             # Refresh sidebar after changes
             self.refresh()
 
-    def _move_to_group(self, client_id: str, group_id: Optional[str]):
+    def _move_to_group(self, client_id: str, group_id: str | None):
         """Move client to a different group.
 
         Args:
@@ -712,7 +727,7 @@ class ClientSidebar(QWidget):
 
         except Exception as e:
             logger.error(f"Failed to move client to group: {e}", exc_info=True)
-            QMessageBox.warning(self, "Error", f"Failed to move client:\n{str(e)}")
+            QMessageBox.warning(self, "Error", f"Failed to move client:\n{e!s}")
 
     def _delete_client(self, client_id: str):
         """Delete client after confirmation.
@@ -742,7 +757,7 @@ class ClientSidebar(QWidget):
 
             except Exception as e:
                 logger.error(f"Failed to delete client: {e}", exc_info=True)
-                QMessageBox.critical(self, "Error", f"Failed to delete client:\n{str(e)}")
+                QMessageBox.critical(self, "Error", f"Failed to delete client:\n{e!s}")
 
     def _open_groups_dialog(self):
         """Open groups management dialog."""

--- a/gui/client_sidebar.py
+++ b/gui/client_sidebar.py
@@ -79,7 +79,7 @@ class CollapsedClientIndicator(QWidget):
 class SectionWidget(QWidget):
     """Widget for a collapsible section (Pinned, Group, All Clients)."""
 
-    def __init__(self, title: str, color: str = None, parent=None):
+    def __init__(self, title: str, color: str | None = None, parent=None):
         """Initialize section widget.
 
         Args:
@@ -388,7 +388,7 @@ class ClientSidebar(QWidget):
 
         except Exception as e:
             self.setUpdatesEnabled(True)
-            logger.error(f"Failed to refresh sidebar: {e}", exc_info=True)
+            logger.exception("Failed to refresh sidebar")
             QMessageBox.warning(self, "Refresh Error", f"Failed to refresh sidebar:\n{e!s}")
         finally:
             # Restore cursor after refresh completes (success or error)
@@ -691,7 +691,7 @@ class ClientSidebar(QWidget):
             self.refresh()
 
         except Exception as e:
-            logger.error(f"Failed to toggle pin: {e}", exc_info=True)
+            logger.exception("Failed to toggle pin")
             QMessageBox.warning(self, "Error", f"Failed to toggle pin:\n{e!s}")
 
     def _edit_client(self, client_id: str):
@@ -726,7 +726,7 @@ class ClientSidebar(QWidget):
             self.refresh()
 
         except Exception as e:
-            logger.error(f"Failed to move client to group: {e}", exc_info=True)
+            logger.exception("Failed to move client to group")
             QMessageBox.warning(self, "Error", f"Failed to move client:\n{e!s}")
 
     def _delete_client(self, client_id: str):
@@ -756,7 +756,7 @@ class ClientSidebar(QWidget):
                 )
 
             except Exception as e:
-                logger.error(f"Failed to delete client: {e}", exc_info=True)
+                logger.exception("Failed to delete client")
                 QMessageBox.critical(self, "Error", f"Failed to delete client:\n{e!s}")
 
     def _open_groups_dialog(self):

--- a/gui/column_config_dialog.py
+++ b/gui/column_config_dialog.py
@@ -480,7 +480,7 @@ class ColumnConfigPanel(QWidget):
                 f"View '{view_name}' has been saved successfully."
             )
         except Exception as e:
-            logger.error(f"Failed to save view '{view_name}': {e}", exc_info=True)
+            logger.exception(f"Failed to save view '{view_name}'")
             QMessageBox.critical(
                 self,
                 "Save Failed",
@@ -520,7 +520,7 @@ class ColumnConfigPanel(QWidget):
                 self.view_combo.setCurrentIndex(index)
 
         except Exception as e:
-            logger.error(f"Failed to delete view '{view_name}': {e}", exc_info=True)
+            logger.exception(f"Failed to delete view '{view_name}'")
             QMessageBox.critical(
                 self,
                 "Delete Failed",
@@ -627,7 +627,7 @@ class ColumnConfigPanel(QWidget):
                 )
 
         except Exception as e:
-            logger.error(f"Failed to apply configuration: {e}", exc_info=True)
+            logger.exception("Failed to apply configuration")
             QMessageBox.critical(
                 self,
                 "Apply Failed",

--- a/gui/column_config_dialog.py
+++ b/gui/column_config_dialog.py
@@ -7,26 +7,25 @@ Phase 4 of table customization feature.
 """
 
 import logging
-from typing import Optional, List, Dict
 
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QDialog,
-    QVBoxLayout,
-    QHBoxLayout,
-    QPushButton,
-    QListWidget,
-    QListWidgetItem,
-    QLineEdit,
     QCheckBox,
     QComboBox,
-    QLabel,
-    QMessageBox,
-    QInputDialog,
+    QDialog,
     QGroupBox,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
     QWidget,
 )
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QIcon
+
 from gui.theme_manager import get_theme_manager
 
 logger = logging.getLogger(__name__)
@@ -57,10 +56,10 @@ class ColumnConfigPanel(QWidget):
 
         self._original_config = None
         self._original_view_name = None
-        self._current_columns: List[str] = []
+        self._current_columns: list[str] = []
         self._is_loading = False
 
-        self.additional_columns_config: List[dict] = []
+        self.additional_columns_config: list[dict] = []
 
         self._init_ui()
         self._connect_signals()
@@ -421,7 +420,6 @@ class ColumnConfigPanel(QWidget):
 
     def _on_auto_hide_toggled(self, checked: bool):
         """Handle auto-hide toggle."""
-        pass
 
     def _on_view_changed(self, view_name: str):
         """Handle view selection change."""
@@ -486,7 +484,7 @@ class ColumnConfigPanel(QWidget):
             QMessageBox.critical(
                 self,
                 "Save Failed",
-                f"Failed to save view: {str(e)}"
+                f"Failed to save view: {e!s}"
             )
 
     def _on_delete_view(self):
@@ -526,7 +524,7 @@ class ColumnConfigPanel(QWidget):
             QMessageBox.critical(
                 self,
                 "Delete Failed",
-                f"Failed to delete view: {str(e)}"
+                f"Failed to delete view: {e!s}"
             )
 
     def _on_reset(self):
@@ -633,7 +631,7 @@ class ColumnConfigPanel(QWidget):
             QMessageBox.critical(
                 self,
                 "Apply Failed",
-                f"Failed to apply configuration: {str(e)}"
+                f"Failed to apply configuration: {e!s}"
             )
 
     def _get_config_from_ui(self):
@@ -721,7 +719,7 @@ class ColumnConfigPanel(QWidget):
             f"Check the columns you want to include in your analysis, then click Apply."
         )
 
-    def _populate_additional_columns_list(self, columns_config: List[dict]):
+    def _populate_additional_columns_list(self, columns_config: list[dict]):
         """Populate the additional columns list widget."""
         self.additional_columns_list.clear()
 

--- a/gui/column_mapping_widget.py
+++ b/gui/column_mapping_widget.py
@@ -5,11 +5,18 @@ Users can see the relationship between their CSV columns and the internal proces
 """
 
 import logging
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QLabel,
-    QLineEdit, QPushButton, QScrollArea, QMessageBox, QGridLayout
-)
+
 from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
 from gui.theme_manager import get_theme_manager
 
 logger = logging.getLogger("ShopifyToolLogger")
@@ -114,7 +121,7 @@ class ColumnMappingWidget(QWidget):
         csv_label.setFixedWidth(120)
 
         csv_input = QLineEdit()
-        csv_input.setPlaceholderText(f"Enter column name...")
+        csv_input.setPlaceholderText("Enter column name...")
         csv_input.setMinimumWidth(200)
 
         # Set current value if exists

--- a/gui/file_handler.py
+++ b/gui/file_handler.py
@@ -1,11 +1,11 @@
-import os
 import logging
+import os
 import tempfile
 from pathlib import Path
-from typing import List, Tuple, Optional, Dict
+
 import pandas as pd
-from PySide6.QtWidgets import QFileDialog, QMessageBox, QListWidgetItem
 from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QFileDialog, QListWidgetItem, QMessageBox
 
 from shopify_tool import core
 
@@ -249,7 +249,7 @@ class FileHandler:
             QMessageBox.critical(
                 self.mw,
                 "File Load Error",
-                f"Failed to load stock file:\n{str(e)}\n\n"
+                f"Failed to load stock file:\n{e!s}\n\n"
                 f"Make sure the delimiter is set correctly in Settings.\n"
                 f"Current delimiter: '{delimiter}'",
             )
@@ -528,7 +528,7 @@ class FileHandler:
             )
         except Exception as e:
             QMessageBox.critical(
-                self.mw, "Validation Error", f"Error validating files:\n{str(e)}"
+                self.mw, "Validation Error", f"Error validating files:\n{e!s}"
             )
             return
 
@@ -553,7 +553,7 @@ class FileHandler:
             merged_path = self.merge_and_save_files(valid_files, "orders", folder_path)
         except Exception as e:
             QMessageBox.critical(
-                self.mw, "Merge Failed", f"Failed to merge files:\n{str(e)}"
+                self.mw, "Merge Failed", f"Failed to merge files:\n{e!s}"
             )
             return
 
@@ -652,7 +652,7 @@ class FileHandler:
             )
         except Exception as e:
             QMessageBox.critical(
-                self.mw, "Validation Error", f"Error validating files:\n{str(e)}"
+                self.mw, "Validation Error", f"Error validating files:\n{e!s}"
             )
             return
 
@@ -677,7 +677,7 @@ class FileHandler:
             merged_path = self.merge_and_save_files(valid_files, "stock", folder_path)
         except Exception as e:
             QMessageBox.critical(
-                self.mw, "Merge Failed", f"Failed to merge files:\n{str(e)}"
+                self.mw, "Merge Failed", f"Failed to merge files:\n{e!s}"
             )
             return
 
@@ -720,7 +720,7 @@ class FileHandler:
 
     def scan_folder_for_csv(
         self, folder_path: str, recursive: bool = False, pattern: str = "*.csv"
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Scan folder for CSV files.
 
@@ -752,8 +752,8 @@ class FileHandler:
         return result
 
     def validate_multiple_files(
-        self, file_paths: List[str], file_type: str
-    ) -> Tuple[List[str], List[Tuple[str, List[str]]], int]:
+        self, file_paths: list[str], file_type: str
+    ) -> tuple[list[str], list[tuple[str, list[str]]], int]:
         """
         Validate multiple CSV files.
 
@@ -833,7 +833,7 @@ class FileHandler:
                     )
 
             except Exception as e:
-                invalid_files.append((filepath, [f"Error: {str(e)}"]))
+                invalid_files.append((filepath, [f"Error: {e!s}"]))
                 self.log.error(f"  {os.path.basename(filepath)}: {e}", exc_info=True)
 
         return valid_files, invalid_files, total_rows
@@ -841,8 +841,8 @@ class FileHandler:
     def show_file_preview(
         self,
         file_type: str,
-        valid_files: List[str],
-        invalid_files: List[Tuple[str, List[str]]],
+        valid_files: list[str],
+        invalid_files: list[tuple[str, list[str]]],
         total_rows: int,
     ) -> bool:
         """
@@ -895,7 +895,7 @@ class FileHandler:
         return reply == QMessageBox.Yes
 
     def merge_and_save_files(
-        self, file_paths: List[str], file_type: str, original_folder: str
+        self, file_paths: list[str], file_type: str, original_folder: str
     ) -> str:
         """
         Merge CSV files and save to temp location.

--- a/gui/file_handler.py
+++ b/gui/file_handler.py
@@ -63,18 +63,18 @@ class FileHandler:
             self.log.info(
                 f"Orders file: detected delimiter '{detected_delimiter}' using {method}"
             )
-        except FileNotFoundError as e:
-            self.log.error(f"Orders file not found for delimiter detection: {e}", exc_info=True)
+        except FileNotFoundError:
+            self.log.exception("Orders file not found for delimiter detection")
             detected_delimiter = ","  # fallback to comma
-        except PermissionError as e:
-            self.log.error(f"Permission denied reading orders file: {e}", exc_info=True)
+        except PermissionError:
+            self.log.exception("Permission denied reading orders file")
             detected_delimiter = ","  # fallback to comma
-        except UnicodeDecodeError as e:
-            self.log.error(f"Encoding error in orders file: {e}", exc_info=True)
+        except UnicodeDecodeError:
+            self.log.exception("Encoding error in orders file")
             detected_delimiter = ","  # fallback to comma
-        except Exception as e:
-            self.log.error(
-                f"Unexpected error detecting delimiter for orders: {e}", exc_info=True
+        except Exception:
+            self.log.exception(
+                "Unexpected error detecting delimiter for orders"
             )
             detected_delimiter = ","  # fallback to comma
 
@@ -167,18 +167,18 @@ class FileHandler:
         try:
             detected_delimiter, method = detect_csv_delimiter(filepath)
             self.log.info(f"Detected delimiter '{detected_delimiter}' using {method}")
-        except FileNotFoundError as e:
-            self.log.error(f"Stock file not found for delimiter detection: {e}", exc_info=True)
+        except FileNotFoundError:
+            self.log.exception("Stock file not found for delimiter detection")
             detected_delimiter = ";"  # fallback
-        except PermissionError as e:
-            self.log.error(f"Permission denied reading stock file: {e}", exc_info=True)
+        except PermissionError:
+            self.log.exception("Permission denied reading stock file")
             detected_delimiter = ";"  # fallback
-        except UnicodeDecodeError as e:
-            self.log.error(f"Encoding error in stock file: {e}", exc_info=True)
+        except UnicodeDecodeError:
+            self.log.exception("Encoding error in stock file")
             detected_delimiter = ";"  # fallback
-        except Exception as e:
-            self.log.error(
-                f"Unexpected error detecting delimiter for stock: {e}", exc_info=True
+        except Exception:
+            self.log.exception(
+                "Unexpected error detecting delimiter for stock"
             )
             detected_delimiter = ";"  # fallback
 
@@ -245,7 +245,7 @@ class FileHandler:
             )
 
         except Exception as e:
-            self.log.error(f"Failed to load stock CSV: {e}", exc_info=True)
+            self.log.exception("Failed to load stock CSV")
             QMessageBox.critical(
                 self.mw,
                 "File Load Error",
@@ -795,7 +795,7 @@ class FileHandler:
         ]
 
         # Get delimiter from config
-        delimiter = config.get("settings", {}).get(delimiter_key, default_delimiter)
+        config.get("settings", {}).get(delimiter_key, default_delimiter)
 
         self.log.info(f"Validating {len(file_paths)} {file_type} files...")
         self.log.info(f"Required columns: {required_csv_cols}")
@@ -834,7 +834,7 @@ class FileHandler:
 
             except Exception as e:
                 invalid_files.append((filepath, [f"Error: {e!s}"]))
-                self.log.error(f"  {os.path.basename(filepath)}: {e}", exc_info=True)
+                self.log.exception(f"  {os.path.basename(filepath)}")
 
         return valid_files, invalid_files, total_rows
 

--- a/gui/groups_management_dialog.py
+++ b/gui/groups_management_dialog.py
@@ -4,16 +4,24 @@ This dialog provides a UI for managing custom client groups with color assignmen
 """
 
 import logging
-from typing import Optional
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QTableWidget,
-    QTableWidgetItem, QHeaderView, QMessageBox, QInputDialog, QColorDialog
-)
+
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QColorDialog,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QInputDialog,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
 
-from shopify_tool.groups_manager import GroupsManager, GroupsManagerError
 from gui.theme_manager import get_theme_manager
+from shopify_tool.groups_manager import GroupsManager, GroupsManagerError
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +159,7 @@ class GroupsManagementDialog(QDialog):
             QMessageBox.warning(
                 self,
                 "Error",
-                f"Failed to load groups:\n{str(e)}"
+                f"Failed to load groups:\n{e!s}"
             )
 
     def _on_selection_changed(self):
@@ -160,7 +168,7 @@ class GroupsManagementDialog(QDialog):
         self.edit_btn.setEnabled(has_selection)
         self.delete_btn.setEnabled(has_selection)
 
-    def _get_selected_group_id(self) -> Optional[str]:
+    def _get_selected_group_id(self) -> str | None:
         """Get selected group ID.
 
         Returns:
@@ -219,14 +227,14 @@ class GroupsManagementDialog(QDialog):
             QMessageBox.warning(
                 self,
                 "Error",
-                f"Failed to create group:\n{str(e)}"
+                f"Failed to create group:\n{e!s}"
             )
         except Exception as e:
             logger.error(f"Unexpected error creating group: {e}", exc_info=True)
             QMessageBox.critical(
                 self,
                 "Error",
-                f"An unexpected error occurred:\n{str(e)}"
+                f"An unexpected error occurred:\n{e!s}"
             )
 
     def _edit_group(self):
@@ -294,14 +302,14 @@ class GroupsManagementDialog(QDialog):
             QMessageBox.warning(
                 self,
                 "Error",
-                f"Failed to update group:\n{str(e)}"
+                f"Failed to update group:\n{e!s}"
             )
         except Exception as e:
             logger.error(f"Unexpected error updating group: {e}", exc_info=True)
             QMessageBox.critical(
                 self,
                 "Error",
-                f"An unexpected error occurred:\n{str(e)}"
+                f"An unexpected error occurred:\n{e!s}"
             )
 
     def _delete_group(self):
@@ -357,12 +365,12 @@ class GroupsManagementDialog(QDialog):
             QMessageBox.warning(
                 self,
                 "Error",
-                f"Failed to delete group:\n{str(e)}"
+                f"Failed to delete group:\n{e!s}"
             )
         except Exception as e:
             logger.error(f"Unexpected error deleting group: {e}", exc_info=True)
             QMessageBox.critical(
                 self,
                 "Error",
-                f"An unexpected error occurred:\n{str(e)}"
+                f"An unexpected error occurred:\n{e!s}"
             )

--- a/gui/groups_management_dialog.py
+++ b/gui/groups_management_dialog.py
@@ -155,7 +155,7 @@ class GroupsManagementDialog(QDialog):
             logger.info(f"Loaded {len(groups)} groups into table")
 
         except Exception as e:
-            logger.error(f"Failed to load groups: {e}", exc_info=True)
+            logger.exception("Failed to load groups")
             QMessageBox.warning(
                 self,
                 "Error",
@@ -230,7 +230,7 @@ class GroupsManagementDialog(QDialog):
                 f"Failed to create group:\n{e!s}"
             )
         except Exception as e:
-            logger.error(f"Unexpected error creating group: {e}", exc_info=True)
+            logger.exception("Unexpected error creating group")
             QMessageBox.critical(
                 self,
                 "Error",
@@ -305,7 +305,7 @@ class GroupsManagementDialog(QDialog):
                 f"Failed to update group:\n{e!s}"
             )
         except Exception as e:
-            logger.error(f"Unexpected error updating group: {e}", exc_info=True)
+            logger.exception("Unexpected error updating group")
             QMessageBox.critical(
                 self,
                 "Error",
@@ -368,7 +368,7 @@ class GroupsManagementDialog(QDialog):
                 f"Failed to delete group:\n{e!s}"
             )
         except Exception as e:
-            logger.error(f"Unexpected error deleting group: {e}", exc_info=True)
+            logger.exception("Unexpected error deleting group")
             QMessageBox.critical(
                 self,
                 "Error",

--- a/gui/log_handler.py
+++ b/gui/log_handler.py
@@ -1,4 +1,5 @@
 import logging
+
 from PySide6.QtCore import QObject, Signal
 
 

--- a/gui/log_viewer.py
+++ b/gui/log_viewer.py
@@ -1,9 +1,10 @@
-import customtkinter as ctk
-import tkinter as tk
-from tkinter import ttk
 import logging
-from collections import deque
 import time
+import tkinter as tk
+from collections import deque
+from tkinter import ttk
+
+import customtkinter as ctk
 
 from gui.theme_manager import get_theme_manager
 

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -1,43 +1,36 @@
-import sys
-import os
 import json
-import shutil
-import pickle
 import logging
+import os
+import sys
 from datetime import datetime
 
 import pandas as pd
+from PySide6.QtCore import QModelIndex, QPoint, Qt, QThreadPool, QTimer
+from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (
     QApplication,
     QMainWindow,
-    QMessageBox,
     QMenu,
+    QMessageBox,
     QTableWidgetItem,
-    QLabel,
 )
-from PySide6.QtCore import QThreadPool, QPoint, QModelIndex, QTimer, Qt
-from PySide6.QtGui import QAction
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from shopify_tool.analysis import recalculate_statistics
-from shopify_tool.profile_manager import ProfileManager, NetworkError
-from shared.server_connection import prompt_for_recovery_path
-from shopify_tool.session_manager import SessionManager
-from shopify_tool.groups_manager import GroupsManager
-from shopify_tool.undo_manager import UndoManager
-from shopify_tool.tag_manager import _normalize_tag_categories
-from gui.log_handler import QtLogHandler
-from gui.ui_manager import UIManager
-from gui.file_handler import FileHandler
 from gui.actions_handler import ActionsHandler
-from gui.client_settings_dialog import ClientSelectorWidget
-from gui.session_browser_widget import SessionBrowserWidget
-from gui.profile_manager_dialog import ProfileManagerDialog
-from gui.tag_management_panel import TagManagementPanel
-from gui.selection_helper import SelectionHelper
+from gui.file_handler import FileHandler
+from gui.log_handler import QtLogHandler
 from gui.pandas_model import FulfillmentFilterProxy
+from gui.selection_helper import SelectionHelper
 from gui.theme_manager import get_theme_manager
+from gui.ui_manager import UIManager
+from shared.server_connection import prompt_for_recovery_path
+from shopify_tool.analysis import recalculate_statistics
+from shopify_tool.groups_manager import GroupsManager
+from shopify_tool.profile_manager import NetworkError, ProfileManager
+from shopify_tool.session_manager import SessionManager
+from shopify_tool.tag_manager import _normalize_tag_categories
+from shopify_tool.undo_manager import UndoManager
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +140,7 @@ class MainWindow(QMainWindow):
                 QMessageBox.critical(
                     self,
                     "Initialization Error",
-                    f"Failed to initialize profile managers:\n{str(e)}",
+                    f"Failed to initialize profile managers:\n{e!s}",
                 )
                 QApplication.quit()
                 return
@@ -172,7 +165,7 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(
                 self,
                 "Initialization Error",
-                f"Failed to initialize profile managers:\n{str(e)}",
+                f"Failed to initialize profile managers:\n{e!s}",
             )
             QApplication.quit()
             return
@@ -254,7 +247,7 @@ class MainWindow(QMainWindow):
         except Exception as e:
             logging.error(f"Failed to load client config: {e}", exc_info=True)
             QMessageBox.critical(
-                self, "Error", f"Failed to load client configuration:\n{str(e)}"
+                self, "Error", f"Failed to load client configuration:\n{e!s}"
             )
 
     def setup_logging(self):
@@ -352,7 +345,7 @@ class MainWindow(QMainWindow):
             )
 
         # Add Ctrl+R shortcut for Run Analysis
-        from PySide6.QtGui import QShortcut, QKeySequence
+        from PySide6.QtGui import QKeySequence, QShortcut
 
         QShortcut(
             QKeySequence("Ctrl+R"),
@@ -885,7 +878,7 @@ class MainWindow(QMainWindow):
 
         except Exception as e:
             logging.error(f"Error changing client: {e}", exc_info=True)
-            QMessageBox.critical(self, "Error", f"Failed to change client: {str(e)}")
+            QMessageBox.critical(self, "Error", f"Failed to change client: {e!s}")
 
     def on_sidebar_refresh(self):
         """Handle manual sidebar refresh request."""
@@ -1089,7 +1082,6 @@ class MainWindow(QMainWindow):
         Args:
             session_path: Path to the session directory
         """
-        from pathlib import Path
 
         try:
             # Set as current session
@@ -1139,7 +1131,7 @@ class MainWindow(QMainWindow):
 
         except Exception as e:
             logging.error(f"Failed to load session: {e}", exc_info=True)
-            QMessageBox.critical(self, "Error", f"Failed to load session:\n{str(e)}")
+            QMessageBox.critical(self, "Error", f"Failed to load session:\n{e!s}")
 
     def filter_table(self):
         """Applies the current filter settings to the results table view.
@@ -1387,8 +1379,9 @@ class MainWindow(QMainWindow):
             if not order_number:
                 return
 
-            from PySide6.QtWidgets import QStyle
             from functools import partial
+
+            from PySide6.QtWidgets import QStyle
 
             menu = QMenu()
 

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -158,7 +158,7 @@ class MainWindow(QMainWindow):
 
             self.table_config_manager = TableConfigManager(self, self.profile_manager)
 
-            logging.info(
+            logger.info(
                 "ProfileManager, SessionManager, GroupsManager, and TableConfigManager initialized successfully"
             )
         except Exception as e:
@@ -186,7 +186,7 @@ class MainWindow(QMainWindow):
             if config:
                 self.active_profile_config = config
                 self.current_client_id = client_id
-                logging.info(f"Loaded configuration for CLIENT_{client_id}")
+                logger.info(f"Loaded configuration for CLIENT_{client_id}")
 
                 # Sync analysis mode combo (block signals to avoid spurious saves)
                 if hasattr(self, "analysis_mode_combo"):
@@ -245,7 +245,7 @@ class MainWindow(QMainWindow):
                     f"Could not load configuration for CLIENT_{client_id}",
                 )
         except Exception as e:
-            logging.error(f"Failed to load client config: {e}", exc_info=True)
+            logger.exception("Failed to load client config")
             QMessageBox.critical(
                 self, "Error", f"Failed to load client configuration:\n{e!s}"
             )
@@ -584,8 +584,8 @@ class MainWindow(QMainWindow):
                     self.tableView.selectionModel().selectionChanged.disconnect(
                         self.on_selection_changed_for_tags
                     )
-                except:
-                    pass  # Not connected yet
+                except Exception as disconnect_exc:
+                    logger.debug(f"selectionChanged not connected yet: {disconnect_exc}")
                 self.tableView.selectionModel().selectionChanged.connect(
                     self.on_selection_changed_for_tags
                 )
@@ -651,11 +651,11 @@ class MainWindow(QMainWindow):
                 f"background-color: {theme.accent_green}; color: white;"
             )
             self._update_bulk_toolbar_state()
-            logging.info("Bulk mode enabled")
+            logger.info("Bulk mode enabled")
         else:
             self.toggle_bulk_mode_btn.setText("Bulk Operations")
             self.toggle_bulk_mode_btn.setStyleSheet("")
-            logging.info("Bulk mode disabled")
+            logger.info("Bulk mode disabled")
 
     def _update_bulk_toolbar_state(self):
         """Update bulk toolbar selection counter and button states."""
@@ -791,14 +791,14 @@ class MainWindow(QMainWindow):
             self.profile_manager.save_shopify_config(
                 self.current_client_id, self.active_profile_config
             )
-            logging.info(
+            logger.info(
                 f"Inventory memory {'enabled' if enabled else 'disabled'} for CLIENT_{self.current_client_id}"
             )
             # Re-evaluate run button (memory mode may unlock it)
             if hasattr(self, "update_ui_state"):
                 self.update_ui_state()
         except Exception as e:
-            logging.warning(f"Failed to save inventory memory toggle: {e}")
+            logger.warning(f"Failed to save inventory memory toggle: {e}")
 
     # --- Client and Session Management (New Architecture) ---
     def on_client_changed(self, client_id: str):
@@ -807,7 +807,7 @@ class MainWindow(QMainWindow):
         Args:
             client_id: Newly selected client ID
         """
-        logging.info(f"Client changed to: {client_id}")
+        logger.info(f"Client changed to: {client_id}")
 
         # Show loading status in status bar
         if hasattr(self, "statusBar"):
@@ -843,7 +843,7 @@ class MainWindow(QMainWindow):
             # Load table configuration for this client
             if hasattr(self, "table_config_manager"):
                 self.table_config_manager.load_config(client_id)
-                logging.info(f"Table configuration loaded for CLIENT_{client_id}")
+                logger.info(f"Table configuration loaded for CLIENT_{client_id}")
 
             # Clear currently loaded files (they're for different client)
             self.orders_file_path = None
@@ -870,14 +870,14 @@ class MainWindow(QMainWindow):
             # Update UI state
             self.update_ui_state()
 
-            logging.info(f"Client {client_id} loaded successfully")
+            logger.info(f"Client {client_id} loaded successfully")
 
             # Update status bar with success message
             if hasattr(self, "statusBar"):
                 self.statusBar().showMessage(f"CLIENT_{client_id} loaded", 2000)
 
         except Exception as e:
-            logging.error(f"Error changing client: {e}", exc_info=True)
+            logger.exception("Error changing client")
             QMessageBox.critical(self, "Error", f"Failed to change client: {e!s}")
 
     def on_sidebar_refresh(self):
@@ -887,7 +887,7 @@ class MainWindow(QMainWindow):
                 self.client_sidebar.refresh()
                 self.log_activity("UI", "Client sidebar refreshed")
         except Exception as e:
-            logging.error(f"Sidebar refresh failed: {e}", exc_info=True)
+            logger.exception("Sidebar refresh failed")
             QMessageBox.warning(self, "Refresh Error", str(e))
 
     def on_session_selected(self, session_path: str):
@@ -896,7 +896,7 @@ class MainWindow(QMainWindow):
         Args:
             session_path: Path to the selected session
         """
-        logging.info(f"Session selected: {session_path}")
+        logger.info(f"Session selected: {session_path}")
 
         reply = QMessageBox.question(
             self,
@@ -922,11 +922,11 @@ class MainWindow(QMainWindow):
 
         # Check prerequisites
         if not self.session_path:
-            logging.debug("No active session - skipping save_session_state")
+            logger.debug("No active session - skipping save_session_state")
             return
 
         if self.analysis_results_df is None or self.analysis_results_df.empty:
-            logging.debug("No analysis data to save - skipping save_session_state")
+            logger.debug("No analysis data to save - skipping save_session_state")
             return
 
         try:
@@ -942,24 +942,24 @@ class MainWindow(QMainWindow):
             stats_path = analysis_dir / "analysis_stats.json"
 
             # Save DataFrame to pickle (fast, primary format)
-            logging.info(f"Saving session state to {pkl_path}")
+            logger.info(f"Saving session state to {pkl_path}")
             self.analysis_results_df.to_pickle(pkl_path)
 
             # Save DataFrame to Excel (backup, human-readable)
-            logging.info(f"Saving session state backup to {xlsx_path}")
+            logger.info(f"Saving session state backup to {xlsx_path}")
             self.analysis_results_df.to_excel(xlsx_path, index=False)
 
             # Save statistics to JSON
             if self.analysis_stats:
-                logging.info(f"Saving statistics to {stats_path}")
+                logger.info(f"Saving statistics to {stats_path}")
                 with open(stats_path, "w", encoding="utf-8") as f:
                     json.dump(self.analysis_stats, f, indent=2, ensure_ascii=False)
 
-            logging.info("Session state saved successfully")
+            logger.info("Session state saved successfully")
 
-        except Exception as e:
+        except Exception:
             # Don't block UI if save fails - just log the error
-            logging.error(f"Failed to save session state: {e}", exc_info=True)
+            logger.exception("Failed to save session state")
 
     def _load_session_analysis(self, session_path):
         """Load analysis data from session directory.
@@ -985,29 +985,29 @@ class MainWindow(QMainWindow):
             pkl_path = analysis_dir / "current_state.pkl"
             if pkl_path.exists():
                 try:
-                    logging.info(f"Loading session state from pickle: {pkl_path}")
+                    logger.info(f"Loading session state from pickle: {pkl_path}")
                     self.analysis_results_df = pd.read_pickle(pkl_path)
 
                     # Load statistics from JSON if available
                     stats_path = analysis_dir / "analysis_stats.json"
                     if stats_path.exists():
-                        logging.info(f"Loading statistics from: {stats_path}")
+                        logger.info(f"Loading statistics from: {stats_path}")
                         with open(stats_path, "r", encoding="utf-8") as f:
                             self.analysis_stats = json.load(f)
                     else:
                         # Recalculate if stats file missing
-                        logging.info("Statistics file not found - recalculating")
+                        logger.info("Statistics file not found - recalculating")
                         self.analysis_stats = recalculate_statistics(
                             self.analysis_results_df
                         )
 
-                    logging.info(
+                    logger.info(
                         f"Loaded {len(self.analysis_results_df)} rows from current_state.pkl"
                     )
                     return True
 
                 except Exception as e:
-                    logging.warning(
+                    logger.warning(
                         f"Failed to load pickle, trying Excel fallback: {e}"
                     )
                     # Continue to fallback options
@@ -1016,7 +1016,7 @@ class MainWindow(QMainWindow):
             xlsx_path = analysis_dir / "current_state.xlsx"
             if xlsx_path.exists():
                 try:
-                    logging.info(f"Loading session state from Excel: {xlsx_path}")
+                    logger.info(f"Loading session state from Excel: {xlsx_path}")
                     self.analysis_results_df = pd.read_excel(xlsx_path)
 
                     # Load or recalculate statistics
@@ -1029,13 +1029,13 @@ class MainWindow(QMainWindow):
                             self.analysis_results_df
                         )
 
-                    logging.info(
+                    logger.info(
                         f"Loaded {len(self.analysis_results_df)} rows from current_state.xlsx"
                     )
                     return True
 
                 except Exception as e:
-                    logging.warning(
+                    logger.warning(
                         f"Failed to load current_state.xlsx, trying original report: {e}"
                     )
                     # Continue to fallback
@@ -1045,10 +1045,10 @@ class MainWindow(QMainWindow):
             analysis_data_file = analysis_dir / "analysis_data.json"
 
             if not analysis_data_file.exists():
-                logging.warning(f"Analysis data not found: {analysis_data_file}")
+                logger.warning(f"Analysis data not found: {analysis_data_file}")
                 return False
 
-            logging.info(f"Found analysis data: {analysis_data_file}")
+            logger.info(f"Found analysis data: {analysis_data_file}")
 
             # Load the actual Excel report to get DataFrame
             report_file = analysis_dir / "fulfillment_analysis.xlsx"
@@ -1058,10 +1058,10 @@ class MainWindow(QMainWindow):
                 report_file = analysis_dir / "analysis_report.xlsx"
 
             if not report_file.exists():
-                logging.warning(f"Analysis report not found: {report_file}")
+                logger.warning(f"Analysis report not found: {report_file}")
                 return False
 
-            logging.info(f"Loading analysis from original report: {report_file}")
+            logger.info(f"Loading analysis from original report: {report_file}")
 
             # Load DataFrame from Excel
             self.analysis_results_df = pd.read_excel(report_file)
@@ -1069,11 +1069,11 @@ class MainWindow(QMainWindow):
             # Recalculate statistics (no saved stats for original report)
             self.analysis_stats = recalculate_statistics(self.analysis_results_df)
 
-            logging.info(f"Loaded {len(self.analysis_results_df)} rows from session")
+            logger.info(f"Loaded {len(self.analysis_results_df)} rows from session")
             return True
 
-        except Exception as e:
-            logging.error(f"Failed to load session analysis: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to load session analysis")
             return False
 
     def load_existing_session(self, session_path: str):
@@ -1130,7 +1130,7 @@ class MainWindow(QMainWindow):
                 self.update_ui_state()
 
         except Exception as e:
-            logging.error(f"Failed to load session: {e}", exc_info=True)
+            logger.exception("Failed to load session")
             QMessageBox.critical(self, "Error", f"Failed to load session:\n{e!s}")
 
     def filter_table(self):
@@ -1171,8 +1171,8 @@ class MainWindow(QMainWindow):
                 self.update_statistics_tab()
                 # Update summary bar in Tab 2
                 self.ui_manager.update_summary_bar()
-            except Exception as e:
-                logging.error(f"Failed to recalculate statistics: {e}", exc_info=True)
+            except Exception:
+                logger.exception("Failed to recalculate statistics")
                 self.analysis_stats = None
                 self._clear_statistics_view()
         else:
@@ -1308,11 +1308,11 @@ class MainWindow(QMainWindow):
             self.profile_manager.save_shopify_config(
                 self.current_client_id, self.active_profile_config
             )
-            logging.debug(
+            logger.debug(
                 f"Saved analysis_mode={mode!r} for CLIENT_{self.current_client_id}"
             )
-        except Exception as e:
-            logging.error(f"Failed to save analysis_mode: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save analysis_mode")
 
     def log_activity(self, op_type, desc):
         """Adds a new entry to the 'Activity Log' table in the UI.
@@ -1321,7 +1321,7 @@ class MainWindow(QMainWindow):
             op_type (str): The type of operation (e.g., "Session", "Analysis").
             desc (str): A description of the activity.
         """
-        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        current_time = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
         self.activity_log_table.insertRow(0)
         self.activity_log_table.setItem(0, 0, QTableWidgetItem(current_time))
         self.activity_log_table.setItem(0, 1, QTableWidgetItem(op_type))

--- a/gui/order_group_delegate.py
+++ b/gui/order_group_delegate.py
@@ -1,8 +1,8 @@
 """Custom ItemDelegate for drawing borders between order groups."""
 
+from PySide6.QtGui import QColor, QPen
 from PySide6.QtWidgets import QStyledItemDelegate
-from PySide6.QtGui import QPainter, QPen, QColor
-from PySide6.QtCore import Qt
+
 from gui.theme_manager import get_theme_manager
 
 

--- a/gui/pandas_model.py
+++ b/gui/pandas_model.py
@@ -1,6 +1,7 @@
-from PySide6.QtCore import QAbstractTableModel, QSortFilterProxyModel, Qt, QModelIndex
-from PySide6.QtGui import QColor
 import pandas as pd
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, QSortFilterProxyModel, Qt
+from PySide6.QtGui import QColor
+
 from gui.theme_manager import get_theme_manager
 
 

--- a/gui/profile_manager_dialog.py
+++ b/gui/profile_manager_dialog.py
@@ -91,10 +91,9 @@ class ProfileManagerDialog(QDialog):
         old_name = current_item.text()
         new_name, ok = QInputDialog.getText(self, "Rename Profile", f"Enter new name for '{old_name}':", text=old_name)
 
-        if ok and new_name and new_name != old_name:
-            if self.parent.rename_profile(old_name, new_name):
-                self.populate_profiles()
-                self.parent.update_profile_combo()
+        if ok and new_name and new_name != old_name and self.parent.rename_profile(old_name, new_name):
+            self.populate_profiles()
+            self.parent.update_profile_combo()
 
     def delete_profile(self):
         """Handles the 'Delete' button click.
@@ -116,7 +115,6 @@ class ProfileManagerDialog(QDialog):
             QMessageBox.No
         )
 
-        if reply == QMessageBox.Yes:
-            if self.parent.delete_profile(name_to_delete):
-                self.populate_profiles()
-                self.parent.update_profile_combo()
+        if reply == QMessageBox.Yes and self.parent.delete_profile(name_to_delete):
+            self.populate_profiles()
+            self.parent.update_profile_combo()

--- a/gui/profile_manager_dialog.py
+++ b/gui/profile_manager_dialog.py
@@ -1,12 +1,12 @@
 from PySide6.QtWidgets import (
     QDialog,
-    QVBoxLayout,
+    QHBoxLayout,
+    QInputDialog,
     QListWidget,
     QListWidgetItem,
-    QHBoxLayout,
-    QPushButton,
-    QInputDialog,
     QMessageBox,
+    QPushButton,
+    QVBoxLayout,
 )
 
 

--- a/gui/reference_labels_widget.py
+++ b/gui/reference_labels_widget.py
@@ -344,8 +344,8 @@ class ReferenceLabelsWidget(QWidget):
 
             self.log.info(f"Output directory set: {self.output_dir}")
 
-        except Exception as e:
-            self.log.error(f"Failed to set output directory: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to set output directory")
             self.output_dir = None
             self.output_dir_label.setText("Error accessing session directory")
             self.output_dir_label.setStyleSheet("color: red;")
@@ -366,7 +366,7 @@ class ReferenceLabelsWidget(QWidget):
             errors.append("PDF file not selected")
         elif not Path(self.pdf_path).exists():
             errors.append(f"PDF file not found: {self.pdf_path}")
-        elif not Path(self.pdf_path).suffix.lower() == '.pdf':
+        elif Path(self.pdf_path).suffix.lower() != '.pdf':
             errors.append("Selected file is not a PDF")
 
         # Validate CSV
@@ -374,7 +374,7 @@ class ReferenceLabelsWidget(QWidget):
             errors.append("CSV file not selected")
         elif not Path(self.csv_path).exists():
             errors.append(f"CSV file not found: {self.csv_path}")
-        elif not Path(self.csv_path).suffix.lower() == '.csv':
+        elif Path(self.csv_path).suffix.lower() != '.csv':
             errors.append("Selected file is not a CSV")
 
         # Validate output directory
@@ -524,7 +524,7 @@ class ReferenceLabelsWidget(QWidget):
         Args:
             error_info: Tuple of (exc_type, exc_value, traceback_str)
         """
-        exctype, value, traceback_str = error_info
+        _exctype, value, traceback_str = error_info
 
         self.status_label.setText("Processing failed")
         self.status_label.setStyleSheet("color: red; font-weight: bold;")
@@ -636,11 +636,10 @@ class ReferenceLabelsWidget(QWidget):
             QMessageBox.No
         )
 
-        if reply == QMessageBox.Yes:
-            if self.history:
-                self.history.clear()
-                self._load_history()
-                self.log.info("History cleared")
+        if reply == QMessageBox.Yes and self.history:
+            self.history.clear()
+            self._load_history()
+            self.log.info("History cleared")
 
     def _open_history_item(self, index):
         """

--- a/gui/reference_labels_widget.py
+++ b/gui/reference_labels_widget.py
@@ -8,24 +8,32 @@ Features:
 - Error handling
 """
 
-import os
 import logging
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QPushButton,
-    QLabel, QProgressBar, QTableWidget, QFileDialog, QCheckBox,
-    QMessageBox, QTableWidgetItem, QHeaderView
-)
-from PySide6.QtCore import Qt, QThreadPool, Signal
+from PySide6.QtCore import Qt, QThreadPool, QUrl, Signal
 from PySide6.QtGui import QDesktopServices
-from PySide6.QtCore import QUrl
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
+from gui.theme_manager import get_theme_manager
 from gui.worker import Worker
 from shopify_tool.reference_labels_history import ReferenceLabelsHistory
 
-from gui.theme_manager import get_theme_manager
 
 class ReferenceLabelsWidget(QWidget):
     """Widget for processing reference labels PDFs."""
@@ -525,7 +533,9 @@ class ReferenceLabelsWidget(QWidget):
 
         # Map errors to user-friendly messages
         from shopify_tool.pdf_processor import (
-            InvalidPDFError, InvalidCSVError, MappingError
+            InvalidCSVError,
+            InvalidPDFError,
+            MappingError,
         )
 
         if isinstance(value, InvalidPDFError):

--- a/gui/report_selection_dialog.py
+++ b/gui/report_selection_dialog.py
@@ -1,9 +1,19 @@
+from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QCheckBox,
-    QFrame, QListWidget, QListWidgetItem, QSplitter, QGroupBox, QTextEdit,
-    QWidget
+    QCheckBox,
+    QDialog,
+    QFrame,
+    QGroupBox,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSplitter,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtCore import Signal, Slot, Qt
+
 from gui.theme_manager import get_theme_manager
 
 
@@ -141,7 +151,7 @@ class ReportSelectionDialog(QDialog):
                         tooltip_lines.append(f"• {filter_text}")
             else:
                 # Unknown format - display as string
-                tooltip_lines.append(f"• {str(filters)}")
+                tooltip_lines.append(f"• {filters!s}")
         else:
             tooltip_lines.append("<i>No filters (includes all data)</i>")
 
@@ -295,7 +305,6 @@ class _BaseReportDialog(QDialog):
 
     def _add_extra_sections(self, layout):
         """Override in subclasses to add sections between preview and generate button."""
-        pass
 
     def _populate_list(self):
         """Fill the report list from reports_config."""

--- a/gui/rule_test_dialog.py
+++ b/gui/rule_test_dialog.py
@@ -9,14 +9,20 @@ Allows users to:
 """
 
 import logging
+
 import pandas as pd
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QPushButton,
-    QGroupBox, QTableWidget, QTableWidgetItem,
-    QLabel, QMessageBox, QScrollArea, QWidget
-)
-from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
 
 logger = logging.getLogger(__name__)
 from gui.theme_manager import get_theme_manager
@@ -207,7 +213,7 @@ class RuleTestDialog(QDialog):
             QMessageBox.critical(
                 self,
                 "Test Error",
-                f"Failed to test rule:\n\n{str(e)}\n\nCheck logs for details."
+                f"Failed to test rule:\n\n{e!s}\n\nCheck logs for details."
             )
 
     def _detect_changed_rows(self):
@@ -332,11 +338,11 @@ class RuleTestDialog(QDialog):
                 actions_text += f": <code>{action_value}</code>"
 
             if action_type == "ADD_TAG":
-                actions_text += f" → Appends to Status_Note column"
+                actions_text += " → Appends to Status_Note column"
             elif action_type == "SET_STATUS":
-                actions_text += f" → Sets Order_Fulfillment_Status"
+                actions_text += " → Sets Order_Fulfillment_Status"
             elif action_type == "ADD_INTERNAL_TAG":
-                actions_text += f" → Appends to Internal_Tags (JSON list)"
+                actions_text += " → Appends to Internal_Tags (JSON list)"
             elif action_type == "COPY_FIELD":
                 source = action.get("source", "")
                 target = action.get("target", "")

--- a/gui/rule_test_dialog.py
+++ b/gui/rule_test_dialog.py
@@ -209,7 +209,7 @@ class RuleTestDialog(QDialog):
             self._populate_after_actions_table()
 
         except Exception as e:
-            logger.error(f"[RULE TEST] Error testing rule: {e}", exc_info=True)
+            logger.exception("[RULE TEST] Error testing rule")
             QMessageBox.critical(
                 self,
                 "Test Error",

--- a/gui/rule_validator.py
+++ b/gui/rule_validator.py
@@ -12,12 +12,11 @@ validation and execution.
 """
 
 import logging
-from typing import Tuple, Optional
 
 logger = logging.getLogger(__name__)
 
 
-def validate_regex(pattern: str) -> Tuple[bool, Optional[str]]:
+def validate_regex(pattern: str) -> tuple[bool, str | None]:
     """
     Validate regex pattern using rule engine's safe compiler.
 
@@ -47,7 +46,7 @@ def validate_regex(pattern: str) -> Tuple[bool, Optional[str]]:
     return (True, None)
 
 
-def validate_date(date_str: str) -> Tuple[bool, Optional[str]]:
+def validate_date(date_str: str) -> tuple[bool, str | None]:
     """
     Validate date string using rule engine's safe parser.
 
@@ -83,7 +82,7 @@ def validate_date(date_str: str) -> Tuple[bool, Optional[str]]:
     return (True, None)
 
 
-def validate_range(range_str: str) -> Tuple[bool, Optional[str], Optional[str]]:
+def validate_range(range_str: str) -> tuple[bool, str | None, str | None]:
     """
     Validate range string using rule engine's parser.
 
@@ -127,7 +126,7 @@ def validate_range(range_str: str) -> Tuple[bool, Optional[str], Optional[str]]:
         return (False, "Invalid format. Use: start-end (e.g., 10-100)", None)
 
 
-def validate_list(list_str: str) -> Tuple[bool, int, Optional[str]]:
+def validate_list(list_str: str) -> tuple[bool, int, str | None]:
     """
     Validate and count list items.
 
@@ -165,7 +164,7 @@ def validate_list(list_str: str) -> Tuple[bool, int, Optional[str]]:
     return (True, len(items), None)
 
 
-def validate_numeric(value_str: str) -> Tuple[bool, Optional[str]]:
+def validate_numeric(value_str: str) -> tuple[bool, str | None]:
     """
     Validate that a string can be converted to a number.
 

--- a/gui/selection_helper.py
+++ b/gui/selection_helper.py
@@ -41,7 +41,7 @@ class SelectionHelper:
         Returns:
             List of integer indexes in analysis_results_df, sorted ascending
         """
-        return sorted(list(self.checked_rows))
+        return sorted(self.checked_rows)
 
     def get_selected_orders_data(self) -> pd.DataFrame:
         """Get DataFrame slice of selected rows.

--- a/gui/selection_helper.py
+++ b/gui/selection_helper.py
@@ -4,7 +4,7 @@ This module provides the SelectionHelper class that manages table selection
 and checkbox state for bulk operations on the Analysis Results table.
 """
 
-from typing import List, Tuple, Set
+
 import pandas as pd
 
 
@@ -33,9 +33,9 @@ class SelectionHelper:
         self.table_view = table_view
         self.proxy_model = proxy_model
         self.main_window = main_window
-        self.checked_rows: Set[int] = set()  # Set of source DataFrame indexes
+        self.checked_rows: set[int] = set()  # Set of source DataFrame indexes
 
-    def get_selected_source_rows(self) -> List[int]:
+    def get_selected_source_rows(self) -> list[int]:
         """Get list of source DataFrame indexes for checked rows.
 
         Returns:
@@ -63,7 +63,7 @@ class SelectionHelper:
 
         return df.loc[valid_indexes].copy()
 
-    def get_selection_summary(self) -> Tuple[int, int]:
+    def get_selection_summary(self) -> tuple[int, int]:
         """Get summary of selected items.
 
         Returns:

--- a/gui/session_browser_widget.py
+++ b/gui/session_browser_widget.py
@@ -6,27 +6,26 @@ with filtering by status and the ability to open existing sessions.
 
 import logging
 from datetime import datetime
+
+from PySide6.QtCore import QEvent, Qt, Signal
 from PySide6.QtWidgets import (
-    QWidget,
-    QVBoxLayout,
+    QGroupBox,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
     QTableWidget,
     QTableWidgetItem,
-    QPushButton,
-    QComboBox,
-    QGroupBox,
-    QHeaderView,
-    QMessageBox,
-    QLineEdit,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtCore import Signal, Qt, QEvent
 
-from shopify_tool.session_manager import SessionManager
-from gui.wheel_ignore_combobox import WheelIgnoreComboBox
-from gui.theme_manager import get_theme_manager
 from gui.background_worker import BackgroundWorker
-
+from gui.theme_manager import get_theme_manager
+from gui.wheel_ignore_combobox import WheelIgnoreComboBox
+from shopify_tool.session_manager import SessionManager
 
 logger = logging.getLogger(__name__)
 
@@ -292,7 +291,7 @@ class SessionBrowserWidget(QWidget):
 
         except Exception as e:
             logger.error(f"Failed to load sessions: {e}", exc_info=True)
-            QMessageBox.warning(self, "Error", f"Failed to load sessions:\n{str(e)}")
+            QMessageBox.warning(self, "Error", f"Failed to load sessions:\n{e!s}")
 
     def _on_sessions_loaded(self, sessions_data):
         """Handle loaded data in main thread (safe for UI updates)."""
@@ -344,7 +343,7 @@ class SessionBrowserWidget(QWidget):
                 try:
                     dt = datetime.fromisoformat(created_at)
                     created_str = dt.strftime("%Y-%m-%d %H:%M")
-                except (ValueError, TypeError) as e:
+                except (ValueError, TypeError):
                     # Invalid datetime format, use original string
                     created_str = created_at
             else:
@@ -505,7 +504,7 @@ Comments: {comments if comments else "None"}"""
 
         except Exception as e:
             logger.error(f"Failed to update status: {e}", exc_info=True)
-            QMessageBox.critical(self, "Error", f"Failed to update status:\n{str(e)}")
+            QMessageBox.critical(self, "Error", f"Failed to update status:\n{e!s}")
             # Revert to previous value
             self.refresh_sessions()
 

--- a/gui/session_browser_widget.py
+++ b/gui/session_browser_widget.py
@@ -71,7 +71,7 @@ class SessionLoaderWorker(BackgroundWorker):
 
         except Exception as e:
             if not self._is_cancelled:
-                logger.error(f"Error loading sessions: {e}", exc_info=True)
+                logger.exception("Error loading sessions")
                 self.error_occurred.emit(str(e))
 
 
@@ -290,7 +290,7 @@ class SessionBrowserWidget(QWidget):
             logger.info(f"Loaded {len(self.sessions_data)} sessions (sync mode)")
 
         except Exception as e:
-            logger.error(f"Failed to load sessions: {e}", exc_info=True)
+            logger.exception("Failed to load sessions")
             QMessageBox.warning(self, "Error", f"Failed to load sessions:\n{e!s}")
 
     def _on_sessions_loaded(self, sessions_data):
@@ -503,7 +503,7 @@ Comments: {comments if comments else "None"}"""
             logger.info(f"Updated session status: {session_path} -> {status}")
 
         except Exception as e:
-            logger.error(f"Failed to update status: {e}", exc_info=True)
+            logger.exception("Failed to update status")
             QMessageBox.critical(self, "Error", f"Failed to update status:\n{e!s}")
             # Revert to previous value
             self.refresh_sessions()
@@ -523,8 +523,8 @@ Comments: {comments if comments else "None"}"""
 
             logger.info(f"Updated session comments: {session_path}")
 
-        except Exception as e:
-            logger.error(f"Failed to update comments: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to update comments")
             # Don't show error dialog for comments (less critical)
             # Just log the error
 
@@ -535,9 +535,12 @@ Comments: {comments if comments else "None"}"""
         over sessions without clicking. Only mouseMoveEvent with no button pressed
         is blocked — drag-selection (button held) still works normally.
         """
-        if watched is self.sessions_table.viewport():
-            if event.type() == QEvent.Type.MouseMove and not event.buttons():
-                return True  # consume event — no selection change on hover
+        if (
+            watched is self.sessions_table.viewport()
+            and event.type() == QEvent.Type.MouseMove
+            and not event.buttons()
+        ):
+            return True  # consume event — no selection change on hover
         return super().eventFilter(watched, event)
 
     def showEvent(self, event):

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -1,41 +1,40 @@
-import sys
-import os
 import json
+import sys
+
 import pandas as pd
+from PySide6.QtCore import QDate, Qt, QTimer
 from PySide6.QtWidgets import (
     QApplication,
+    QCheckBox,
+    QComboBox,
+    QDateEdit,
     QDialog,
     QDialogButtonBox,
-    QVBoxLayout,
-    QListWidget,
-    QListWidgetItem,
-    QStackedWidget,
-    QWidget,
+    QDoubleSpinBox,
+    QFileDialog,
     QFormLayout,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QScrollArea,
     QGroupBox,
     QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
     QPushButton,
-    QComboBox,
-    QTextEdit,
+    QScrollArea,
+    QSpinBox,
+    QStackedWidget,
     QTableWidget,
     QTableWidgetItem,
-    QHeaderView,
-    QFileDialog,
-    QSpinBox,
-    QDoubleSpinBox,
-    QDateEdit,
-    QCheckBox,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtCore import Qt, QTimer, QDate
 
-from shopify_tool.core import get_unique_column_values
 from gui.column_mapping_widget import ColumnMappingWidget
 from gui.wheel_ignore_combobox import WheelIgnoreComboBox
-from shopify_tool.set_decoder import import_sets_from_csv, export_sets_to_csv
+from shopify_tool.core import get_unique_column_values
+from shopify_tool.set_decoder import export_sets_to_csv, import_sets_from_csv
 
 
 class SettingsWindow(QDialog):
@@ -971,8 +970,8 @@ class SettingsWindow(QDialog):
 
         # DATE OPERATORS - Use QDateEdit with calendar popup
         elif op in ["date before", "date after", "date equals"]:
-            from PySide6.QtWidgets import QDateEdit
             from PySide6.QtCore import QDate
+            from PySide6.QtWidgets import QDateEdit
 
             new_widget = QDateEdit()
             new_widget.setCalendarPopup(True)  # Enable calendar dropdown
@@ -1030,7 +1029,6 @@ class SettingsWindow(QDialog):
         Args:
             condition_refs (dict): Condition widget references
         """
-        from PySide6.QtCore import QTimer
 
         op = condition_refs["op"].currentText()
 
@@ -1057,11 +1055,10 @@ class SettingsWindow(QDialog):
             condition_refs (dict): Condition widget references
         """
         from gui.rule_validator import (
-            validate_regex,
-            validate_date,
-            validate_range,
             validate_list,
-            validate_numeric
+            validate_numeric,
+            validate_range,
+            validate_regex,
         )
 
         op = condition_refs["op"].currentText()
@@ -1071,7 +1068,7 @@ class SettingsWindow(QDialog):
             return
 
         # Get value based on widget type
-        from PySide6.QtWidgets import QComboBox, QLineEdit, QDateEdit
+        from PySide6.QtWidgets import QComboBox, QLineEdit
         if isinstance(value_widget, QComboBox):
             value = value_widget.currentText()
         elif isinstance(value_widget, QDateEdit):
@@ -1188,7 +1185,6 @@ class SettingsWindow(QDialog):
         Returns:
             QDate object or None if parsing fails
         """
-        from PySide6.QtCore import QDate
         from shopify_tool.rules import _parse_date_safe
 
         pd_timestamp = _parse_date_safe(date_str)
@@ -1210,6 +1206,7 @@ class SettingsWindow(QDialog):
             rule_widget_refs (dict): Rule widget references
         """
         from PySide6.QtWidgets import QMessageBox
+
         from gui.rule_test_dialog import RuleTestDialog
 
         if self.analysis_df is None or self.analysis_df.empty:
@@ -1254,7 +1251,7 @@ class SettingsWindow(QDialog):
         Returns:
             dict: Rule configuration compatible with RuleEngine
         """
-        from PySide6.QtWidgets import QComboBox, QLineEdit, QDateEdit
+        from PySide6.QtWidgets import QComboBox, QLineEdit
 
         steps = []
         for step_refs in rule_widget_refs.get("steps", []):
@@ -2142,7 +2139,7 @@ class SettingsWindow(QDialog):
             QMessageBox.critical(
                 self,
                 "Import Error",
-                f"Failed to import sets from CSV:\n\n{str(e)}"
+                f"Failed to import sets from CSV:\n\n{e!s}"
             )
 
     def _export_sets_to_csv(self):
@@ -2177,7 +2174,7 @@ class SettingsWindow(QDialog):
             QMessageBox.critical(
                 self,
                 "Export Error",
-                f"Failed to export sets to CSV:\n\n{str(e)}"
+                f"Failed to export sets to CSV:\n\n{e!s}"
             )
 
     # ========================================
@@ -2554,7 +2551,7 @@ class SettingsWindow(QDialog):
             )
 
         except Exception as e:
-            QMessageBox.critical(self, "Import Error", f"Failed to import SKUs:\n\n{str(e)}")
+            QMessageBox.critical(self, "Import Error", f"Failed to import SKUs:\n\n{e!s}")
 
     def _weight_import_products_from_csv(self):
         """Import SKU dimensions from an arbitrary CSV into the products table."""
@@ -2702,7 +2699,7 @@ class SettingsWindow(QDialog):
             QMessageBox.information(self, "Import Complete", " ".join(parts))
 
         except Exception as e:
-            QMessageBox.critical(self, "Import Error", f"Failed to import dimensions:\n\n{str(e)}")
+            QMessageBox.critical(self, "Import Error", f"Failed to import dimensions:\n\n{e!s}")
 
     def _weight_import_boxes_from_csv(self):
         """Import boxes from an arbitrary CSV into the boxes table."""
@@ -2825,7 +2822,7 @@ class SettingsWindow(QDialog):
             QMessageBox.information(self, "Import Complete", " ".join(parts))
 
         except Exception as e:
-            QMessageBox.critical(self, "Import Error", f"Failed to import boxes:\n\n{str(e)}")
+            QMessageBox.critical(self, "Import Error", f"Failed to import boxes:\n\n{e!s}")
 
     def _weight_export_products_to_csv(self):
         """Export products table to a CSV file."""
@@ -2868,7 +2865,7 @@ class SettingsWindow(QDialog):
             df.to_csv(file_path, sep=";", index=False, encoding="utf-8-sig")
             QMessageBox.information(self, "Export Complete", f"Exported {len(rows)} product(s) to:\n{file_path}")
         except Exception as e:
-            QMessageBox.critical(self, "Export Error", f"Failed to export products:\n\n{str(e)}")
+            QMessageBox.critical(self, "Export Error", f"Failed to export products:\n\n{e!s}")
 
     def _weight_export_boxes_to_csv(self):
         """Export boxes table to a CSV file."""
@@ -2902,7 +2899,7 @@ class SettingsWindow(QDialog):
             df.to_csv(file_path, sep=";", index=False, encoding="utf-8-sig")
             QMessageBox.information(self, "Export Complete", f"Exported {len(rows)} box(es) to:\n{file_path}")
         except Exception as e:
-            QMessageBox.critical(self, "Export Error", f"Failed to export boxes:\n\n{str(e)}")
+            QMessageBox.critical(self, "Export Error", f"Failed to export boxes:\n\n{e!s}")
 
     def _weight_collect_config(self) -> dict:
         """Collect weight configuration from UI tables."""
@@ -3262,14 +3259,14 @@ class SettingsWindow(QDialog):
             QMessageBox.critical(
                 self,
                 "Validation Error",
-                f"Invalid value entered:\n\n{str(e)}\n\nPlease check your inputs."
+                f"Invalid value entered:\n\n{e!s}\n\nPlease check your inputs."
             )
         except Exception as e:
             import traceback
             QMessageBox.critical(
                 self,
                 "Error",
-                f"Failed to save settings:\n\n{str(e)}\n\n{traceback.format_exc()}"
+                f"Failed to save settings:\n\n{e!s}\n\n{traceback.format_exc()}"
             )
     # ========================================
     # TAG CATEGORIES TAB
@@ -3336,6 +3333,7 @@ class SettingsWindow(QDialog):
     def create_sku_labels_tab(self):
         """Create the SKU Label Printing settings tab."""
         from PySide6.QtPrintSupport import QPrinterInfo
+
         from gui.theme_manager import get_theme_manager
 
         theme = get_theme_manager().get_current_theme()

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from typing import ClassVar
 
 import pandas as pd
 from PySide6.QtCore import QDate, Qt, QTimer
@@ -62,7 +63,7 @@ class SettingsWindow(QDialog):
     """
 
     # Constants for builders
-    FILTERABLE_COLUMNS = [
+    FILTERABLE_COLUMNS: ClassVar[list[str]] = [
         "Order_Number",
         "Order_Type",
         "SKU",
@@ -76,9 +77,9 @@ class SettingsWindow(QDialog):
         "Status_Note",
         "Total Price",
     ]
-    FILTER_OPERATORS = ["==", "!=", "in", "not in", "contains"]
+    FILTER_OPERATORS: ClassVar[list[str]] = ["==", "!=", "in", "not in", "contains"]
     # Group order-level fields first for better UX
-    ORDER_LEVEL_FIELDS = [
+    ORDER_LEVEL_FIELDS: ClassVar[list[str]] = [
         "--- ORDER-LEVEL FIELDS ---",
         "item_count",
         "total_quantity",
@@ -86,8 +87,8 @@ class SettingsWindow(QDialog):
         "Has_SKU",
         "--- ARTICLE-LEVEL FIELDS ---",
     ]
-    CONDITION_FIELDS = ORDER_LEVEL_FIELDS + FILTERABLE_COLUMNS
-    CONDITION_OPERATORS = [
+    CONDITION_FIELDS: ClassVar[list[str]] = ORDER_LEVEL_FIELDS + FILTERABLE_COLUMNS
+    CONDITION_OPERATORS: ClassVar[list[str]] = [
         "equals",
         "does not equal",
         "contains",
@@ -110,7 +111,7 @@ class SettingsWindow(QDialog):
         "matches regex",
         "does not match regex",
     ]
-    ACTION_TYPES = [
+    ACTION_TYPES: ClassVar[list[str]] = [
         "ADD_TAG",
         "ADD_ORDER_TAG",
         "ADD_INTERNAL_TAG",
@@ -124,7 +125,7 @@ class SettingsWindow(QDialog):
 
     # Grouped left-nav replacing the old 10-tab horizontal QTabWidget strip.
     # Group/order chosen to mirror VS Code's own Settings UI grouping.
-    SETTINGS_NAV_GROUPS = [
+    SETTINGS_NAV_GROUPS: ClassVar[list[tuple[str, list[str]]]] = [
         ("Data", ["General", "Mappings", "Column Config"]),
         ("Fulfillment Logic", ["Rules", "Sets", "Weight"]),
         ("Output", ["Packing Lists", "Stock Exports", "SKU Labels"]),
@@ -812,7 +813,7 @@ class SettingsWindow(QDialog):
         if step_refs not in steps or len(steps) <= 1:
             return
 
-        idx = steps.index(step_refs)
+        steps.index(step_refs)
         steps.remove(step_refs)
 
         # Remove widgets
@@ -2466,7 +2467,7 @@ class SettingsWindow(QDialog):
 
     def _weight_delete_selected(self, table):
         """Delete selected rows from the given table."""
-        selected = sorted(set(idx.row() for idx in table.selectedIndexes()), reverse=True)
+        selected = sorted({idx.row() for idx in table.selectedIndexes()}, reverse=True)
         for row in selected:
             table.removeRow(row)
 
@@ -2602,7 +2603,7 @@ class SettingsWindow(QDialog):
                     existing_skus[item.text().strip()] = r
 
             rows_in_csv = df[sku_col].dropna().astype(str).str.strip().tolist()
-            new_skus = [s for s in rows_in_csv if s and s != "nan" and s not in existing_skus]
+            [s for s in rows_in_csv if s and s != "nan" and s not in existing_skus]
             dup_skus = [s for s in rows_in_csv if s and s != "nan" and s in existing_skus]
 
             update_existing = False
@@ -2621,6 +2622,14 @@ class SettingsWindow(QDialog):
             updated = 0
             skipped = 0
 
+            def _val(row, col):
+                if col and pd.notna(row.get(col)):
+                    try:
+                        return float(str(row[col]).replace(",", ".").strip())
+                    except ValueError:
+                        pass
+                return None
+
             self.weight_products_table.blockSignals(True)
             for _, csv_row in df.iterrows():
                 sku = str(csv_row[sku_col]).strip() if pd.notna(csv_row[sku_col]) else ""
@@ -2629,17 +2638,9 @@ class SettingsWindow(QDialog):
 
                 name = str(csv_row[name_col]).strip() if name_col and pd.notna(csv_row.get(name_col)) else ""
 
-                def _val(col):
-                    if col and pd.notna(csv_row.get(col)):
-                        try:
-                            return float(str(csv_row[col]).replace(",", ".").strip())
-                        except ValueError:
-                            pass
-                    return None
-
-                l = _val(l_col)
-                w = _val(w_col)
-                h = _val(h_col)
+                l = _val(csv_row, l_col)
+                w = _val(csv_row, w_col)
+                h = _val(csv_row, h_col)
                 vol_w = round((l * w * h) / divisor, 4) if (l and w and h and divisor > 0) else 0.0
 
                 no_pkg = False
@@ -2767,23 +2768,23 @@ class SettingsWindow(QDialog):
             updated = 0
             skipped = 0
 
+            def _val(row, col):
+                if col and pd.notna(row.get(col)):
+                    try:
+                        return float(str(row[col]).replace(",", ".").strip())
+                    except ValueError:
+                        pass
+                return None
+
             self.weight_boxes_table.blockSignals(True)
             for _, csv_row in df.iterrows():
                 name = str(csv_row[name_col]).strip() if pd.notna(csv_row[name_col]) else ""
                 if not name or name == "nan":
                     continue
 
-                def _val(col):
-                    if col and pd.notna(csv_row.get(col)):
-                        try:
-                            return float(str(csv_row[col]).replace(",", ".").strip())
-                        except ValueError:
-                            pass
-                    return None
-
-                l = _val(l_col)
-                w = _val(w_col)
-                h = _val(h_col)
+                l = _val(csv_row, l_col)
+                w = _val(csv_row, w_col)
+                h = _val(csv_row, h_col)
                 vol_w = round((l * w * h) / divisor, 4) if (l and w and h and divisor > 0) else 0.0
 
                 if name in existing_boxes:

--- a/gui/sku_label_widget.py
+++ b/gui/sku_label_widget.py
@@ -11,15 +11,25 @@ Workflow:
 
 import logging
 
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox,
-    QPushButton, QLabel, QLineEdit, QSpinBox, QDoubleSpinBox, QComboBox, QFormLayout,
-    QMessageBox, QSizePolicy,
-)
 from PySide6.QtCore import Qt, QThreadPool, QTimer
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
 
-from gui.worker import Worker
 from gui.theme_manager import get_theme_manager
+from gui.worker import Worker
 from shopify_tool.sku_label_manager import SKULabelManager
 
 logger = logging.getLogger(__name__)
@@ -228,7 +238,7 @@ class SKULabelWidget(QWidget):
         backend = config.get("print_backend", "qt")
         idx = self.backend_combo.findData(backend)
         self.backend_combo.blockSignals(True)
-        self.backend_combo.setCurrentIndex(idx if idx >= 0 else 0)
+        self.backend_combo.setCurrentIndex(max(idx, 0))
         self.backend_combo.blockSignals(False)
 
         # Sync label size override fields

--- a/gui/table_config_manager.py
+++ b/gui/table_config_manager.py
@@ -7,12 +7,12 @@ Author: Claude Code
 Date: 2026-02-03
 """
 
-from dataclasses import dataclass, field, asdict
-from typing import Dict, List, Optional
 import logging
+from dataclasses import asdict, dataclass, field
+
 import pandas as pd
-from PySide6.QtWidgets import QTableView
 from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QTableView
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +30,11 @@ class TableConfig:
         locked_columns: Columns that cannot be hidden or reordered
     """
     version: int = 1
-    visible_columns: Dict[str, bool] = field(default_factory=dict)
-    column_order: List[str] = field(default_factory=list)
-    column_widths: Dict[str, int] = field(default_factory=dict)
+    visible_columns: dict[str, bool] = field(default_factory=dict)
+    column_order: list[str] = field(default_factory=list)
+    column_widths: dict[str, int] = field(default_factory=dict)
     auto_hide_empty: bool = True
-    locked_columns: List[str] = field(default_factory=lambda: ["Order_Number"])
+    locked_columns: list[str] = field(default_factory=lambda: ["Order_Number"])
 
     def to_dict(self) -> dict:
         """Convert config to dictionary for JSON serialization."""
@@ -83,13 +83,13 @@ class TableConfigManager:
         """
         self.mw = main_window
         self.pm = profile_manager
-        self._current_config: Optional[TableConfig] = None
-        self._current_client_id: Optional[str] = None
+        self._current_config: TableConfig | None = None
+        self._current_client_id: str | None = None
         self._current_view_name: str = "Default"
 
         # Store references for signal handlers
-        self._current_table_view: Optional[QTableView] = None
-        self._current_df: Optional[pd.DataFrame] = None
+        self._current_table_view: QTableView | None = None
+        self._current_df: pd.DataFrame | None = None
 
         # Flag to suppress signal handlers during bulk config application
         self._applying_config = False
@@ -209,7 +209,7 @@ class TableConfigManager:
             logger.error(f"Failed to save table config for CLIENT_{client_id}: {e}", exc_info=True)
             raise
 
-    def get_default_config(self, columns: List[str]) -> TableConfig:
+    def get_default_config(self, columns: list[str]) -> TableConfig:
         """Create default configuration for given columns.
 
         Args:
@@ -518,7 +518,7 @@ class TableConfigManager:
 
         logger.info("Auto-fit column widths applied")
 
-    def get_column_name_from_logical_index(self, logical_index: int, df: pd.DataFrame, table_view: QTableView) -> Optional[str]:
+    def get_column_name_from_logical_index(self, logical_index: int, df: pd.DataFrame, table_view: QTableView) -> str | None:
         """Get column name from logical index.
 
         Args:
@@ -555,7 +555,7 @@ class TableConfigManager:
 
         return df_columns[logical_index]
 
-    def detect_empty_columns(self, df: pd.DataFrame) -> List[str]:
+    def detect_empty_columns(self, df: pd.DataFrame) -> list[str]:
         """Detect columns that are completely empty.
 
         A column is considered empty if:
@@ -920,7 +920,7 @@ class TableConfigManager:
 
         return self._current_config.visible_columns.get(column_name, True)
 
-    def get_hidden_columns(self, df: pd.DataFrame) -> List[str]:
+    def get_hidden_columns(self, df: pd.DataFrame) -> list[str]:
         """Get list of currently hidden columns.
 
         Args:
@@ -972,7 +972,7 @@ class TableConfigManager:
 
     # Methods for managing named views (Phase 4)
 
-    def get_current_config(self) -> Optional[TableConfig]:
+    def get_current_config(self) -> TableConfig | None:
         """Get the currently loaded configuration.
 
         Returns:
@@ -988,7 +988,7 @@ class TableConfigManager:
         """
         return self._current_view_name
 
-    def list_views(self, client_id: Optional[str] = None) -> List[str]:
+    def list_views(self, client_id: str | None = None) -> list[str]:
         """List all saved view names for a client.
 
         Args:
@@ -1006,7 +1006,7 @@ class TableConfigManager:
 
         return self._list_views_impl(client_id)
 
-    def _list_views_impl(self, client_id: str) -> List[str]:
+    def _list_views_impl(self, client_id: str) -> list[str]:
         """List all saved view names for a client (internal implementation).
 
         Args:
@@ -1025,7 +1025,7 @@ class TableConfigManager:
             logger.error(f"Failed to list views for CLIENT_{client_id}: {e}", exc_info=True)
             return []
 
-    def load_view(self, view_name: str, client_id: Optional[str] = None) -> Optional[TableConfig]:
+    def load_view(self, view_name: str, client_id: str | None = None) -> TableConfig | None:
         """Load a specific named view.
 
         Args:
@@ -1044,7 +1044,7 @@ class TableConfigManager:
 
         return self.load_config(client_id, view_name)
 
-    def _load_view_legacy(self, client_id: str, view_name: str) -> Optional[TableConfig]:
+    def _load_view_legacy(self, client_id: str, view_name: str) -> TableConfig | None:
         """Load a specific named view (legacy method for tests).
 
         Args:
@@ -1056,7 +1056,7 @@ class TableConfigManager:
         """
         return self.load_config(client_id, view_name)
 
-    def save_view(self, view_name: str, config: TableConfig, client_id: Optional[str] = None):
+    def save_view(self, view_name: str, config: TableConfig, client_id: str | None = None):
         """Save a named view.
 
         Args:
@@ -1074,7 +1074,7 @@ class TableConfigManager:
         self.save_config(client_id, config, view_name)
         self._current_view_name = view_name
 
-    def delete_view(self, view_name: str, client_id: Optional[str] = None):
+    def delete_view(self, view_name: str, client_id: str | None = None):
         """Delete a named view.
 
         Args:

--- a/gui/table_config_manager.py
+++ b/gui/table_config_manager.py
@@ -205,8 +205,8 @@ class TableConfigManager:
 
             logger.debug(f"Saved table view '{view_name}' for CLIENT_{client_id}")
 
-        except Exception as e:
-            logger.error(f"Failed to save table config for CLIENT_{client_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Failed to save table config for CLIENT_{client_id}")
             raise
 
     def get_default_config(self, columns: list[str]) -> TableConfig:
@@ -675,12 +675,11 @@ class TableConfigManager:
         checkbox_offset = 1 if has_checkbox else 0
 
         # Locked columns (Order_Number) must stay at position after checkbox
-        if column_name in self._current_config.locked_columns:
-            if new_visual_index != checkbox_offset:
-                # Revert move
-                header.moveSection(new_visual_index, old_visual_index)
-                logger.warning(f"Cannot move locked column '{column_name}' from position {checkbox_offset}")
-                return
+        if column_name in self._current_config.locked_columns and new_visual_index != checkbox_offset:
+            # Revert move
+            header.moveSection(new_visual_index, old_visual_index)
+            logger.warning(f"Cannot move locked column '{column_name}' from position {checkbox_offset}")
+            return
 
         # Don't allow moving to the locked position (after checkbox)
         if new_visual_index == checkbox_offset and column_name not in self._current_config.locked_columns:
@@ -691,7 +690,7 @@ class TableConfigManager:
 
         # Update column order in config
         # Get current visual order
-        df_columns = self._current_df.columns.tolist()
+        self._current_df.columns.tolist()
         new_order = []
 
         for visual_pos in range(checkbox_offset, header.count()):
@@ -728,8 +727,8 @@ class TableConfigManager:
             )
             self._pending_save = False
             logger.debug("Debounced save completed")
-        except Exception as e:
-            logger.error(f"Failed to perform debounced save: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to perform debounced save")
 
     # Column visibility management methods (Phase 2)
 
@@ -1021,8 +1020,8 @@ class TableConfigManager:
             table_view_settings = ui_settings.get("table_view", {})
             views = table_view_settings.get("views", {})
             return list(views.keys())
-        except Exception as e:
-            logger.error(f"Failed to list views for CLIENT_{client_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Failed to list views for CLIENT_{client_id}")
             return []
 
     def load_view(self, view_name: str, client_id: str | None = None) -> TableConfig | None:
@@ -1112,6 +1111,6 @@ class TableConfigManager:
             else:
                 logger.warning(f"View '{view_name}' not found for CLIENT_{client_id}")
 
-        except Exception as e:
-            logger.error(f"Failed to delete view '{view_name}' for CLIENT_{client_id}: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"Failed to delete view '{view_name}' for CLIENT_{client_id}")
             raise

--- a/gui/tag_categories_dialog.py
+++ b/gui/tag_categories_dialog.py
@@ -5,19 +5,38 @@ with support for v2 format including order, colors, and SKU writeoff configurati
 """
 
 import logging
-from typing import Dict, Optional, List
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton,
-    QListWidget, QListWidgetItem, QWidget, QFormLayout, QSpinBox,
-    QDialogButtonBox, QMessageBox, QColorDialog, QSplitter, QGroupBox,
-    QCheckBox, QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView,
-    QDoubleSpinBox, QComboBox, QInputDialog
-)
+
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QColorDialog,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
-from shopify_tool.tag_manager import validate_tag_categories_v2
 from gui.theme_manager import get_theme_manager
+from shopify_tool.tag_manager import validate_tag_categories_v2
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +50,7 @@ class TagCategoriesPanel(QWidget):
 
     categories_updated = Signal(dict)
 
-    def __init__(self, tag_categories: Dict, parent=None):
+    def __init__(self, tag_categories: dict, parent=None):
         super().__init__(parent)
 
         self.working_categories = tag_categories.copy()
@@ -43,7 +62,7 @@ class TagCategoriesPanel(QWidget):
                 "categories": self.working_categories
             }
 
-        self.current_category_id: Optional[str] = None
+        self.current_category_id: str | None = None
         self.modified = False
 
         self.theme = get_theme_manager().get_current_theme()
@@ -241,7 +260,7 @@ class TagCategoriesPanel(QWidget):
     # Data management
     # ------------------------------------------------------------------
 
-    def get_categories(self) -> Dict:
+    def get_categories(self) -> dict:
         """Return the current working categories dict (including pending edits)."""
         if self.current_category_id:
             self._save_editor_to_working_copy()
@@ -706,7 +725,7 @@ class TagCategoriesDialog(QDialog):
 
     categories_updated = Signal(dict)
 
-    def __init__(self, tag_categories: Dict, parent=None):
+    def __init__(self, tag_categories: dict, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Tag Categories Management")
         self.setModal(True)
@@ -773,6 +792,6 @@ class TagCategoriesDialog(QDialog):
                 return
         self.reject()
 
-    def get_categories(self) -> Dict:
+    def get_categories(self) -> dict:
         """Get the current categories configuration."""
         return self.panel.get_categories()

--- a/gui/tag_categories_dialog.py
+++ b/gui/tag_categories_dialog.py
@@ -618,7 +618,7 @@ class TagCategoriesPanel(QWidget):
 
     def _on_remove_mapping(self):
         """Remove selected writeoff mapping."""
-        selected_rows = set(index.row() for index in self.writeoff_mappings_table.selectedIndexes())
+        selected_rows = {index.row() for index in self.writeoff_mappings_table.selectedIndexes()}
 
         if not selected_rows:
             return

--- a/gui/tag_delegate.py
+++ b/gui/tag_delegate.py
@@ -1,11 +1,10 @@
 """Custom ItemDelegate for rendering Internal_Tags as colored badges."""
 
-import json
-from PySide6.QtWidgets import QStyledItemDelegate, QStyle
-from PySide6.QtCore import Qt, QRect, QSize
-from PySide6.QtGui import QPainter, QColor, QFont, QPen, QFontMetrics
+from PySide6.QtCore import QRect, QSize, Qt
+from PySide6.QtGui import QColor, QFont, QFontMetrics, QPen
+from PySide6.QtWidgets import QStyle, QStyledItemDelegate
 
-from shopify_tool.tag_manager import parse_tags, get_tag_color
+from shopify_tool.tag_manager import get_tag_color, parse_tags
 
 
 class TagDelegate(QStyledItemDelegate):

--- a/gui/tag_management_panel.py
+++ b/gui/tag_management_panel.py
@@ -1,14 +1,20 @@
 """Tag Management Panel for managing Internal_Tags on selected orders."""
 
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QGroupBox,
-    QPushButton, QComboBox, QLineEdit, QListWidget
-)
 from PySide6.QtCore import Signal
-
-from shopify_tool.tag_manager import parse_tags
+from PySide6.QtWidgets import (
+    QComboBox,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 from gui.theme_manager import get_theme_manager
+from shopify_tool.tag_manager import parse_tags
+
 
 class TagManagementPanel(QWidget):
     """

--- a/gui/theme_manager.py
+++ b/gui/theme_manager.py
@@ -76,16 +76,16 @@ class ThemeManager(QObject):
             settings = QSettings("ShopifyFulfillmentTool", "FulfillmentApp")
             settings.setValue("theme", self._current_theme_name)
             settings.sync()
-        except Exception as e:
-            logger.error(f"Failed to save theme preference: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save theme preference")
 
     def _load_theme_preference(self):
         try:
             settings = QSettings("ShopifyFulfillmentTool", "FulfillmentApp")
             saved_theme = settings.value("theme", "light")
             self._current_theme_name = saved_theme if saved_theme in ("light", "dark") else "light"
-        except Exception as e:
-            logger.error(f"Failed to load theme preference: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to load theme preference")
             self._current_theme_name = "light"
 
 

--- a/gui/theme_manager.py
+++ b/gui/theme_manager.py
@@ -7,10 +7,11 @@ token definitions and stylesheet/palette builders.
 
 import logging
 from typing import Optional
-from PySide6.QtCore import QObject, Signal, QSettings
+
+from PySide6.QtCore import QObject, QSettings, Signal
 from PySide6.QtWidgets import QApplication
 
-from shared.theme import ThemeTokens, get_theme, build_stylesheet, build_palette
+from shared.theme import ThemeTokens, build_palette, build_stylesheet, get_theme
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ class ThemeManager(QObject):
             self._current_theme_name = "light"
 
 
-_theme_manager_instance: Optional[ThemeManager] = None
+_theme_manager_instance: ThemeManager | None = None
 
 
 def get_theme_manager() -> ThemeManager:

--- a/gui/tools_widget.py
+++ b/gui/tools_widget.py
@@ -7,13 +7,10 @@ Contains sub-tabs:
 - SKU Labels: Barcode-scan-to-print labeling workflow
 """
 
-from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QTabWidget, QLabel
-)
-from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QTabWidget, QVBoxLayout, QWidget
 
-from gui.reference_labels_widget import ReferenceLabelsWidget
 from gui.barcode_generator_widget import BarcodeGeneratorWidget
+from gui.reference_labels_widget import ReferenceLabelsWidget
 from gui.sku_label_widget import SKULabelWidget
 
 

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -1,40 +1,39 @@
 import logging
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QKeySequence, QShortcut
 from PySide6.QtWidgets import (
-    QWidget,
-    QVBoxLayout,
-    QHBoxLayout,
-    QGridLayout,
-    QFormLayout,
-    QPushButton,
-    QLabel,
-    QTabWidget,
-    QGroupBox,
-    QTableView,
-    QPlainTextEdit,
-    QTableWidget,
-    QTableWidgetItem,
-    QLineEdit,
-    QComboBox,
     QCheckBox,
-    QRadioButton,
+    QFrame,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
     QListWidget,
     QListWidgetItem,
-    QFrame,
-    QStyle,
+    QPlainTextEdit,
+    QPushButton,
+    QRadioButton,
     QScrollArea,
     QSplitter,
-    QHeaderView,
+    QStyle,
+    QTableView,
+    QTableWidget,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
 )
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QColor, QKeySequence, QShortcut
-from .pandas_model import PandasModel
-from .wheel_ignore_combobox import WheelIgnoreComboBox
-from .tag_management_panel import TagManagementPanel
-from .bulk_operations_toolbar import BulkOperationsToolbar
-from .selection_helper import SelectionHelper
-from .theme_manager import get_theme_manager
+
 from shared.server_connection import ConnectionSettingsDialog
 from shopify_tool.profile_manager import PROD_SERVER_PATH
+
+from .bulk_operations_toolbar import BulkOperationsToolbar
+from .pandas_model import PandasModel
+from .tag_management_panel import TagManagementPanel
+from .theme_manager import get_theme_manager
+from .wheel_ignore_combobox import WheelIgnoreComboBox
 
 
 class UIManager:
@@ -725,8 +724,8 @@ class UIManager:
 
     def _open_session_folder(self):
         """Open session folder in file explorer."""
-        import subprocess
         import platform
+        import subprocess
 
         if not self.mw.session_path:
             from PySide6.QtWidgets import QMessageBox
@@ -748,7 +747,7 @@ class UIManager:
             from PySide6.QtWidgets import QMessageBox
 
             QMessageBox.critical(
-                self.mw, "Error", f"Failed to open session folder:\n{str(e)}"
+                self.mw, "Error", f"Failed to open session folder:\n{e!s}"
             )
 
     def _create_main_actions_group(self):
@@ -1047,7 +1046,7 @@ class UIManager:
             Dict mapping category_label -> list of tags
             Example: {"Packaging": ["BOX", "BAG"], "Priority": ["URGENT"]}
         """
-        from shopify_tool.tag_manager import get_tag_category, _normalize_tag_categories
+        from shopify_tool.tag_manager import _normalize_tag_categories, get_tag_category
 
         categories = _normalize_tag_categories(tag_categories)
         grouped = {}
@@ -1338,8 +1337,8 @@ class UIManager:
         Args:
             position: Position where menu was requested
         """
-        from PySide6.QtWidgets import QMenu
         from PySide6.QtGui import QAction
+        from PySide6.QtWidgets import QMenu
 
         # Only show menu if table config manager is available
         if not hasattr(self.mw, "table_config_manager"):
@@ -1554,8 +1553,8 @@ class UIManager:
 
     def _show_hidden_columns_popup(self):
         """Show popup menu listing hidden columns with quick-toggle options."""
-        from PySide6.QtWidgets import QMenu
         from PySide6.QtGui import QAction
+        from PySide6.QtWidgets import QMenu
 
         if (
             not hasattr(self.mw, "table_config_manager")

--- a/gui/wheel_ignore_combobox.py
+++ b/gui/wheel_ignore_combobox.py
@@ -5,9 +5,10 @@ This prevents users from accidentally changing combo box values when scrolling
 through the window, which is a common UX issue in dense forms.
 """
 
-from PySide6.QtWidgets import QComboBox
-from PySide6.QtCore import QEvent, Qt
 import logging
+
+from PySide6.QtCore import QEvent, Qt
+from PySide6.QtWidgets import QComboBox
 
 logger = logging.getLogger(__name__)
 

--- a/gui/worker.py
+++ b/gui/worker.py
@@ -1,5 +1,6 @@
 import sys
 import traceback
+
 from PySide6.QtCore import QObject, QRunnable, Signal, Slot
 
 
@@ -42,7 +43,7 @@ class Worker(QRunnable):
             *args: Positional arguments to pass to the function.
             **kwargs: Keyword arguments to pass to the function.
         """
-        super(Worker, self).__init__()
+        super().__init__()
         # Store constructor arguments (re-used for processing)
         self.fn = fn
         self.args = args

--- a/gui_main.py
+++ b/gui_main.py
@@ -4,8 +4,9 @@ This script initializes the QApplication, creates the main window, and
 starts the application's event loop. It also handles setting the platform
 to 'offscreen' for testing or continuous integration (CI) environments.
 """
-import sys
 import os
+import sys
+
 from PySide6.QtWidgets import QApplication
 
 __version__ = "1.9.9.1"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+# Project-wide rule decisions, on top of ruff's defaults.
+[lint]
+ignore = [
+    # Codebase idiom: warehouse-floor GUI, so most I/O and Qt-callback sites
+    # deliberately catch broad Exception at a boundary (worker thread, cleanup
+    # handler, best-effort cache read) rather than crash the app. Narrowing
+    # each to a specific exception type would guess at failure modes we can't
+    # verify and would weaken the "must not crash" guarantee these guards exist for.
+    "BLE001",
+]
+
+[lint.flake8-bugbear]
+# QModelIndex() is an immutable value type (Qt's standard "no parent" sentinel),
+# so using it as a default argument is safe despite the general mutable-default footgun.
+extend-immutable-calls = ["PySide6.QtCore.QModelIndex"]

--- a/run_dev.py
+++ b/run_dev.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Local dev runner: launches the app against a throwaway local dev-server."""
 import os
 from pathlib import Path

--- a/scripts/sync_shared.py
+++ b/scripts/sync_shared.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """One-way sync of the canonical shared/ package from packing-tool into this
 repo. packing-tool/shared/ is the single source of truth (see
 packing-tool/docs/superpowers/specs/2026-07-25-shared-unification-design.md)

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -11,9 +11,9 @@ from .file_lock import FileLockError
 from .stats_manager import StatsManager, StatsManagerError
 
 __all__ = [
+    'FileLockError',
     'StatsManager',
     'StatsManagerError',
-    'FileLockError',
 ]
 
 __version__ = '2.0.0'

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -11,9 +11,9 @@ from .file_lock import FileLockError
 from .stats_manager import StatsManager, StatsManagerError
 
 __all__ = [
-    'FileLockError',
     'StatsManager',
     'StatsManagerError',
+    'FileLockError',
 ]
 
 __version__ = '2.0.0'

--- a/shared/atomic_write.py
+++ b/shared/atomic_write.py
@@ -1,9 +1,12 @@
 """Atomic JSON writes (temp file + rename) for files on shared network storage."""
 import json
+import logging
 import os
 import tempfile
 import time
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def atomic_write_json(path, data, *, indent=2, ensure_ascii=False, retries=3, retry_delay=0.15):
@@ -36,8 +39,8 @@ def atomic_write_json(path, data, *, indent=2, ensure_ascii=False, retries=3, re
             if tmp_path and tmp_path.exists():
                 try:
                     tmp_path.unlink()
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Could not remove temp file {tmp_path}: {e}")
             if attempt < retries - 1:
                 time.sleep(retry_delay)
 

--- a/shared/file_lock.py
+++ b/shared/file_lock.py
@@ -73,16 +73,15 @@ def locked_file(file_handle, timeout: float = 5.0, retry_delay: float = 0.1):
 
 
 if __name__ == "__main__":
-    import tempfile
     import os
+    import tempfile
 
     with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp:
         tmp_path = tmp.name
 
     try:
-        with open(tmp_path, 'r+') as f:
-            with locked_file(f):
-                f.write("locked ok")
+        with open(tmp_path, 'r+') as f, locked_file(f):
+            f.write("locked ok")
         with open(tmp_path) as f:
             assert f.read() == "locked ok"
         print("file_lock self-check OK")

--- a/shared/file_lock.py
+++ b/shared/file_lock.py
@@ -1,4 +1,5 @@
 """Cross-platform advisory file locking for shared JSON files on network storage."""
+import logging
 import time
 from contextlib import contextmanager
 
@@ -13,6 +14,8 @@ try:
     UNIX_LOCKING_AVAILABLE = True
 except ImportError:
     UNIX_LOCKING_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class FileLockError(Exception):
@@ -68,21 +71,20 @@ def locked_file(file_handle, timeout: float = 5.0, retry_delay: float = 0.1):
                     msvcrt.locking(file_handle.fileno(), msvcrt.LK_UNLCK, 1)
                 elif UNIX_LOCKING_AVAILABLE:
                     fcntl.flock(file_handle.fileno(), fcntl.LOCK_UN)
-            except Exception:
-                pass  # Ignore unlock errors
+            except Exception as e:
+                logger.debug(f"Ignoring unlock error: {e}")
 
 
 if __name__ == "__main__":
-    import tempfile
     import os
+    import tempfile
 
     with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp:
         tmp_path = tmp.name
 
     try:
-        with open(tmp_path, 'r+') as f:
-            with locked_file(f):
-                f.write("locked ok")
+        with open(tmp_path, 'r+') as f, locked_file(f):
+            f.write("locked ok")
         with open(tmp_path) as f:
             assert f.read() == "locked ok"
         print("file_lock self-check OK")

--- a/shared/file_lock.py
+++ b/shared/file_lock.py
@@ -73,15 +73,16 @@ def locked_file(file_handle, timeout: float = 5.0, retry_delay: float = 0.1):
 
 
 if __name__ == "__main__":
-    import os
     import tempfile
+    import os
 
     with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp:
         tmp_path = tmp.name
 
     try:
-        with open(tmp_path, 'r+') as f, locked_file(f):
-            f.write("locked ok")
+        with open(tmp_path, 'r+') as f:
+            with locked_file(f):
+                f.write("locked ok")
         with open(tmp_path) as f:
             assert f.read() == "locked ok"
         print("file_lock self-check OK")

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -52,7 +52,7 @@ class UnifiedJSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         log_data = {
-            "timestamp": datetime.fromtimestamp(record.created).isoformat(),
+            "timestamp": datetime.fromtimestamp(record.created).astimezone().isoformat(),
             "level": record.levelname,
             "tool": self.tool_name,
             "module": record.module,

--- a/shared/metadata_utils.py
+++ b/shared/metadata_utils.py
@@ -11,7 +11,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def get_current_timestamp() -> str:
     return datetime.now().astimezone().isoformat()
 
 
-def parse_timestamp(timestamp_str: str) -> Optional[datetime]:
+def parse_timestamp(timestamp_str: str) -> datetime | None:
     """Parse ISO timestamp to datetime object
 
     Handles both timezone-aware and timezone-naive timestamps for
@@ -99,7 +99,7 @@ def calculate_duration(start: str, end: str) -> int:
     return int((end_dt - start_dt).total_seconds())
 
 
-def load_session_summary(path: Path) -> Dict[str, Any]:
+def load_session_summary(path: Path) -> dict[str, Any]:
     """Load session summary in v1.3.0 format
 
     Args:
@@ -124,8 +124,8 @@ def load_session_summary(path: Path) -> Dict[str, Any]:
     try:
         with open(path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-    except json.JSONDecodeError as e:
-        logger.error(f"Corrupted session summary at {path}: {e}", exc_info=True)
+    except json.JSONDecodeError:
+        logger.exception(f"Corrupted session summary at {path}")
         raise
 
     # Check version
@@ -140,7 +140,7 @@ def load_session_summary(path: Path) -> Dict[str, Any]:
     return validated
 
 
-def _validate_v1_3_0_format(data: Dict[str, Any]) -> Dict[str, Any]:
+def _validate_v1_3_0_format(data: dict[str, Any]) -> dict[str, Any]:
     """Validate and fill missing fields in v1.3.0 format
 
     Args:

--- a/shared/metadata_utils.py
+++ b/shared/metadata_utils.py
@@ -11,7 +11,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def get_current_timestamp() -> str:
     return datetime.now().astimezone().isoformat()
 
 
-def parse_timestamp(timestamp_str: str) -> Optional[datetime]:
+def parse_timestamp(timestamp_str: str) -> datetime | None:
     """Parse ISO timestamp to datetime object
 
     Handles both timezone-aware and timezone-naive timestamps for
@@ -99,7 +99,7 @@ def calculate_duration(start: str, end: str) -> int:
     return int((end_dt - start_dt).total_seconds())
 
 
-def load_session_summary(path: Path) -> Dict[str, Any]:
+def load_session_summary(path: Path) -> dict[str, Any]:
     """Load session summary in v1.3.0 format
 
     Args:
@@ -140,7 +140,7 @@ def load_session_summary(path: Path) -> Dict[str, Any]:
     return validated
 
 
-def _validate_v1_3_0_format(data: Dict[str, Any]) -> Dict[str, Any]:
+def _validate_v1_3_0_format(data: dict[str, Any]) -> dict[str, Any]:
     """Validate and fill missing fields in v1.3.0 format
 
     Args:

--- a/shared/metadata_utils.py
+++ b/shared/metadata_utils.py
@@ -11,7 +11,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Optional, Dict, Any
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def get_current_timestamp() -> str:
     return datetime.now().astimezone().isoformat()
 
 
-def parse_timestamp(timestamp_str: str) -> datetime | None:
+def parse_timestamp(timestamp_str: str) -> Optional[datetime]:
     """Parse ISO timestamp to datetime object
 
     Handles both timezone-aware and timezone-naive timestamps for
@@ -99,7 +99,7 @@ def calculate_duration(start: str, end: str) -> int:
     return int((end_dt - start_dt).total_seconds())
 
 
-def load_session_summary(path: Path) -> dict[str, Any]:
+def load_session_summary(path: Path) -> Dict[str, Any]:
     """Load session summary in v1.3.0 format
 
     Args:
@@ -140,7 +140,7 @@ def load_session_summary(path: Path) -> dict[str, Any]:
     return validated
 
 
-def _validate_v1_3_0_format(data: dict[str, Any]) -> dict[str, Any]:
+def _validate_v1_3_0_format(data: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and fill missing fields in v1.3.0 format
 
     Args:

--- a/shared/server_connection.py
+++ b/shared/server_connection.py
@@ -12,12 +12,18 @@ Effective path priority (highest first):
 import os
 import threading
 from pathlib import Path
-from typing import Optional
 
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton,
-    QFileDialog, QDialogButtonBox, QMessageBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
 )
 
 _SETTINGS_KEY = "server_path"
@@ -52,7 +58,7 @@ def test_path_reachable(path: str, timeout: int = 5) -> bool:
     return result.get("ok", False)
 
 
-def get_saved_server_path(org: str) -> Optional[str]:
+def get_saved_server_path(org: str) -> str | None:
     """Path saved via the UI for `org`, or None if never set."""
     value = QSettings(org, "Connection").value(_SETTINGS_KEY, None)
     return value or None

--- a/shared/server_connection.py
+++ b/shared/server_connection.py
@@ -12,18 +12,12 @@ Effective path priority (highest first):
 import os
 import threading
 from pathlib import Path
+from typing import Optional
 
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import (
-    QDialog,
-    QDialogButtonBox,
-    QFileDialog,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QPushButton,
-    QVBoxLayout,
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton,
+    QFileDialog, QDialogButtonBox, QMessageBox,
 )
 
 _SETTINGS_KEY = "server_path"
@@ -58,7 +52,7 @@ def test_path_reachable(path: str, timeout: int = 5) -> bool:
     return result.get("ok", False)
 
 
-def get_saved_server_path(org: str) -> str | None:
+def get_saved_server_path(org: str) -> Optional[str]:
     """Path saved via the UI for `org`, or None if never set."""
     value = QSettings(org, "Connection").value(_SETTINGS_KEY, None)
     return value or None

--- a/shared/session_id.py
+++ b/shared/session_id.py
@@ -3,9 +3,10 @@ Tool, so a record written by one and a record written by the other for the
 same real-world session carry the exact same session_id string.
 """
 from pathlib import Path
+from typing import Union
 
 
-def derive_session_id(session_path: str | Path) -> str:
+def derive_session_id(session_path: Union[str, Path]) -> str:
     """Derive a session_id from a session directory path.
 
     Both apps must call this instead of building their own session_id.

--- a/shared/session_id.py
+++ b/shared/session_id.py
@@ -3,10 +3,9 @@ Tool, so a record written by one and a record written by the other for the
 same real-world session carry the exact same session_id string.
 """
 from pathlib import Path
-from typing import Union
 
 
-def derive_session_id(session_path: Union[str, Path]) -> str:
+def derive_session_id(session_path: str | Path) -> str:
     """Derive a session_id from a session directory path.
 
     Both apps must call this instead of building their own session_id.

--- a/shared/stats_manager.py
+++ b/shared/stats_manager.py
@@ -42,14 +42,15 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Dict, Any, Optional, List
 
-from shared.file_lock import FileLockError, locked_file
+from shared.file_lock import locked_file, FileLockError
 from shared.metadata_utils import get_current_timestamp, parse_timestamp
 
 
 class StatsManagerError(Exception):
     """Base exception for StatsManager errors."""
+    pass
 
 
 class StatsManager:
@@ -109,7 +110,7 @@ class StatsManager:
 
         self.stats_file.parent.mkdir(parents=True, exist_ok=True)
 
-    def _get_default_stats(self) -> dict[str, Any]:
+    def _get_default_stats(self) -> Dict[str, Any]:
         """Get default statistics structure."""
         return {
             "total_orders_analyzed": 0,
@@ -124,7 +125,7 @@ class StatsManager:
             "version": "2.0",
         }
 
-    def _load_stats(self) -> dict[str, Any]:
+    def _load_stats(self) -> Dict[str, Any]:
         """Load statistics from file with file locking."""
         if not self.stats_file.exists():
             return self._get_default_stats()
@@ -153,14 +154,14 @@ class StatsManager:
 
             except json.JSONDecodeError:
                 return self._get_default_stats()
-            except (OSError, FileLockError) as e:
+            except (IOError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to load stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
 
         return self._get_default_stats()
 
-    def _save_stats(self, stats: dict[str, Any]) -> None:
+    def _save_stats(self, stats: Dict[str, Any]) -> None:
         """Save statistics to file with file locking."""
         stats["last_updated"] = get_current_timestamp()
 
@@ -179,7 +180,7 @@ class StatsManager:
 
                 return
 
-            except (OSError, FileLockError) as e:
+            except (IOError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to save stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
@@ -253,7 +254,7 @@ class StatsManager:
 
                 return  # Success
 
-            except (OSError, FileLockError) as e:
+            except (IOError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to update stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
@@ -263,7 +264,7 @@ class StatsManager:
         client_id: str,
         session_id: str,
         orders_count: int,
-        metadata: dict[str, Any] | None = None
+        metadata: Optional[Dict[str, Any]] = None
     ) -> None:
         """Record an analysis completion from Shopify Tool.
 
@@ -308,10 +309,10 @@ class StatsManager:
         self,
         client_id: str,
         session_id: str,
-        worker_id: str | None,
+        worker_id: Optional[str],
         orders_count: int,
         items_count: int,
-        metadata: dict[str, Any] | None = None
+        metadata: Optional[Dict[str, Any]] = None
     ) -> None:
         """Record a packing session completion from Packing Tool.
 
@@ -357,7 +358,7 @@ class StatsManager:
 
         self._atomic_update(update)
 
-    def get_global_stats(self) -> dict[str, Any]:
+    def get_global_stats(self) -> Dict[str, Any]:
         """Get global statistics summary."""
         stats = self._load_stats()
         return {
@@ -367,23 +368,23 @@ class StatsManager:
             "last_updated": stats.get("last_updated"),
         }
 
-    def get_client_stats(self, client_id: str) -> dict[str, Any]:
+    def get_client_stats(self, client_id: str) -> Dict[str, Any]:
         """Get statistics for a specific client."""
         stats = self._load_stats()
         if client_id not in stats.get("by_client", {}):
             return {"orders_analyzed": 0, "orders_packed": 0, "sessions": 0}
         return stats["by_client"][client_id].copy()
 
-    def get_all_clients_stats(self) -> dict[str, dict[str, Any]]:
+    def get_all_clients_stats(self) -> Dict[str, Dict[str, Any]]:
         """Get statistics for all clients."""
         stats = self._load_stats()
         return stats.get("by_client", {}).copy()
 
     def get_analysis_history(
         self,
-        client_id: str | None = None,
-        limit: int | None = None
-    ) -> list[dict[str, Any]]:
+        client_id: Optional[str] = None,
+        limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
         """Get analysis history with optional filtering (newest first)."""
         stats = self._load_stats()
         history = stats.get("analysis_history", [])
@@ -400,10 +401,10 @@ class StatsManager:
 
     def get_packing_history(
         self,
-        client_id: str | None = None,
-        worker_id: str | None = None,
-        limit: int | None = None
-    ) -> list[dict[str, Any]]:
+        client_id: Optional[str] = None,
+        worker_id: Optional[str] = None,
+        limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
         """Get packing history with optional filtering (newest first)."""
         stats = self._load_stats()
         history = stats.get("packing_history", [])
@@ -458,11 +459,11 @@ class StatsManager:
 
     def get_label_print_history(
         self,
-        client_id: str | None = None,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        limit: int | None = None,
-    ) -> list[dict[str, Any]]:
+        client_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
         """Get label print history with optional filtering.
 
         start_date/end_date may be naive or timezone-aware (the GUI builds
@@ -508,12 +509,12 @@ class StatsManager:
 
     def get_label_stats(
         self,
-        client_id: str | None = None,
-    ) -> dict[str, Any]:
+        client_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Get label printing summary statistics."""
         history = self.get_label_print_history(client_id=client_id)
 
-        sku_counts: dict[str, int] = {}
+        sku_counts: Dict[str, int] = {}
         for record in history:
             sku = record.get("sku", "Unknown")
             sku_counts[sku] = sku_counts.get(sku, 0) + record.get("copies", 1)

--- a/shared/stats_manager.py
+++ b/shared/stats_manager.py
@@ -42,15 +42,14 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, Optional, List
+from typing import Any
 
-from shared.file_lock import locked_file, FileLockError
+from shared.file_lock import FileLockError, locked_file
 from shared.metadata_utils import get_current_timestamp, parse_timestamp
 
 
 class StatsManagerError(Exception):
     """Base exception for StatsManager errors."""
-    pass
 
 
 class StatsManager:
@@ -110,7 +109,7 @@ class StatsManager:
 
         self.stats_file.parent.mkdir(parents=True, exist_ok=True)
 
-    def _get_default_stats(self) -> Dict[str, Any]:
+    def _get_default_stats(self) -> dict[str, Any]:
         """Get default statistics structure."""
         return {
             "total_orders_analyzed": 0,
@@ -125,7 +124,7 @@ class StatsManager:
             "version": "2.0",
         }
 
-    def _load_stats(self) -> Dict[str, Any]:
+    def _load_stats(self) -> dict[str, Any]:
         """Load statistics from file with file locking."""
         if not self.stats_file.exists():
             return self._get_default_stats()
@@ -154,14 +153,14 @@ class StatsManager:
 
             except json.JSONDecodeError:
                 return self._get_default_stats()
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to load stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
 
         return self._get_default_stats()
 
-    def _save_stats(self, stats: Dict[str, Any]) -> None:
+    def _save_stats(self, stats: dict[str, Any]) -> None:
         """Save statistics to file with file locking."""
         stats["last_updated"] = get_current_timestamp()
 
@@ -180,7 +179,7 @@ class StatsManager:
 
                 return
 
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to save stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
@@ -254,7 +253,7 @@ class StatsManager:
 
                 return  # Success
 
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to update stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
@@ -264,7 +263,7 @@ class StatsManager:
         client_id: str,
         session_id: str,
         orders_count: int,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: dict[str, Any] | None = None
     ) -> None:
         """Record an analysis completion from Shopify Tool.
 
@@ -309,10 +308,10 @@ class StatsManager:
         self,
         client_id: str,
         session_id: str,
-        worker_id: Optional[str],
+        worker_id: str | None,
         orders_count: int,
         items_count: int,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: dict[str, Any] | None = None
     ) -> None:
         """Record a packing session completion from Packing Tool.
 
@@ -358,7 +357,7 @@ class StatsManager:
 
         self._atomic_update(update)
 
-    def get_global_stats(self) -> Dict[str, Any]:
+    def get_global_stats(self) -> dict[str, Any]:
         """Get global statistics summary."""
         stats = self._load_stats()
         return {
@@ -368,23 +367,23 @@ class StatsManager:
             "last_updated": stats.get("last_updated"),
         }
 
-    def get_client_stats(self, client_id: str) -> Dict[str, Any]:
+    def get_client_stats(self, client_id: str) -> dict[str, Any]:
         """Get statistics for a specific client."""
         stats = self._load_stats()
         if client_id not in stats.get("by_client", {}):
             return {"orders_analyzed": 0, "orders_packed": 0, "sessions": 0}
         return stats["by_client"][client_id].copy()
 
-    def get_all_clients_stats(self) -> Dict[str, Dict[str, Any]]:
+    def get_all_clients_stats(self) -> dict[str, dict[str, Any]]:
         """Get statistics for all clients."""
         stats = self._load_stats()
         return stats.get("by_client", {}).copy()
 
     def get_analysis_history(
         self,
-        client_id: Optional[str] = None,
-        limit: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get analysis history with optional filtering (newest first)."""
         stats = self._load_stats()
         history = stats.get("analysis_history", [])
@@ -401,10 +400,10 @@ class StatsManager:
 
     def get_packing_history(
         self,
-        client_id: Optional[str] = None,
-        worker_id: Optional[str] = None,
-        limit: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        worker_id: str | None = None,
+        limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get packing history with optional filtering (newest first)."""
         stats = self._load_stats()
         history = stats.get("packing_history", [])
@@ -459,11 +458,11 @@ class StatsManager:
 
     def get_label_print_history(
         self,
-        client_id: Optional[str] = None,
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
-        limit: Optional[int] = None,
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Get label print history with optional filtering.
 
         start_date/end_date may be naive or timezone-aware (the GUI builds
@@ -509,12 +508,12 @@ class StatsManager:
 
     def get_label_stats(
         self,
-        client_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
         """Get label printing summary statistics."""
         history = self.get_label_print_history(client_id=client_id)
 
-        sku_counts: Dict[str, int] = {}
+        sku_counts: dict[str, int] = {}
         for record in history:
             sku = record.get("sku", "Unknown")
             sku_counts[sku] = sku_counts.get(sku, 0) + record.get("copies", 1)

--- a/shared/stats_manager.py
+++ b/shared/stats_manager.py
@@ -42,15 +42,14 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, Optional, List
+from typing import Any
 
-from shared.file_lock import locked_file, FileLockError
+from shared.file_lock import FileLockError, locked_file
 from shared.metadata_utils import get_current_timestamp, parse_timestamp
 
 
 class StatsManagerError(Exception):
     """Base exception for StatsManager errors."""
-    pass
 
 
 class StatsManager:
@@ -110,7 +109,7 @@ class StatsManager:
 
         self.stats_file.parent.mkdir(parents=True, exist_ok=True)
 
-    def _get_default_stats(self) -> Dict[str, Any]:
+    def _get_default_stats(self) -> dict[str, Any]:
         """Get default statistics structure."""
         return {
             "total_orders_analyzed": 0,
@@ -125,7 +124,7 @@ class StatsManager:
             "version": "2.0",
         }
 
-    def _load_stats(self) -> Dict[str, Any]:
+    def _load_stats(self) -> dict[str, Any]:
         """Load statistics from file with file locking."""
         if not self.stats_file.exists():
             return self._get_default_stats()
@@ -133,35 +132,34 @@ class StatsManager:
         for attempt in range(self.max_retries):
             try:
                 mode = 'r+' if self.stats_file.exists() else 'w+'
-                with open(self.stats_file, mode, encoding='utf-8') as f:
-                    with locked_file(f):
-                        f.seek(0)
-                        content = f.read()
-                        if not content.strip():
-                            return self._get_default_stats()
+                with open(self.stats_file, mode, encoding='utf-8') as f, locked_file(f):
+                    f.seek(0)
+                    content = f.read()
+                    if not content.strip():
+                        return self._get_default_stats()
 
-                        stats = json.loads(content)
+                    stats = json.loads(content)
 
-                        if not isinstance(stats, dict):
-                            return self._get_default_stats()
+                    if not isinstance(stats, dict):
+                        return self._get_default_stats()
 
-                        default = self._get_default_stats()
-                        for key in default:
-                            if key not in stats:
-                                stats[key] = default[key]
+                    default = self._get_default_stats()
+                    for key in default:
+                        if key not in stats:
+                            stats[key] = default[key]
 
-                        return stats
+                    return stats
 
             except json.JSONDecodeError:
                 return self._get_default_stats()
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to load stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
 
         return self._get_default_stats()
 
-    def _save_stats(self, stats: Dict[str, Any]) -> None:
+    def _save_stats(self, stats: dict[str, Any]) -> None:
         """Save statistics to file with file locking."""
         stats["last_updated"] = get_current_timestamp()
 
@@ -170,17 +168,16 @@ class StatsManager:
                 self.stats_file.parent.mkdir(parents=True, exist_ok=True)
 
                 mode = 'r+' if self.stats_file.exists() else 'w+'
-                with open(self.stats_file, mode, encoding='utf-8') as f:
-                    with locked_file(f):
-                        f.seek(0)
-                        f.truncate()
-                        json.dump(stats, f, indent=4, ensure_ascii=False)
-                        f.flush()
-                        os.fsync(f.fileno())
+                with open(self.stats_file, mode, encoding='utf-8') as f, locked_file(f):
+                    f.seek(0)
+                    f.truncate()
+                    json.dump(stats, f, indent=4, ensure_ascii=False)
+                    f.flush()
+                    os.fsync(f.fileno())
 
                 return
 
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to save stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
@@ -207,54 +204,53 @@ class StatsManager:
                     with open(self.stats_file, 'w', encoding='utf-8') as f:
                         json.dump(self._get_default_stats(), f, indent=4)
 
-                with open(self.stats_file, 'r+', encoding='utf-8') as f:
-                    with locked_file(f):
-                        f.seek(0)
-                        content = f.read()
-                        if content.strip():
-                            try:
-                                stats = json.loads(content)
-                            except json.JSONDecodeError:
-                                stats = self._get_default_stats()
-                        else:
-                            stats = self._get_default_stats()
-
-                        if not isinstance(stats, dict):
-                            stats = self._get_default_stats()
-
-                        default = self._get_default_stats()
-                        for key in default:
-                            if key not in stats:
-                                stats[key] = default[key]
-
-                        update_func(stats)
-
-                        stats["last_updated"] = get_current_timestamp()
-
-                        tmp_fd, tmp_name = tempfile.mkstemp(
-                            dir=self.stats_file.parent,
-                            prefix=f".{self.stats_file.stem}_tmp_",
-                            suffix=self.stats_file.suffix,
-                        )
+                with open(self.stats_file, 'r+', encoding='utf-8') as f, locked_file(f):
+                    f.seek(0)
+                    content = f.read()
+                    if content.strip():
                         try:
-                            with os.fdopen(tmp_fd, 'w', encoding='utf-8') as tmp_f:
-                                json.dump(stats, tmp_f, indent=4, ensure_ascii=False)
-                            new_content = Path(tmp_name).read_text(encoding='utf-8')
-                        finally:
-                            try:
-                                os.unlink(tmp_name)
-                            except OSError:
-                                pass
+                            stats = json.loads(content)
+                        except json.JSONDecodeError:
+                            stats = self._get_default_stats()
+                    else:
+                        stats = self._get_default_stats()
 
-                        f.seek(0)
-                        f.truncate()
-                        f.write(new_content)
-                        f.flush()
-                        os.fsync(f.fileno())
+                    if not isinstance(stats, dict):
+                        stats = self._get_default_stats()
+
+                    default = self._get_default_stats()
+                    for key in default:
+                        if key not in stats:
+                            stats[key] = default[key]
+
+                    update_func(stats)
+
+                    stats["last_updated"] = get_current_timestamp()
+
+                    tmp_fd, tmp_name = tempfile.mkstemp(
+                        dir=self.stats_file.parent,
+                        prefix=f".{self.stats_file.stem}_tmp_",
+                        suffix=self.stats_file.suffix,
+                    )
+                    try:
+                        with os.fdopen(tmp_fd, 'w', encoding='utf-8') as tmp_f:
+                            json.dump(stats, tmp_f, indent=4, ensure_ascii=False)
+                        new_content = Path(tmp_name).read_text(encoding='utf-8')
+                    finally:
+                        try:
+                            os.unlink(tmp_name)
+                        except OSError:
+                            pass
+
+                    f.seek(0)
+                    f.truncate()
+                    f.write(new_content)
+                    f.flush()
+                    os.fsync(f.fileno())
 
                 return  # Success
 
-            except (IOError, FileLockError) as e:
+            except (OSError, FileLockError) as e:
                 if attempt == self.max_retries - 1:
                     raise StatsManagerError(f"Failed to update stats after {self.max_retries} attempts: {e}")
                 time.sleep(self.retry_delay * (attempt + 1))
@@ -264,7 +260,7 @@ class StatsManager:
         client_id: str,
         session_id: str,
         orders_count: int,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: dict[str, Any] | None = None
     ) -> None:
         """Record an analysis completion from Shopify Tool.
 
@@ -309,10 +305,10 @@ class StatsManager:
         self,
         client_id: str,
         session_id: str,
-        worker_id: Optional[str],
+        worker_id: str | None,
         orders_count: int,
         items_count: int,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: dict[str, Any] | None = None
     ) -> None:
         """Record a packing session completion from Packing Tool.
 
@@ -358,7 +354,7 @@ class StatsManager:
 
         self._atomic_update(update)
 
-    def get_global_stats(self) -> Dict[str, Any]:
+    def get_global_stats(self) -> dict[str, Any]:
         """Get global statistics summary."""
         stats = self._load_stats()
         return {
@@ -368,23 +364,23 @@ class StatsManager:
             "last_updated": stats.get("last_updated"),
         }
 
-    def get_client_stats(self, client_id: str) -> Dict[str, Any]:
+    def get_client_stats(self, client_id: str) -> dict[str, Any]:
         """Get statistics for a specific client."""
         stats = self._load_stats()
         if client_id not in stats.get("by_client", {}):
             return {"orders_analyzed": 0, "orders_packed": 0, "sessions": 0}
         return stats["by_client"][client_id].copy()
 
-    def get_all_clients_stats(self) -> Dict[str, Dict[str, Any]]:
+    def get_all_clients_stats(self) -> dict[str, dict[str, Any]]:
         """Get statistics for all clients."""
         stats = self._load_stats()
         return stats.get("by_client", {}).copy()
 
     def get_analysis_history(
         self,
-        client_id: Optional[str] = None,
-        limit: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get analysis history with optional filtering (newest first)."""
         stats = self._load_stats()
         history = stats.get("analysis_history", [])
@@ -401,10 +397,10 @@ class StatsManager:
 
     def get_packing_history(
         self,
-        client_id: Optional[str] = None,
-        worker_id: Optional[str] = None,
-        limit: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        worker_id: str | None = None,
+        limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get packing history with optional filtering (newest first)."""
         stats = self._load_stats()
         history = stats.get("packing_history", [])
@@ -459,11 +455,11 @@ class StatsManager:
 
     def get_label_print_history(
         self,
-        client_id: Optional[str] = None,
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
-        limit: Optional[int] = None,
-    ) -> List[Dict[str, Any]]:
+        client_id: str | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Get label print history with optional filtering.
 
         start_date/end_date may be naive or timezone-aware (the GUI builds
@@ -509,12 +505,12 @@ class StatsManager:
 
     def get_label_stats(
         self,
-        client_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
         """Get label printing summary statistics."""
         history = self.get_label_print_history(client_id=client_id)
 
-        sku_counts: Dict[str, int] = {}
+        sku_counts: dict[str, int] = {}
         for record in history:
             sku = record.get("sku", "Unknown")
             sku_counts[sku] = sku_counts.get(sku, 0) + record.get("copies", 1)

--- a/shared/theme.py
+++ b/shared/theme.py
@@ -376,7 +376,7 @@ def build_stylesheet(theme: ThemeTokens) -> str:
 def build_palette(theme: ThemeTokens):
     """Build a QPalette for one theme. Import is local so this module stays
     importable in a pure-Python (no Qt) context, e.g. under plain pytest."""
-    from PySide6.QtGui import QColor, QPalette
+    from PySide6.QtGui import QPalette, QColor
 
     palette = QPalette()
     palette.setColor(QPalette.ColorRole.Window, QColor(theme.background))

--- a/shared/theme.py
+++ b/shared/theme.py
@@ -376,7 +376,7 @@ def build_stylesheet(theme: ThemeTokens) -> str:
 def build_palette(theme: ThemeTokens):
     """Build a QPalette for one theme. Import is local so this module stays
     importable in a pure-Python (no Qt) context, e.g. under plain pytest."""
-    from PySide6.QtGui import QPalette, QColor
+    from PySide6.QtGui import QColor, QPalette
 
     palette = QPalette()
     palette.setColor(QPalette.ColorRole.Window, QColor(theme.background))

--- a/shopify_tool/analysis.py
+++ b/shopify_tool/analysis.py
@@ -1,20 +1,20 @@
 import copy
-import math
-import re
-import pandas as pd
-import numpy as np
-from typing import Tuple, Dict, List, Optional
-from datetime import date
 import logging
+import math
+from datetime import date
+
+import numpy as np
+import pandas as pd
+
 from shopify_tool.csv_utils import order_number_sort_key
 
 logger = logging.getLogger(__name__)
 
 # Bulgarian ERP CSV column names for lot tracking (Expiry_Date, Batch)
-_LOT_COLUMN_DEFAULTS: Dict[str, str] = {"Годност": "Expiry_Date", "Партида": "Batch"}
+_LOT_COLUMN_DEFAULTS: dict[str, str] = {"Годност": "Expiry_Date", "Партида": "Batch"}
 
 
-def _parse_expiry_date(raw) -> Optional[date]:
+def _parse_expiry_date(raw) -> date | None:
     """Parse a raw expiry string from the stock CSV to a comparable date object.
 
     Handles:
@@ -46,7 +46,7 @@ def _parse_expiry_date(raw) -> Optional[date]:
     return None
 
 
-def _build_fifo_lots(stock_df: pd.DataFrame) -> Optional[Dict[str, List[dict]]]:
+def _build_fifo_lots(stock_df: pd.DataFrame) -> dict[str, list[dict]] | None:
     """Build a FIFO-sorted lot inventory from a multi-row stock DataFrame.
 
     Returns None when neither Expiry_Date nor Batch column is present
@@ -72,7 +72,7 @@ def _build_fifo_lots(stock_df: pd.DataFrame) -> Optional[Dict[str, List[dict]]]:
     if not has_expiry and not has_batch:
         return None
 
-    fifo_lots: Dict[str, List[dict]] = {}
+    fifo_lots: dict[str, list[dict]] = {}
     _SENTINEL = date(9999, 12, 31)  # sorts after all real dates
 
     for sku, group in stock_df.groupby("SKU"):
@@ -124,9 +124,9 @@ def _build_fifo_lots(stock_df: pd.DataFrame) -> Optional[Dict[str, List[dict]]]:
 def _clean_and_prepare_data(
     orders_df: pd.DataFrame,
     stock_df: pd.DataFrame,
-    column_mappings: Optional[dict] = None,
-    additional_columns_config: Optional[List[dict]] = None,
-) -> Tuple[pd.DataFrame, pd.DataFrame, Optional[Dict[str, List[dict]]]]:
+    column_mappings: dict | None = None,
+    additional_columns_config: list[dict] | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, list[dict]] | None]:
     """
     Clean and standardize input data for analysis.
 
@@ -494,8 +494,8 @@ def _simulate_stock_allocation(
     orders_df: pd.DataFrame,
     stock_df: pd.DataFrame,
     prioritized_orders: pd.DataFrame,
-    fifo_lots: Optional[Dict[str, List[dict]]] = None,
-) -> Tuple[Dict[str, dict], Dict[str, Dict[str, List[dict]]]]:
+    fifo_lots: dict[str, list[dict]] | None = None,
+) -> tuple[dict[str, dict], dict[str, dict[str, list[dict]]]]:
     """
     Simulate stock allocation across prioritized orders.
 
@@ -536,7 +536,7 @@ def _simulate_stock_allocation(
         orders_for_simulation = orders_df.copy()
 
     # Pre-group required quantities per order — single O(N) pass avoids O(N²) per-order scans
-    order_required_quantities: Dict[str, "pd.Series"] = {
+    order_required_quantities: dict[str, pd.Series] = {
         order_num: grp.groupby("SKU")["Quantity"].sum()
         for order_num, grp in orders_for_simulation.groupby("Order_Number")
     }
@@ -546,7 +546,7 @@ def _simulate_stock_allocation(
     # NaN, so an order whose only line item is invalid would otherwise look
     # like a legitimate zero-quantity order and get marked Fulfillable.
     invalid_qty_rows = orders_for_simulation[orders_for_simulation["Quantity"].isna()]
-    invalid_qty_by_order: Dict[str, List[str]] = (
+    invalid_qty_by_order: dict[str, list[str]] = (
         invalid_qty_rows.groupby("Order_Number")["SKU"].apply(list).to_dict()
         if not invalid_qty_rows.empty
         else {}
@@ -558,7 +558,7 @@ def _simulate_stock_allocation(
         # --- LEGACY PATH (no lot tracking) ---
         # Initialize stock tracking - VECTORIZED dict creation
         live_stock = pd.Series(stock_df.Stock.values, index=stock_df.SKU).to_dict()
-        lot_allocations: Dict[str, Dict[str, List[dict]]] = {}
+        lot_allocations: dict[str, dict[str, list[dict]]] = {}
 
         for order_number in prioritized_orders["Order_Number"]:
             if order_number in invalid_qty_by_order:
@@ -638,10 +638,10 @@ def _simulate_stock_allocation(
 
             # COMMIT PHASE (mutate live_lots only if order is fulfillable)
             if can_fulfill_order:
-                order_alloc: Dict[str, List[dict]] = {}
+                order_alloc: dict[str, list[dict]] = {}
                 for sku, needed in required_quantities.items():
                     remaining = needed
-                    sku_alloc: List[dict] = []
+                    sku_alloc: list[dict] = []
                     for lot in live_lots.get(sku, []):
                         if remaining <= 0:
                             break
@@ -684,7 +684,7 @@ def _simulate_stock_allocation(
 
 
 def _calculate_final_stock(
-    stock_df: pd.DataFrame, fulfillment_results: Dict[str, str], orders_df: pd.DataFrame
+    stock_df: pd.DataFrame, fulfillment_results: dict[str, str], orders_df: pd.DataFrame
 ) -> pd.DataFrame:
     """
     Calculate final stock levels after fulfillment simulation.
@@ -873,12 +873,12 @@ def _merge_results_to_dataframe(
     stock_df: pd.DataFrame,
     order_item_counts: pd.Series,
     final_stock_levels: pd.DataFrame,
-    fulfillment_results: Dict[str, str],
+    fulfillment_results: dict[str, str],
     history_df: pd.DataFrame,
-    courier_mappings: Optional[dict] = None,
+    courier_mappings: dict | None = None,
     repeat_window_days: int = 1,
-    additional_columns_config: Optional[list] = None,
-    lot_allocations: Optional[Dict[str, Dict[str, List[dict]]]] = None,
+    additional_columns_config: list | None = None,
+    lot_allocations: dict[str, dict[str, list[dict]]] | None = None,
 ) -> pd.DataFrame:
     """
     Merge all analysis results into final output DataFrame.
@@ -1138,7 +1138,7 @@ def _merge_results_to_dataframe(
 
 def _generate_summary_reports(
     final_df: pd.DataFrame,
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Generate summary reports for fulfilled and missing items.
 

--- a/shopify_tool/analysis.py
+++ b/shopify_tool/analysis.py
@@ -799,7 +799,9 @@ def _detect_repeated_orders(
                 # Example: if repeat_window_days=1 and today=2026-01-16:
                 #   - cutoff = 2026-01-16 (today)
                 #   - We want: Execution_Date < 2026-01-16 (i.e., 2026-01-15 and earlier)
-                today = datetime.now().replace(
+                # Deliberately naive: must compare against Execution_Date_Parsed,
+                # which pd.to_datetime() above produces as tz-naive.
+                today = datetime.now().replace(  # noqa: DTZ005
                     hour=0, minute=0, second=0, microsecond=0
                 )
                 cutoff_date = today - timedelta(days=repeat_window_days - 1)
@@ -815,8 +817,8 @@ def _detect_repeated_orders(
                     f"Using {len(old_history)} old history records (>= {repeat_window_days} days ago) "
                     f"(total: {len(history_df)}, cutoff: < {cutoff_date.strftime('%Y-%m-%d')})"
                 )
-        except Exception as e:
-            logger.error(f"Failed to parse history dates: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to parse history dates")
             # Fallback to full history
             repeated_orders = history_df["Order_Number"].unique()
             logger.warning("Falling back to full history due to date parsing error")
@@ -1467,14 +1469,14 @@ def run_analysis(
 
         return final_df, summary_present_df, summary_missing_df, stats
 
-    except ValueError as e:
-        logger.error(f"Validation error during analysis: {e}", exc_info=True)
+    except ValueError:
+        logger.exception("Validation error during analysis")
         raise
-    except KeyError as e:
-        logger.error(f"Missing required column: {e}", exc_info=True)
+    except KeyError:
+        logger.exception("Missing required column")
         raise
-    except Exception as e:
-        logger.error(f"Unexpected error during analysis: {e}", exc_info=True)
+    except Exception:
+        logger.exception("Unexpected error during analysis")
         raise
 
 
@@ -1601,8 +1603,8 @@ def recalculate_statistics(df):
                 f"{len(tags_breakdown_not_fulfillable)} not-fulfillable unique tags"
             )
 
-        except Exception as e:
-            logger.error(f"Failed to calculate tags breakdown: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to calculate tags breakdown")
 
     # === NEW: SKU Summary ===
     sku_summary = None
@@ -1652,8 +1654,8 @@ def recalculate_statistics(df):
 
         logger.info(f"SKU summary calculated: {len(sku_summary)} unique SKUs")
 
-    except Exception as e:
-        logger.error(f"Failed to calculate SKU summary: {e}", exc_info=True)
+    except Exception:
+        logger.exception("Failed to calculate SKU summary")
         sku_summary = None
 
     stats["tags_breakdown"] = tags_breakdown

--- a/shopify_tool/barcode_history.py
+++ b/shopify_tool/barcode_history.py
@@ -5,11 +5,11 @@ Tracks all generated barcodes for audit and statistics.
 History persisted per packing list in barcode_history.json.
 """
 
-import logging
 import json
-from pathlib import Path
-from typing import Dict, Any
+import logging
 from datetime import datetime
+from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class BarcodeHistory:
         self.history_file = history_file
         self.data = self._load_history()
 
-    def _load_history(self) -> Dict:
+    def _load_history(self) -> dict:
         """Load history from JSON file."""
         if not self.history_file.exists():
             logger.info(f"Creating new history file: {self.history_file}")
@@ -48,7 +48,7 @@ class BarcodeHistory:
             logger.error(f"Failed to load history: {e}", exc_info=True)
             return {"generated_barcodes": []}
 
-    def _save_history(self, data: Dict = None):
+    def _save_history(self, data: dict = None):
         """Save history to JSON file."""
         if data is None:
             data = self.data
@@ -62,7 +62,7 @@ class BarcodeHistory:
         except Exception as e:
             logger.error(f"Failed to save history: {e}", exc_info=True)
 
-    def add_entry(self, entry: Dict[str, Any]):
+    def add_entry(self, entry: dict[str, Any]):
         """
         Add barcode generation entry to history.
 
@@ -88,7 +88,7 @@ class BarcodeHistory:
         self._save_history()
         logger.info("History cleared")
 
-    def get_statistics(self) -> Dict:
+    def get_statistics(self) -> dict:
         """
         Get statistics from history.
 

--- a/shopify_tool/barcode_history.py
+++ b/shopify_tool/barcode_history.py
@@ -44,11 +44,11 @@ class BarcodeHistory:
             logger.info(f"Loaded history: {len(data.get('generated_barcodes', []))} entries")
             return data
 
-        except (json.JSONDecodeError, KeyError) as e:
-            logger.error(f"Failed to load history: {e}", exc_info=True)
+        except (json.JSONDecodeError, KeyError):
+            logger.exception("Failed to load history")
             return {"generated_barcodes": []}
 
-    def _save_history(self, data: dict = None):
+    def _save_history(self, data: dict | None = None):
         """Save history to JSON file."""
         if data is None:
             data = self.data
@@ -59,8 +59,8 @@ class BarcodeHistory:
 
             logger.debug(f"Saved history: {len(data.get('generated_barcodes', []))} entries")
 
-        except Exception as e:
-            logger.error(f"Failed to save history: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save history")
 
     def add_entry(self, entry: dict[str, Any]):
         """
@@ -71,7 +71,7 @@ class BarcodeHistory:
         """
         # Add timestamp if not present
         if 'generated_at' not in entry:
-            entry['generated_at'] = datetime.now().isoformat()
+            entry['generated_at'] = datetime.now().astimezone().isoformat()
 
         # Convert Path objects to strings for JSON serialization
         if 'file_path' in entry and entry['file_path'] is not None:

--- a/shopify_tool/barcode_processor.py
+++ b/shopify_tool/barcode_processor.py
@@ -23,20 +23,20 @@ Fields:
 """
 
 import io
-import logging
-from functools import lru_cache
-from pathlib import Path
-from typing import Dict, List, Any, Optional, Callable
-from datetime import datetime
 import json
+import logging
+from collections.abc import Callable
+from datetime import datetime
+from functools import cache
+from pathlib import Path
+from typing import Any
 
 import pandas as pd
-import barcode
 from barcode.codex import Code128
 from barcode.writer import ImageWriter
 from PIL import Image, ImageDraw, ImageFont
-from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import mm
+from reportlab.pdfgen import canvas
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,6 @@ logger = logging.getLogger(__name__)
 # This prevents "cannot open resource" errors when fonts are not available
 def _noop_paint_text(self, *args, **kwargs):
     """No-op replacement for _paint_text to avoid font loading."""
-    pass
 
 ImageWriter._paint_text = _noop_paint_text
 
@@ -71,17 +70,14 @@ FONT_SIZE_LARGE = 16   # For courier name (bold)
 # === EXCEPTIONS ===
 class BarcodeProcessorError(Exception):
     """Base exception for barcode processor."""
-    pass
 
 
 class InvalidOrderNumberError(BarcodeProcessorError):
     """Invalid order number for barcode encoding."""
-    pass
 
 
 class BarcodeGenerationError(BarcodeProcessorError):
     """Error during barcode generation."""
-    pass
 
 
 # === UTILITY FUNCTIONS ===
@@ -115,7 +111,7 @@ def sanitize_order_number(order_number: str) -> str:
     return clean
 
 
-@lru_cache(maxsize=None)
+@cache
 def load_font(size: int, bold: bool = False) -> ImageFont.FreeTypeFont:
     """
     Load font with fallback strategy, cached to avoid repeated disk reads.
@@ -166,7 +162,6 @@ def format_tags_for_barcode(internal_tag: str) -> str:
         return ""
 
     # Try to parse as JSON array (Internal_Tags format)
-    import json
     try:
         if internal_tag.startswith('[') and internal_tag.endswith(']'):
             tags_list = json.loads(internal_tag)
@@ -196,7 +191,7 @@ def generate_barcode_label(
     output_dir: Path,
     label_width_mm: float = LABEL_WIDTH_MM,
     label_height_mm: float = LABEL_HEIGHT_MM
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Generate single barcode label with complex layout.
 
@@ -488,9 +483,9 @@ def generate_barcode_label(
 def generate_barcodes_batch(
     df: pd.DataFrame,
     output_dir: Path,
-    sequential_map: Optional[Dict[str, int]] = None,
-    progress_callback: Optional[Callable[[int, int, str], None]] = None
-) -> List[Dict[str, Any]]:
+    sequential_map: dict[str, int] | None = None,
+    progress_callback: Callable[[int, int, str], None] | None = None
+) -> list[dict[str, Any]]:
     """
     Generate barcodes for multiple orders with progress tracking.
 
@@ -612,7 +607,7 @@ def generate_barcodes_batch(
 
 
 def generate_barcodes_pdf(
-    barcode_files: List[Path],
+    barcode_files: list[Path],
     output_pdf: Path,
     label_width_mm: float = LABEL_WIDTH_MM,
     label_height_mm: float = LABEL_HEIGHT_MM

--- a/shopify_tool/barcode_processor.py
+++ b/shopify_tool/barcode_processor.py
@@ -237,7 +237,7 @@ def generate_barcode_label(
         # Prepare display values
         country_display = country if country else "N/A"
         tag_display = format_tags_for_barcode(tag) if tag else "N/A"
-        date_str = datetime.now().strftime("%d/%m/%y")
+        date_str = datetime.now().astimezone().strftime("%d/%m/%y")
 
         # Calculate dimensions
         dpi = DPI
@@ -363,9 +363,9 @@ def generate_barcode_label(
 
             # Draw tags with word wrapping
             current_line = ""
-            for tag in tags:
+            for single_tag in tags:
                 # Try to fit tag on current line
-                test_line = current_line + (", " if current_line else "") + tag
+                test_line = current_line + (", " if current_line else "") + single_tag
                 bbox = draw.textbbox((0, 0), test_line, font=font_tag_multiline)
                 line_width = bbox[2] - bbox[0]
 
@@ -376,7 +376,7 @@ def generate_barcode_label(
                     if current_line:
                         draw.text((tag_x, tag_y), current_line, font=font_tag_multiline, fill='black')
                         tag_y += line_height
-                    current_line = tag
+                    current_line = single_tag
 
                 # Check if we're out of vertical space
                 if tag_y + line_height > tag_start_y + available_height:
@@ -450,7 +450,7 @@ def generate_barcode_label(
         }
 
     except InvalidOrderNumberError as e:
-        logger.error(f"Invalid order number '{order_number}': {e}", exc_info=True)
+        logger.exception(f"Invalid order number '{order_number}'")
         return {
             "order_number": order_number,
             "sequential_num": 0,
@@ -465,7 +465,7 @@ def generate_barcode_label(
         }
 
     except Exception as e:
-        logger.error(f"Failed to generate barcode for '{order_number}': {e}", exc_info=True)
+        logger.exception(f"Failed to generate barcode for '{order_number}'")
         return {
             "order_number": order_number,
             "sequential_num": 0,
@@ -584,7 +584,7 @@ def generate_barcodes_batch(
             results.append(result)
 
         except Exception as e:
-            logger.error(f"Failed to generate barcode for {order_number}: {e}", exc_info=True)
+            logger.exception(f"Failed to generate barcode for {order_number}")
 
             results.append({
                 "order_number": order_number,

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -1,17 +1,19 @@
-import os
-import logging
-import pandas as pd
 import json
+import logging
+import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Tuple, Dict, Any, List
-from . import analysis, packing_lists, stock_export
-from .rules import RuleEngine
-from .utils import get_persistent_data_path
-from .csv_utils import normalize_sku
-from .session_manager import SessionManagerError
+from typing import Any
+
 import numpy as np
+import pandas as pd
+
+from . import analysis, packing_lists, stock_export
+from .csv_utils import normalize_sku
+from .rules import RuleEngine
+from .session_manager import SessionManagerError
+from .utils import get_persistent_data_path
 
 SYSTEM_TAGS = ["Repeat", "Priority", "Error"]
 
@@ -63,7 +65,7 @@ def _get_sku_dtype_dict(column_mappings: dict, file_type: str) -> dict:
     return dtype_dict
 
 
-def build_packing_order_data(order_number: str, group: pd.DataFrame) -> Dict[str, Any]:
+def build_packing_order_data(order_number: str, group: pd.DataFrame) -> dict[str, Any]:
     """Build canonical order metadata dict for Packer-tool JSON integration.
 
     Used by both analysis_data.json and packing list JSON generators
@@ -83,7 +85,7 @@ def build_packing_order_data(order_number: str, group: pd.DataFrame) -> Dict[str
     # Parse Internal_Tags: "[]" JSON string → Python list
     tags_raw = first_row.get("Internal_Tags", "[]") or "[]"
     try:
-        internal_tags: List[str] = (
+        internal_tags: list[str] = (
             json.loads(tags_raw) if isinstance(tags_raw, str) else []
         )
     except (json.JSONDecodeError, TypeError):
@@ -91,7 +93,7 @@ def build_packing_order_data(order_number: str, group: pd.DataFrame) -> Dict[str
 
     # Parse Tags: "tag1, tag2" CSV string → list
     tags_value = first_row.get("Tags", "") or ""
-    tags_list: List[str] = (
+    tags_list: list[str] = (
         [t.strip() for t in str(tags_value).split(",") if t.strip()]
         if str(tags_value).strip()
         else []
@@ -100,7 +102,7 @@ def build_packing_order_data(order_number: str, group: pd.DataFrame) -> Dict[str
     # Optional Order_Min_Box (only present if weight config is active)
     # pd.isna() handles None, float('nan'), pd.NaT from pandas mixed-type columns
     min_box_raw = first_row.get("Order_Min_Box", None)
-    order_min_box: Optional[str] = (
+    order_min_box: str | None = (
         str(min_box_raw)
         if min_box_raw is not None
         and not pd.isna(min_box_raw)
@@ -115,7 +117,7 @@ def build_packing_order_data(order_number: str, group: pd.DataFrame) -> Dict[str
     destination_country: str = str(first_row.get("Destination_Country", "") or "")
 
     # Build items list with safe Quantity conversion (guards against NaN / non-numeric)
-    items: List[Dict[str, Any]] = []
+    items: list[dict[str, Any]] = []
     for _, row in group.iterrows():
         warehouse_name = row.get("Warehouse_Name", "")
         if not warehouse_name or warehouse_name == "N/A":
@@ -164,7 +166,7 @@ def build_packing_order_data(order_number: str, group: pd.DataFrame) -> Dict[str
     }
 
 
-def _create_analysis_data_for_packing(final_df: pd.DataFrame) -> Dict[str, Any]:
+def _create_analysis_data_for_packing(final_df: pd.DataFrame) -> dict[str, Any]:
     """Create analysis_data.json structure for Packing Tool integration.
 
     This function extracts relevant data from the analysis DataFrame and
@@ -371,13 +373,13 @@ def validate_csv_headers(file_path, required_columns, delimiter=","):
 
 
 def _validate_and_prepare_inputs(
-    stock_file_path: Optional[str],
-    orders_file_path: Optional[str],
+    stock_file_path: str | None,
+    orders_file_path: str | None,
     output_dir_path: str,
-    client_id: Optional[str],
-    session_manager: Optional[Any],
-    session_path: Optional[str],
-) -> Tuple[bool, Optional[str], str, Optional[str]]:
+    client_id: str | None,
+    session_manager: Any | None,
+    session_path: str | None,
+) -> tuple[bool, str | None, str, str | None]:
     """Validates inputs and prepares session/working paths.
 
     Determines whether to use session-based or legacy workflow mode,
@@ -475,12 +477,12 @@ def _validate_and_prepare_inputs(
 
 
 def _load_and_validate_files(
-    stock_file_path: Optional[str],
-    orders_file_path: Optional[str],
+    stock_file_path: str | None,
+    orders_file_path: str | None,
     stock_delimiter: str,
     orders_delimiter: str,
     config: dict,
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Loads and validates CSV files.
 
     Loads stock and orders CSV files, applies proper encoding and
@@ -534,15 +536,15 @@ def _load_and_validate_files(
             error_msg = (
                 f"Failed to parse stock file. The file may have incorrect delimiter.\n"
                 f"Current delimiter: '{stock_delimiter}'\n"
-                f"Error: {str(e)}"
+                f"Error: {e!s}"
             )
             logger.error(error_msg, exc_info=True)
             raise
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             error_msg = f"Stock file not found at path: {stock_file_path}"
             logger.error(error_msg, exc_info=True)
             raise
-        except PermissionError as e:
+        except PermissionError:
             error_msg = f"Permission denied reading stock file: {stock_file_path}"
             logger.error(error_msg, exc_info=True)
             raise
@@ -550,7 +552,7 @@ def _load_and_validate_files(
             error_msg = (
                 f"Failed to read stock file due to encoding issue.\n"
                 f"Please ensure file is UTF-8 encoded.\n"
-                f"Error: {str(e)}"
+                f"Error: {e!s}"
             )
             logger.error(error_msg, exc_info=True)
             raise
@@ -583,15 +585,15 @@ def _load_and_validate_files(
             error_msg = (
                 f"Failed to parse orders file. The file may have incorrect delimiter.\n"
                 f"Current delimiter: '{orders_delimiter}'\n"
-                f"Error: {str(e)}"
+                f"Error: {e!s}"
             )
             logger.error(error_msg, exc_info=True)
             raise
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             error_msg = f"Orders file not found at path: {orders_file_path}"
             logger.error(error_msg, exc_info=True)
             raise
-        except PermissionError as e:
+        except PermissionError:
             error_msg = f"Permission denied reading orders file: {orders_file_path}"
             logger.error(error_msg, exc_info=True)
             raise
@@ -599,7 +601,7 @@ def _load_and_validate_files(
             error_msg = (
                 f"Failed to read orders file due to encoding issue.\n"
                 f"Please ensure file is UTF-8 encoded.\n"
-                f"Error: {str(e)}"
+                f"Error: {e!s}"
             )
             logger.error(error_msg, exc_info=True)
             raise
@@ -670,10 +672,10 @@ def _load_and_validate_files(
 
 
 def _load_history_data(
-    stock_file_path: Optional[str],
-    orders_file_path: Optional[str],
-    client_id: Optional[str],
-    profile_manager: Optional[Any],
+    stock_file_path: str | None,
+    orders_file_path: str | None,
+    client_id: str | None,
+    profile_manager: Any | None,
     config: dict,
 ) -> pd.DataFrame:
     """Loads fulfillment history from appropriate storage location.
@@ -758,7 +760,7 @@ def _run_analysis_and_rules(
     stock_df: pd.DataFrame,
     history_df: pd.DataFrame,
     config: dict,
-) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, dict]:
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, dict]:
     """Runs analysis simulation and applies business rules.
 
     Executes the core fulfillment analysis, applies low stock alerts,
@@ -863,15 +865,15 @@ def _save_results_and_reports(
     summary_missing_df: pd.DataFrame,
     stats: dict,
     history_df: pd.DataFrame,
-    stock_file_path: Optional[str],
-    orders_file_path: Optional[str],
+    stock_file_path: str | None,
+    orders_file_path: str | None,
     use_session_mode: bool,
     working_path: str,
     output_dir_path: str,
-    session_manager: Optional[Any],
-    client_id: Optional[str],
-    profile_manager: Optional[Any],
-) -> Tuple[str, Optional[str]]:
+    session_manager: Any | None,
+    client_id: str | None,
+    profile_manager: Any | None,
+) -> tuple[str, str | None]:
     """Saves all analysis results, reports, and updates history.
 
     Saves Excel report with analysis results, creates analysis_data.json
@@ -1141,10 +1143,10 @@ def run_full_analysis(
     stock_delimiter,
     orders_delimiter,
     config,
-    client_id: Optional[str] = None,
-    session_manager: Optional[Any] = None,
-    profile_manager: Optional[Any] = None,
-    session_path: Optional[str] = None,
+    client_id: str | None = None,
+    session_manager: Any | None = None,
+    profile_manager: Any | None = None,
+    session_path: str | None = None,
 ):
     """Orchestrates the entire fulfillment analysis process.
 
@@ -1288,19 +1290,19 @@ def run_full_analysis(
         return True, primary_path, final_df, stats
 
     except FileNotFoundError as e:
-        error_msg = f"File not found: {str(e)}"
+        error_msg = f"File not found: {e!s}"
         logger.error(error_msg, exc_info=True)
         return False, error_msg, None, None
     except ValueError as e:
-        error_msg = f"Validation error: {str(e)}"
+        error_msg = f"Validation error: {e!s}"
         logger.error(error_msg, exc_info=True)
         return False, error_msg, None, None
     except pd.errors.ParserError as e:
-        error_msg = f"CSV parsing error: {str(e)}"
+        error_msg = f"CSV parsing error: {e!s}"
         logger.error(error_msg, exc_info=True)
         return False, error_msg, None, None
     except Exception as e:
-        error_msg = f"Analysis failed: {str(e)}"
+        error_msg = f"Analysis failed: {e!s}"
         logger.error(error_msg, exc_info=True)
         return False, error_msg, None, None
 
@@ -1308,8 +1310,8 @@ def run_full_analysis(
 def create_packing_list_report(
     analysis_df,
     report_config,
-    session_manager: Optional[Any] = None,
-    session_path: Optional[str] = None,
+    session_manager: Any | None = None,
+    session_path: str | None = None,
 ):
     """Generates a single packing list report based on a report configuration.
 
@@ -1427,9 +1429,9 @@ def get_unique_column_values(df, column_name):
 def create_stock_export_report(
     analysis_df,
     report_config,
-    session_manager: Optional[Any] = None,
-    session_path: Optional[str] = None,
-    tag_categories: Optional[Dict] = None,
+    session_manager: Any | None = None,
+    session_path: str | None = None,
+    tag_categories: dict | None = None,
 ):
     """Generates a single stock export report based on a configuration.
 
@@ -1524,11 +1526,11 @@ def create_stock_export_report(
 
 def create_writeoff_report(
     analysis_df: pd.DataFrame,
-    report_config: Dict,
-    tag_categories: Dict,
-    session_manager: Optional[Any] = None,
-    session_path: Optional[str] = None,
-) -> Tuple[bool, str]:
+    report_config: dict,
+    tag_categories: dict,
+    session_manager: Any | None = None,
+    session_path: str | None = None,
+) -> tuple[bool, str]:
     """Generate standalone SKU writeoff report.
 
     Session Mode: When session_manager and session_path are provided, the report

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -194,7 +194,7 @@ def _create_analysis_data_for_packing(final_df: pd.DataFrame) -> dict[str, Any]:
         not_fulfillable_orders = total_orders - fulfillable_orders
 
         analysis_data = {
-            "analyzed_at": datetime.now().isoformat(),
+            "analyzed_at": datetime.now().astimezone().isoformat(),
             "total_orders": total_orders,
             "fulfillable_orders": fulfillable_orders,
             "not_fulfillable_orders": not_fulfillable_orders,
@@ -204,9 +204,9 @@ def _create_analysis_data_for_packing(final_df: pd.DataFrame) -> dict[str, Any]:
         return analysis_data
 
     except KeyError as e:
-        logger.error(f"Missing required column in DataFrame for packing analysis: {e}", exc_info=True)
+        logger.exception("Missing required column in DataFrame for packing analysis")
         return {
-            "analyzed_at": datetime.now().isoformat(),
+            "analyzed_at": datetime.now().astimezone().isoformat(),
             "total_orders": 0,
             "fulfillable_orders": 0,
             "not_fulfillable_orders": 0,
@@ -214,9 +214,9 @@ def _create_analysis_data_for_packing(final_df: pd.DataFrame) -> dict[str, Any]:
             "error": f"Missing required column: {e}",
         }
     except (ValueError, TypeError) as e:
-        logger.error(f"Invalid data type in DataFrame for packing analysis: {e}", exc_info=True)
+        logger.exception("Invalid data type in DataFrame for packing analysis")
         return {
-            "analyzed_at": datetime.now().isoformat(),
+            "analyzed_at": datetime.now().astimezone().isoformat(),
             "total_orders": 0,
             "fulfillable_orders": 0,
             "not_fulfillable_orders": 0,
@@ -224,9 +224,9 @@ def _create_analysis_data_for_packing(final_df: pd.DataFrame) -> dict[str, Any]:
             "error": f"Invalid data type: {e}",
         }
     except AttributeError as e:
-        logger.error(f"Invalid DataFrame object for packing analysis: {e}", exc_info=True)
+        logger.exception("Invalid DataFrame object for packing analysis")
         return {
-            "analyzed_at": datetime.now().isoformat(),
+            "analyzed_at": datetime.now().astimezone().isoformat(),
             "total_orders": 0,
             "fulfillable_orders": 0,
             "not_fulfillable_orders": 0,
@@ -234,11 +234,11 @@ def _create_analysis_data_for_packing(final_df: pd.DataFrame) -> dict[str, Any]:
             "error": f"Invalid DataFrame: {e}",
         }
     except Exception as e:
-        logger.error(
-            f"Unexpected error creating analysis data for packing: {e}", exc_info=True
+        logger.exception(
+            "Unexpected error creating analysis data for packing"
         )
         return {
-            "analyzed_at": datetime.now().isoformat(),
+            "analyzed_at": datetime.now().astimezone().isoformat(),
             "total_orders": 0,
             "fulfillable_orders": 0,
             "not_fulfillable_orders": 0,
@@ -360,14 +360,13 @@ def validate_csv_headers(file_path, required_columns, delimiter=","):
     except FileNotFoundError:
         return False, [f"File not found at path: {file_path}"]
     except pd.errors.ParserError as e:
-        logger.error(f"Parser error validating CSV '{file_path}': {e}", exc_info=True)
+        logger.exception(f"Parser error validating CSV '{file_path}'")
         return False, [
             f"Could not parse file. It might be corrupt or not a valid CSV. Error: {e}"
         ]
     except Exception as e:
-        logger.error(
-            f"Unexpected error validating CSV headers for {file_path}: {e}",
-            exc_info=True,
+        logger.exception(
+            f"Unexpected error validating CSV headers for {file_path}",
         )
         return False, [f"An unexpected error occurred: {e}"]
 
@@ -416,13 +415,13 @@ def _validate_and_prepare_inputs(
                 logger.info(f"Session created at: {session_path}")
             except SessionManagerError as e:
                 error_msg = f"Failed to create session for client {client_id}: {e}"
-                logger.error(error_msg, exc_info=True)
+                logger.exception(error_msg)
                 raise ValueError(error_msg)
             except (OSError, PermissionError) as e:
                 error_msg = (
                     f"File system error creating session for client {client_id}: {e}"
                 )
-                logger.error(error_msg, exc_info=True)
+                logger.exception(error_msg)
                 raise ValueError(error_msg)
 
         working_path = session_path
@@ -458,19 +457,19 @@ def _validate_and_prepare_inputs(
             logger.info("Input files copied to session directory")
         except FileNotFoundError as e:
             error_msg = f"Input file not found during session setup: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise ValueError(error_msg)
         except PermissionError as e:
             error_msg = f"Permission denied copying files to session directory: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise ValueError(error_msg)
         except SessionManagerError as e:
             error_msg = f"Session manager error during setup: {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise ValueError(error_msg)
         except OSError as e:
             error_msg = f"File system error during session setup (disk full or invalid path?): {e}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise ValueError(error_msg)
 
     return use_session_mode, working_path, None, session_path
@@ -538,15 +537,15 @@ def _load_and_validate_files(
                 f"Current delimiter: '{stock_delimiter}'\n"
                 f"Error: {e!s}"
             )
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
         except FileNotFoundError:
             error_msg = f"Stock file not found at path: {stock_file_path}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
         except PermissionError:
             error_msg = f"Permission denied reading stock file: {stock_file_path}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
         except UnicodeDecodeError as e:
             error_msg = (
@@ -554,18 +553,11 @@ def _load_and_validate_files(
                 f"Please ensure file is UTF-8 encoded.\n"
                 f"Error: {e!s}"
             )
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
-        except pd.errors.ParserError as e:
-            error_msg = (
-                f"Failed to parse stock CSV file (corrupted or invalid format): {e}"
-            )
-            logger.error(error_msg, exc_info=True)
-            raise
-        except Exception as e:
-            logger.error(
-                f"Unexpected error loading stock file {stock_file_path}: {e}",
-                exc_info=True,
+        except Exception:
+            logger.exception(
+                f"Unexpected error loading stock file {stock_file_path}",
             )
             raise
 
@@ -587,15 +579,15 @@ def _load_and_validate_files(
                 f"Current delimiter: '{orders_delimiter}'\n"
                 f"Error: {e!s}"
             )
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
         except FileNotFoundError:
             error_msg = f"Orders file not found at path: {orders_file_path}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
         except PermissionError:
             error_msg = f"Permission denied reading orders file: {orders_file_path}"
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
         except UnicodeDecodeError as e:
             error_msg = (
@@ -603,18 +595,11 @@ def _load_and_validate_files(
                 f"Please ensure file is UTF-8 encoded.\n"
                 f"Error: {e!s}"
             )
-            logger.error(error_msg, exc_info=True)
+            logger.exception(error_msg)
             raise
-        except pd.errors.ParserError as e:
-            error_msg = (
-                f"Failed to parse orders CSV file (corrupted or invalid format): {e}"
-            )
-            logger.error(error_msg, exc_info=True)
-            raise
-        except Exception as e:
-            logger.error(
-                f"Unexpected error loading orders file {orders_file_path}: {e}",
-                exc_info=True,
+        except Exception:
+            logger.exception(
+                f"Unexpected error loading orders file {orders_file_path}",
             )
             raise
     else:
@@ -931,7 +916,7 @@ def _save_results_and_reports(
 
         workbook = writer.book
         report_info_sheet = workbook.add_worksheet("Report Info")
-        generation_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        generation_time = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
         report_info_sheet.write("A1", "Report Generated On:")
         report_info_sheet.write("B1", generation_time)
         report_info_sheet.set_column("A:B", 25)
@@ -984,17 +969,17 @@ def _save_results_and_reports(
 
             logger.info("Initial session state files saved successfully")
 
-        except PermissionError as e:
-            logger.error(f"Permission denied saving session state files: {e}", exc_info=True)
+        except PermissionError:
+            logger.exception("Permission denied saving session state files")
             # Continue with the workflow even if initial state save fails
-        except OSError as e:
-            logger.error(
-                f"File system error saving session state (disk full or invalid path?): {e}"
-            , exc_info=True)
+        except OSError:
+            logger.exception(
+                "File system error saving session state (disk full or invalid path?)"
+            )
             # Continue with the workflow even if initial state save fails
-        except Exception as e:
-            logger.error(
-                f"Unexpected error saving initial session state: {e}", exc_info=True
+        except Exception:
+            logger.exception(
+                "Unexpected error saving initial session state"
             )
             # Continue with the workflow even if initial state save fails
 
@@ -1016,7 +1001,7 @@ def _save_results_and_reports(
                 working_path,
                 {
                     "analysis_completed": True,
-                    "analysis_completed_at": datetime.now().isoformat(),
+                    "analysis_completed_at": datetime.now().astimezone().isoformat(),
                     "total_orders": analysis_data["total_orders"],
                     "fulfillable_orders": analysis_data["fulfillable_orders"],
                     "not_fulfillable_orders": analysis_data["not_fulfillable_orders"],
@@ -1032,22 +1017,22 @@ def _save_results_and_reports(
 
             logger.info("Session info updated with analysis results and statistics")
 
-        except PermissionError as e:
-            logger.error(f"Permission denied exporting analysis data: {e}", exc_info=True)
+        except PermissionError:
+            logger.exception("Permission denied exporting analysis data")
             # Continue with the workflow even if export fails
-        except OSError as e:
-            logger.error(
-                f"File system error exporting analysis data (disk full or invalid path?): {e}"
-            , exc_info=True)
-            # Continue with the workflow even if export fails
-        except SessionManagerError as e:
-            logger.error(
-                f"Session manager error updating session info: {e}", exc_info=True
+        except OSError:
+            logger.exception(
+                "File system error exporting analysis data (disk full or invalid path?)"
             )
             # Continue with the workflow even if export fails
-        except Exception as e:
-            logger.error(
-                f"Unexpected error exporting analysis data: {e}", exc_info=True
+        except SessionManagerError:
+            logger.exception(
+                "Session manager error updating session info"
+            )
+            # Continue with the workflow even if export fails
+        except Exception:
+            logger.exception(
+                "Unexpected error exporting analysis data"
             )
             # Continue with the workflow even if export fails
 
@@ -1058,7 +1043,7 @@ def _save_results_and_reports(
     ].drop_duplicates()
 
     if not newly_fulfilled.empty:
-        newly_fulfilled["Execution_Date"] = datetime.now().strftime("%Y-%m-%d")
+        newly_fulfilled["Execution_Date"] = datetime.now().astimezone().strftime("%Y-%m-%d")
         updated_history = pd.concat([history_df, newly_fulfilled]).drop_duplicates(
             subset=["Order_Number"], keep="last"
         )
@@ -1086,8 +1071,8 @@ def _save_results_and_reports(
             logger.info(
                 f"History updated and saved to: {history_path} ({len(newly_fulfilled)} new records)"
             )
-        except Exception as e:
-            logger.error(f"Failed to save history: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save history")
             # Don't fail the entire analysis if history save fails
 
     # Persist inventory memory if enabled (or unconditionally update the SKU snapshot)
@@ -1291,19 +1276,19 @@ def run_full_analysis(
 
     except FileNotFoundError as e:
         error_msg = f"File not found: {e!s}"
-        logger.error(error_msg, exc_info=True)
+        logger.exception(error_msg)
         return False, error_msg, None, None
     except ValueError as e:
         error_msg = f"Validation error: {e!s}"
-        logger.error(error_msg, exc_info=True)
+        logger.exception(error_msg)
         return False, error_msg, None, None
     except pd.errors.ParserError as e:
         error_msg = f"CSV parsing error: {e!s}"
-        logger.error(error_msg, exc_info=True)
+        logger.exception(error_msg)
         return False, error_msg, None, None
     except Exception as e:
         error_msg = f"Analysis failed: {e!s}"
-        logger.error(error_msg, exc_info=True)
+        logger.exception(error_msg)
         return False, error_msg, None, None
 
 
@@ -1386,8 +1371,8 @@ def create_packing_list_report(
         error_message = (
             f"Configuration error for report '{report_name}': Missing key {e}."
         )
-        logger.error(
-            f"Config error for packing list '{report_name}': {e}", exc_info=True
+        logger.exception(
+            f"Config error for packing list '{report_name}'"
         )
         return False, error_message
     except PermissionError:
@@ -1395,14 +1380,13 @@ def create_packing_list_report(
         error_message = (
             f"Permission denied. Could not write report to '{output_filename}'."
         )
-        logger.error(
+        logger.exception(
             f"Permission error creating packing list '{report_name}' at '{output_filename}'",
-            exc_info=True,
         )
         return False, error_message
-    except Exception as e:
+    except Exception:
         error_message = f"Failed to create report '{report_name}'. See logs/app_errors.log for details."
-        logger.error(f"Error creating packing list '{report_name}': {e}", exc_info=True)
+        logger.exception(f"Error creating packing list '{report_name}'")
         return False, error_message
 
 
@@ -1506,21 +1490,21 @@ def create_stock_export_report(
         error_message = (
             f"Configuration error for stock export '{report_name}': Missing key {e}."
         )
-        logger.error(
-            f"Config error for stock export '{report_name}': {e}", exc_info=True
+        logger.exception(
+            f"Config error for stock export '{report_name}'"
         )
         return False, error_message
     except PermissionError:
         error_message = "Permission denied. Could not write stock export."
-        logger.error(
-            f"Permission error creating stock export '{report_name}'", exc_info=True
+        logger.exception(
+            f"Permission error creating stock export '{report_name}'"
         )
         return False, error_message
-    except Exception as e:
+    except Exception:
         error_message = (
             f"Failed to create stock export '{report_name}'. See logs for details."
         )
-        logger.error(f"Error creating stock export '{report_name}': {e}", exc_info=True)
+        logger.exception(f"Error creating stock export '{report_name}'")
         return False, error_message
 
 
@@ -1595,21 +1579,21 @@ def create_writeoff_report(
         error_message = (
             f"Configuration error for writeoff report '{report_name}': Missing key {e}."
         )
-        logger.error(
-            f"Config error for writeoff report '{report_name}': {e}", exc_info=True
+        logger.exception(
+            f"Config error for writeoff report '{report_name}'"
         )
         return False, error_message
     except PermissionError:
         error_message = "Permission denied. Could not write writeoff report."
-        logger.error(
-            f"Permission error creating writeoff report '{report_name}'", exc_info=True
+        logger.exception(
+            f"Permission error creating writeoff report '{report_name}'"
         )
         return False, error_message
-    except Exception as e:
+    except Exception:
         error_message = (
             f"Failed to create writeoff report '{report_name}'. See logs for details."
         )
-        logger.error(
-            f"Error creating writeoff report '{report_name}': {e}", exc_info=True
+        logger.exception(
+            f"Error creating writeoff report '{report_name}'"
         )
         return False, error_message

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -378,7 +378,7 @@ def _validate_and_prepare_inputs(
     client_id: str | None,
     session_manager: Any | None,
     session_path: str | None,
-) -> tuple[bool, str | None, str, str | None]:
+) -> tuple[bool, str, str | None, str | None]:
     """Validates inputs and prepares session/working paths.
 
     Determines whether to use session-based or legacy workflow mode,
@@ -858,7 +858,7 @@ def _save_results_and_reports(
     session_manager: Any | None,
     client_id: str | None,
     profile_manager: Any | None,
-) -> tuple[str, str | None]:
+) -> tuple[str | None, str | None]:
     """Saves all analysis results, reports, and updates history.
 
     Saves Excel report with analysis results, creates analysis_data.json

--- a/shopify_tool/csv_utils.py
+++ b/shopify_tool/csv_utils.py
@@ -2,10 +2,11 @@
 CSV utility functions for delimiter detection and validation.
 """
 import csv
+import logging
 import os
 import re
-import logging
-from typing import Tuple, Any, List, Optional, Dict
+from typing import Any
+
 import pandas as pd
 
 logger = logging.getLogger(__name__)
@@ -22,7 +23,7 @@ def order_number_sort_key(s) -> int:
     return int(nums[-1]) if nums else 0
 
 
-def detect_csv_delimiter(file_path: str, encoding: str = 'utf-8-sig') -> Tuple[str, str]:
+def detect_csv_delimiter(file_path: str, encoding: str = 'utf-8-sig') -> tuple[str, str]:
     """
     Automatically detect CSV delimiter.
 
@@ -144,7 +145,7 @@ def validate_delimiter(file_path: str, delimiter: str, encoding: str = 'utf-8-si
 
 
 def suggest_delimiter_fix(file_path: str, failed_delimiter: str,
-                         encoding: str = 'utf-8-sig') -> Tuple[str, str]:
+                         encoding: str = 'utf-8-sig') -> tuple[str, str]:
     """
     Suggest alternative delimiter when current one fails.
 
@@ -290,13 +291,13 @@ def normalize_sku_for_matching(sku: Any) -> str:
 
 
 def merge_csv_files(
-    file_paths: List[str],
+    file_paths: list[str],
     delimiter: str,
     encoding: str = 'utf-8-sig',
-    dtype_dict: Optional[Dict] = None,
+    dtype_dict: dict | None = None,
     add_source_column: bool = True,
     remove_duplicates: bool = False,
-    duplicate_keys: Optional[List[str]] = None
+    duplicate_keys: list[str] | None = None
 ) -> pd.DataFrame:
     """
     Merge multiple CSV files into single DataFrame.
@@ -411,8 +412,8 @@ def merge_csv_files(
 def discover_additional_columns(
     orders_df: pd.DataFrame,
     column_mappings: dict,
-    current_additional_columns: List[dict]
-) -> List[dict]:
+    current_additional_columns: list[dict]
+) -> list[dict]:
     """
     Discover available additional columns from orders DataFrame.
 

--- a/shopify_tool/csv_utils.py
+++ b/shopify_tool/csv_utils.py
@@ -12,6 +12,10 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
+class CSVLoadError(Exception):
+    """Raised when a CSV file fails to load or merge."""
+
+
 def order_number_sort_key(s) -> int:
     """Return a numeric sort key for an order-number string.
 
@@ -81,8 +85,8 @@ def detect_csv_delimiter(file_path: str, encoding: str = 'utf-8-sig') -> tuple[s
 
             # Check consistency across multiple lines
             for line in lines[1:]:
-                for delim in delimiters:
-                    if line.count(delim) != delimiters[delim]:
+                for delim, count in delimiters.items():
+                    if line.count(delim) != count:
                         # Not consistent - reduce confidence
                         delimiters[delim] = 0
 
@@ -316,7 +320,7 @@ def merge_csv_files(
 
     Raises:
         ValueError: If file_paths is empty
-        Exception: If any file fails to load
+        CSVLoadError: If any file fails to load
 
     Example:
         >>> files = ["shop1.csv", "shop2.csv", "shop3.csv"]
@@ -353,8 +357,8 @@ def merge_csv_files(
             logger.info(f"✓ Loaded {len(df)} rows from {os.path.basename(filepath)}")
 
         except Exception as e:
-            logger.error(f"✗ Failed to load {os.path.basename(filepath)}: {e}", exc_info=True)
-            raise Exception(f"Failed to load {os.path.basename(filepath)}: {e}")
+            logger.exception(f"✗ Failed to load {os.path.basename(filepath)}")
+            raise CSVLoadError(f"Failed to load {os.path.basename(filepath)}: {e}") from e
 
     # Concatenate all DataFrames
     merged_df = pd.concat(dataframes, ignore_index=True)
@@ -387,8 +391,8 @@ def merge_csv_files(
                         subset=duplicate_keys,
                         keep='first'
                     )
-                except Exception as e:
-                    logger.error(f"Error removing duplicates with keys {duplicate_keys}: {e}", exc_info=True)
+                except Exception:
+                    logger.exception(f"Error removing duplicates with keys {duplicate_keys}")
                     raise
             else:
                 logger.warning("No valid duplicate keys found, skipping duplicate removal")

--- a/shopify_tool/groups_manager.py
+++ b/shopify_tool/groups_manager.py
@@ -20,7 +20,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger("ShopifyToolLogger")
 
@@ -28,7 +28,6 @@ logger = logging.getLogger("ShopifyToolLogger")
 # Custom Exception
 class GroupsManagerError(Exception):
     """Base exception for GroupsManager errors."""
-    pass
 
 
 class GroupsManager:
@@ -67,7 +66,7 @@ class GroupsManager:
         if not self.groups_path.exists():
             self.save_groups(groups_data)
 
-    def _create_default_groups(self) -> Dict[str, Any]:
+    def _create_default_groups(self) -> dict[str, Any]:
         """Create default groups configuration with special groups.
 
         Returns:
@@ -92,7 +91,7 @@ class GroupsManager:
             }
         }
 
-    def load_groups(self) -> Dict[str, Any]:
+    def load_groups(self) -> dict[str, Any]:
         """Load groups configuration with corruption recovery.
 
         Returns:
@@ -134,7 +133,7 @@ class GroupsManager:
             logger.error(f"Unexpected error loading groups: {e}", exc_info=True)
             return self._create_default_groups()
 
-    def save_groups(self, groups_data: Dict[str, Any]) -> bool:
+    def save_groups(self, groups_data: dict[str, Any]) -> bool:
         """Save groups configuration with file locking and backup.
 
         Args:
@@ -176,7 +175,7 @@ class GroupsManager:
                         )
                         time.sleep(retry_delay)
 
-            except (IOError, OSError) as e:
+            except OSError as e:
                 if attempt < max_retries - 1:
                     logger.warning(
                         f"Save failed (attempt {attempt + 1}/{max_retries}), "
@@ -193,7 +192,7 @@ class GroupsManager:
         logger.error(error_msg)
         raise GroupsManagerError(error_msg)
 
-    def _save_with_windows_lock(self, file_path: Path, data: Dict) -> bool:
+    def _save_with_windows_lock(self, file_path: Path, data: dict) -> bool:
         """Save file with Windows file locking (locks entire file).
 
         Args:
@@ -218,7 +217,7 @@ class GroupsManager:
                 try:
                     f.seek(0)
                     msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, file_size)
-                except IOError:
+                except OSError:
                     return False
 
                 try:
@@ -241,7 +240,7 @@ class GroupsManager:
                 temp_path.unlink()
             return False
 
-    def _save_with_unix_lock(self, file_path: Path, data: Dict) -> bool:
+    def _save_with_unix_lock(self, file_path: Path, data: dict) -> bool:
         """Save file with Unix file locking.
 
         Args:
@@ -261,7 +260,7 @@ class GroupsManager:
                 # Try to acquire exclusive lock
                 try:
                     fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                except IOError:
+                except OSError:
                     return False
 
                 try:
@@ -337,7 +336,7 @@ class GroupsManager:
                 lock_file.close()
 
     @staticmethod
-    def _name_collides_with_special_group(groups_data: Dict[str, Any], name: str) -> bool:
+    def _name_collides_with_special_group(groups_data: dict[str, Any], name: str) -> bool:
         special_groups = groups_data.get("special_groups", {})
         return any(
             special.get("name", "").lower() == name.lower()
@@ -380,8 +379,7 @@ class GroupsManager:
             max_order = -1
             for group in groups_data.get("groups", []):
                 order = group.get("display_order", 0)
-                if order > max_order:
-                    max_order = order
+                max_order = max(max_order, order)
             display_order = max_order + 1
 
             # Create new group
@@ -505,7 +503,7 @@ class GroupsManager:
 
             return True
 
-    def get_group(self, group_id: str) -> Optional[Dict[str, Any]]:
+    def get_group(self, group_id: str) -> dict[str, Any] | None:
         """Get group by ID.
 
         Args:
@@ -522,7 +520,7 @@ class GroupsManager:
 
         return None
 
-    def list_groups(self) -> List[Dict[str, Any]]:
+    def list_groups(self) -> list[dict[str, Any]]:
         """List all groups sorted by display_order.
 
         Returns:
@@ -536,7 +534,7 @@ class GroupsManager:
 
         return sorted_groups
 
-    def get_clients_in_group(self, group_id: str, profile_manager) -> List[str]:
+    def get_clients_in_group(self, group_id: str, profile_manager) -> list[str]:
         """Get list of client IDs assigned to a group.
 
         Args:

--- a/shopify_tool/groups_manager.py
+++ b/shopify_tool/groups_manager.py
@@ -123,14 +123,14 @@ class GroupsManager:
 
             return groups_data
 
-        except json.JSONDecodeError as e:
-            logger.error(f"Corrupted JSON in groups.json: {e}", exc_info=True)
+        except json.JSONDecodeError:
+            logger.exception("Corrupted JSON in groups.json")
             backup_path = self.groups_path.with_suffix('.corrupted.bak')
             shutil.copy2(self.groups_path, backup_path)
             logger.info(f"Corrupted file backed up to {backup_path}")
             return self._create_default_groups()
-        except Exception as e:
-            logger.error(f"Unexpected error loading groups: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Unexpected error loading groups")
             return self._create_default_groups()
 
     def save_groups(self, groups_data: dict[str, Any]) -> bool:
@@ -150,7 +150,7 @@ class GroupsManager:
             self._create_backup()
 
         # Update timestamp
-        groups_data["last_updated"] = datetime.now().isoformat()
+        groups_data["last_updated"] = datetime.now().astimezone().isoformat()
 
         max_retries = 10
         retry_delay = 1.0
@@ -184,7 +184,7 @@ class GroupsManager:
                     time.sleep(retry_delay)
                 else:
                     error_msg = f"Failed to save groups configuration after {max_retries} attempts: {e}"
-                    logger.error(error_msg, exc_info=True)
+                    logger.exception(error_msg)
                     raise GroupsManagerError(error_msg)
 
         # If we get here, all retries failed
@@ -234,8 +234,8 @@ class GroupsManager:
             shutil.move(str(temp_path), str(file_path))
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to save with Windows lock: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save with Windows lock")
             if temp_path.exists():
                 temp_path.unlink()
             return False
@@ -272,8 +272,8 @@ class GroupsManager:
             shutil.move(str(temp_path), str(file_path))
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to save with Unix lock: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save with Unix lock")
             if temp_path.exists():
                 temp_path.unlink()
             return False
@@ -289,7 +289,7 @@ class GroupsManager:
         backups_dir = self.clients_dir / "backups"
         backups_dir.mkdir(exist_ok=True)
 
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp = datetime.now().astimezone().strftime("%Y%m%d_%H%M%S")
         backup_path = backups_dir / f"groups_{timestamp}.json"
 
         try:
@@ -314,17 +314,16 @@ class GroupsManager:
         stale snapshot and the second save silently clobbers the first.
         """
         lock_path = self.groups_path.with_suffix(".lock")
-        lock_file = open(lock_path, "a+")
-        try:
-            if os.name == "nt":
-                import msvcrt
-                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
-            else:
-                import fcntl
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-            yield
-        finally:
+        with open(lock_path, "a+") as lock_file:
             try:
+                if os.name == "nt":
+                    import msvcrt
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                yield
+            finally:
                 if os.name == "nt":
                     import msvcrt
                     lock_file.seek(0)
@@ -332,8 +331,6 @@ class GroupsManager:
                 else:
                     import fcntl
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-            finally:
-                lock_file.close()
 
     @staticmethod
     def _name_collides_with_special_group(groups_data: dict[str, Any], name: str) -> bool:
@@ -388,7 +385,7 @@ class GroupsManager:
                 "name": name,
                 "color": color,
                 "display_order": display_order,
-                "created_at": datetime.now().isoformat()
+                "created_at": datetime.now().astimezone().isoformat()
             }
 
             groups_data["groups"].append(new_group)
@@ -399,7 +396,7 @@ class GroupsManager:
 
             return group_id
 
-    def update_group(self, group_id: str, name: str = None, color: str = None) -> bool:
+    def update_group(self, group_id: str, name: str | None = None, color: str | None = None) -> bool:
         """Update existing group.
 
         Args:
@@ -485,13 +482,16 @@ class GroupsManager:
                 for client_id in clients_in_group:
                     try:
                         config = profile_manager.load_client_config(client_id)
-                        if config and "ui_settings" in config:
-                            if config["ui_settings"].get("group_id") == group_id:
-                                config["ui_settings"]["group_id"] = None
-                                profile_manager.save_client_config(client_id, config)
-                                logger.info(f"Unassigned CLIENT_{client_id} from group {group_id}")
-                    except Exception as e:
-                        logger.error(f"Failed to unassign CLIENT_{client_id}: {e}", exc_info=True)
+                        if (
+                            config
+                            and "ui_settings" in config
+                            and config["ui_settings"].get("group_id") == group_id
+                        ):
+                            config["ui_settings"]["group_id"] = None
+                            profile_manager.save_client_config(client_id, config)
+                            logger.info(f"Unassigned CLIENT_{client_id} from group {group_id}")
+                    except Exception:
+                        logger.exception(f"Failed to unassign CLIENT_{client_id}")
                         # Continue with other clients
 
             # Remove group from groups.json
@@ -550,9 +550,12 @@ class GroupsManager:
         for client_id in all_clients:
             try:
                 config = profile_manager.load_client_config(client_id)
-                if config and "ui_settings" in config:
-                    if config["ui_settings"].get("group_id") == group_id:
-                        clients_in_group.append(client_id)
+                if (
+                    config
+                    and "ui_settings" in config
+                    and config["ui_settings"].get("group_id") == group_id
+                ):
+                    clients_in_group.append(client_id)
             except Exception as e:
                 logger.warning(f"Failed to check group for CLIENT_{client_id}: {e}")
                 continue

--- a/shopify_tool/packing_lists.py
+++ b/shopify_tool/packing_lists.py
@@ -308,3 +308,4 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
 
     except Exception:
         logger.exception("ERROR while creating packing list")
+        raise

--- a/shopify_tool/packing_lists.py
+++ b/shopify_tool/packing_lists.py
@@ -1,7 +1,9 @@
-import pandas as pd
-import os
 import logging
+import os
 from datetime import datetime
+
+import pandas as pd
+
 from .csv_utils import normalize_sku_for_matching, order_number_sort_key
 
 logger = logging.getLogger("ShopifyToolLogger")

--- a/shopify_tool/packing_lists.py
+++ b/shopify_tool/packing_lists.py
@@ -219,7 +219,7 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
 
         print_list = sorted_list[columns_for_print]
 
-        generation_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        generation_timestamp = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S")
         output_filename = os.path.basename(output_file)
 
         # Rename columns to embed metadata into the header
@@ -306,5 +306,5 @@ def create_packing_list(analysis_df, output_file, report_name="Packing List", fi
 
         logger.info(f"Report '{report_name}' created successfully.")
 
-    except Exception as e:
-        logger.error(f"ERROR while creating packing list: {e}", exc_info=True)
+    except Exception:
+        logger.exception("ERROR while creating packing list")

--- a/shopify_tool/pdf_processor.py
+++ b/shopify_tool/pdf_processor.py
@@ -9,18 +9,17 @@ Processes courier label PDFs by:
 5. Saving processed PDF
 """
 
-import re
-import logging
-import time
-from pathlib import Path
-from datetime import datetime
-from typing import Dict, Optional, Callable
 import csv
+import logging
+import re
+import time
+from collections.abc import Callable
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
 
 from pypdf import PdfReader, PdfWriter
 from reportlab.pdfgen import canvas
-from io import BytesIO
-
 
 logger = logging.getLogger(__name__)
 
@@ -28,30 +27,26 @@ logger = logging.getLogger(__name__)
 # Custom Exceptions
 class PDFProcessorError(Exception):
     """Base exception for PDF processor."""
-    pass
 
 
 class InvalidPDFError(PDFProcessorError):
     """Invalid or corrupted PDF file."""
-    pass
 
 
 class InvalidCSVError(PDFProcessorError):
     """Invalid CSV mapping file."""
-    pass
 
 
 class MappingError(PDFProcessorError):
     """Error matching pages to references."""
-    pass
 
 
 def process_reference_labels(
     pdf_path: str,
     csv_path: str,
     output_dir: str,
-    progress_callback: Optional[Callable[[int, int, str], None]] = None
-) -> Dict:
+    progress_callback: Callable[[int, int, str], None] | None = None
+) -> dict:
     """
     Process PDF with reference labels.
 
@@ -229,7 +224,7 @@ def process_reference_labels(
         raise PDFProcessorError(f"Unexpected error: {e}")
 
 
-def load_csv_mapping(csv_path: str) -> Dict[str, Dict]:
+def load_csv_mapping(csv_path: str) -> dict[str, dict]:
     """
     Load CSV mapping file.
 
@@ -328,7 +323,7 @@ def normalize_text(text: str) -> str:
     return re.sub(r'\s+', ' ', str(text)).strip().lower()
 
 
-def match_reference(page_text: str, mapping: Dict) -> Optional[Dict]:
+def match_reference(page_text: str, mapping: dict) -> dict | None:
     """
     Match page text to reference using 3-step verification:
     1. PostOne ID (R/P + 10 digits)
@@ -398,7 +393,7 @@ def match_reference(page_text: str, mapping: Dict) -> Optional[Dict]:
     return None
 
 
-def extract_postone_number(text: str) -> Optional[str]:
+def extract_postone_number(text: str) -> str | None:
     """
     Extract PostOne number (R or P + 10 digits) from text.
 
@@ -501,7 +496,7 @@ def sort_pages_by_reference(page_data_list: list) -> list:
     return matched_pages + unmatched_pages
 
 
-def create_reference_order_map(sorted_pages: list) -> Dict[str, int]:
+def create_reference_order_map(sorted_pages: list) -> dict[str, int]:
     """
     Create mapping of reference number to order position.
 

--- a/shopify_tool/pdf_processor.py
+++ b/shopify_tool/pdf_processor.py
@@ -183,8 +183,8 @@ def process_reference_labels(
                     )
                     page.merge_page(PdfReader(overlay).pages[0])
 
-                except Exception as e:
-                    logger.error(f"Failed to add overlay for ref {ref}: {e}", exc_info=True)
+                except Exception:
+                    logger.exception(f"Failed to add overlay for ref {ref}")
 
             writer.add_page(page)
 
@@ -220,7 +220,7 @@ def process_reference_labels(
         raise
     except Exception as e:
         # Catch all other errors
-        logger.error(f"Unexpected error during PDF processing: {e}", exc_info=True)
+        logger.exception("Unexpected error during PDF processing")
         raise PDFProcessorError(f"Unexpected error: {e}")
 
 
@@ -576,5 +576,5 @@ def generate_output_filename() -> str:
     Returns:
         str: Filename like "labels_20250115_143022_processed.pdf"
     """
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now().astimezone().strftime("%Y%m%d_%H%M%S")
     return f"labels_{timestamp}_processed.pdf"

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -20,7 +20,7 @@ import shutil
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from shared.logger import setup_logging
 from shared.server_connection import resolve_server_path, test_path_reachable
@@ -70,12 +70,12 @@ class ProfileManager:
     # Class-level cache: key → (data, mtime_float). mtime-based invalidation is more
     # correct than TTL — no stale reads after a write, no unnecessary re-reads within a window.
     # Key includes base_path so multiple instances with different roots don't collide.
-    _config_cache: dict[str, tuple[dict, float]] = {}
+    _config_cache: ClassVar[dict[str, tuple[dict, float]]] = {}
 
     # Class-level constants for metadata cache
     METADATA_CACHE_TIMEOUT_SECONDS = 300  # 5 minutes
 
-    def __init__(self, base_path: str = None):
+    def __init__(self, base_path: str | None = None):
         """Initialize ProfileManager with automatic environment detection.
 
         Args:
@@ -170,15 +170,15 @@ class ProfileManager:
             self.sessions_dir.mkdir(parents=True, exist_ok=True)
             self.stats_dir.mkdir(parents=True, exist_ok=True)
             self.logs_dir.mkdir(parents=True, exist_ok=True)
-        except PermissionError as e:
-            logger.error(f"Network connection FAILED - Permission denied: {e}", exc_info=True)
+        except PermissionError:
+            logger.exception("Network connection FAILED - Permission denied")
             return False
-        except OSError as e:
-            logger.error(f"Network connection FAILED - OS error (network issue?): {e}", exc_info=True)
+        except OSError:
+            logger.exception("Network connection FAILED - OS error (network issue?)")
             return False
-        except Exception as e:
-            logger.error(
-                f"Network connection FAILED - Unexpected error: {e}", exc_info=True
+        except Exception:
+            logger.exception(
+                "Network connection FAILED - Unexpected error"
             )
             return False
 
@@ -262,14 +262,14 @@ class ProfileManager:
 
             return sorted(clients)
 
-        except PermissionError as e:
-            logger.error(f"Permission denied accessing clients directory: {e}", exc_info=True)
+        except PermissionError:
+            logger.exception("Permission denied accessing clients directory")
             return []
-        except OSError as e:
-            logger.error(f"File system error listing clients: {e}", exc_info=True)
+        except OSError:
+            logger.exception("File system error listing clients")
             return []
-        except Exception as e:
-            logger.error(f"Unexpected error listing clients: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Unexpected error listing clients")
             return []
 
     def create_client_profile(self, client_id: str, client_name: str) -> bool:
@@ -314,7 +314,7 @@ class ProfileManager:
             client_config = {
                 "client_id": client_id,
                 "client_name": client_name,
-                "created_at": datetime.now().isoformat(),
+                "created_at": datetime.now().astimezone().isoformat(),
                 "created_by": os.environ.get("COMPUTERNAME", "Unknown"),
             }
 
@@ -337,7 +337,7 @@ class ProfileManager:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to create client profile: {e}", exc_info=True)
+            logger.exception("Failed to create client profile")
             # Cleanup on failure
             if client_dir.exists():
                 shutil.rmtree(client_dir, ignore_errors=True)
@@ -433,7 +433,7 @@ class ProfileManager:
 
         # Add migration metadata
         config["_migration_info"] = {
-            "migrated_at": datetime.now().isoformat(),
+            "migrated_at": datetime.now().astimezone().isoformat(),
             "from_version": 1,
             "to_version": 2,
             "migrated_by": os.environ.get("COMPUTERNAME", "Unknown"),
@@ -691,7 +691,7 @@ class ProfileManager:
         # Update config version if migration occurred
         if migrated:
             config["config_version"] = "2.1"
-            config["migrated_at"] = datetime.now().isoformat()
+            config["migrated_at"] = datetime.now().astimezone().isoformat()
             logger.info(
                 f"Delimiter migration successful for CLIENT_{client_id}, version: 2.1"
             )
@@ -769,7 +769,7 @@ class ProfileManager:
         return {
             "client_id": client_id,
             "client_name": client_name,
-            "created_at": datetime.now().isoformat(),
+            "created_at": datetime.now().astimezone().isoformat(),
             "column_mappings": {
                 "version": 2,
                 "orders": {
@@ -910,18 +910,17 @@ class ProfileManager:
 
             return config
 
-        except PermissionError as e:
-            logger.error(
-                f"Permission denied reading client config for CLIENT_{client_id}: {e}"
-            , exc_info=True)
+        except PermissionError:
+            logger.exception(
+                f"Permission denied reading client config for CLIENT_{client_id}"
+            )
             return None
-        except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON in client config for CLIENT_{client_id}: {e}", exc_info=True)
+        except json.JSONDecodeError:
+            logger.exception(f"Invalid JSON in client config for CLIENT_{client_id}")
             return None
-        except Exception as e:
-            logger.error(
-                f"Unexpected error loading client config for CLIENT_{client_id}: {e}",
-                exc_info=True,
+        except Exception:
+            logger.exception(
+                f"Unexpected error loading client config for CLIENT_{client_id}",
             )
             return None
 
@@ -998,8 +997,8 @@ class ProfileManager:
 
             return config
 
-        except Exception as e:
-            logger.error(f"Failed to load shopify config: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to load shopify config")
             return None
 
     def save_shopify_config(self, client_id: str, config: dict) -> bool:
@@ -1032,7 +1031,7 @@ class ProfileManager:
             self._create_backup(client_id, config_path, "shopify_config")
 
         # Update timestamp
-        config["last_updated"] = datetime.now().isoformat()
+        config["last_updated"] = datetime.now().astimezone().isoformat()
         config["updated_by"] = os.environ.get("COMPUTERNAME", "Unknown")
 
         # Calculate config size and metrics for logging
@@ -1094,10 +1093,10 @@ class ProfileManager:
                     )
                     time.sleep(retry_delay)
                 else:
-                    logger.error(
+                    logger.exception(
                         f"Save failed after {max_retries} attempts, "
                         f"config size: {config_size:,} bytes, {num_sets} sets"
-                    , exc_info=True)
+                    )
                     raise ProfileManagerError(
                         "Configuration is locked by another user. Please try again."
                     )
@@ -1111,7 +1110,7 @@ class ProfileManager:
     # --- Set/Bundle Management Methods ---
 
     def save_inventory_memory(
-        self, client_id: str, stock_dict: dict, config: dict = None, names_dict: dict = None
+        self, client_id: str, stock_dict: dict, config: dict | None = None, names_dict: dict | None = None
     ) -> bool:
         """Persist final stock snapshot to shopify_config inventory_memory section.
 
@@ -1141,7 +1140,7 @@ class ProfileManager:
             # Keep zero-qty SKUs: dropping them shrinks old_skus overlap ratio and can
             # trigger a false 'Wrong client file?' anomaly on the next stock load.
             "skus": {normalize_sku(k): float(v) for k, v in stock_dict.items()},
-            "last_updated": datetime.now().isoformat(timespec="seconds"),
+            "last_updated": datetime.now().astimezone().isoformat(timespec="seconds"),
             "total_units": int(sum(v for v in stock_dict.values() if v > 0)),
         }
         if names_dict is not None:
@@ -1340,8 +1339,8 @@ class ProfileManager:
             logger.debug(f"Config saved successfully: {file_path.name}")
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to save with Windows lock: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save with Windows lock")
             if temp_path.exists():
                 temp_path.unlink()
             return False
@@ -1378,8 +1377,8 @@ class ProfileManager:
             shutil.move(str(temp_path), str(file_path))
             return True
 
-        except Exception as e:
-            logger.error(f"Failed to save with Unix lock: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save with Unix lock")
             if temp_path.exists():
                 temp_path.unlink()
             return False
@@ -1398,7 +1397,7 @@ class ProfileManager:
             backup_dir = self.clients_dir / f"CLIENT_{client_id}" / "backups"
             backup_dir.mkdir(exist_ok=True)
 
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now().astimezone().strftime("%Y%m%d_%H%M%S")
             backup_path = backup_dir / f"{file_type}_{timestamp}.json"
 
             shutil.copy2(file_path, backup_path)
@@ -1506,7 +1505,7 @@ class ProfileManager:
             self._create_backup(client_id, config_path, "client_config")
 
         # Update timestamp
-        config["last_updated"] = datetime.now().isoformat()
+        config["last_updated"] = datetime.now().astimezone().isoformat()
         config["updated_by"] = os.environ.get("COMPUTERNAME", "Unknown")
 
         max_retries = 5  # Reduced from 10 to minimize UI blocking
@@ -1554,7 +1553,7 @@ class ProfileManager:
                     time.sleep(retry_delay)
                 else:
                     error_msg = f"Failed to save client config after {max_retries} attempts: {e}"
-                    logger.error(error_msg, exc_info=True)
+                    logger.exception(error_msg)
                     raise ProfileManagerError(error_msg)
 
         # If we get here, all retries failed
@@ -1668,7 +1667,7 @@ class ProfileManager:
         # Check cache (unless force refresh)
         if not force_refresh and cache_key in self._metadata_cache:
             cached_data, cached_time = self._metadata_cache[cache_key]
-            age_seconds = (datetime.now() - cached_time).total_seconds()
+            age_seconds = (datetime.now().astimezone() - cached_time).total_seconds()
 
             if age_seconds < self.METADATA_CACHE_TIMEOUT_SECONDS:
                 logger.debug(
@@ -1685,9 +1684,9 @@ class ProfileManager:
             metadata = {
                 "total_sessions": 0,
                 "last_session_date": None,
-                "last_accessed": datetime.now().isoformat(),
+                "last_accessed": datetime.now().astimezone().isoformat(),
             }
-            self._metadata_cache[cache_key] = (metadata, datetime.now())
+            self._metadata_cache[cache_key] = (metadata, datetime.now().astimezone())
             return metadata
 
         try:
@@ -1701,17 +1700,17 @@ class ProfileManager:
 
             last_session_date = None
             if session_folders:
-                latest = sorted(session_folders, key=lambda d: d.name)[-1]
+                latest = max(session_folders, key=lambda d: d.name)
                 date_part = latest.name.split("_")[0]
                 last_session_date = date_part
 
             metadata = {
                 "total_sessions": total_sessions,
                 "last_session_date": last_session_date,
-                "last_accessed": datetime.now().isoformat(),
+                "last_accessed": datetime.now().astimezone().isoformat(),
             }
 
-            self._metadata_cache[cache_key] = (metadata, datetime.now())
+            self._metadata_cache[cache_key] = (metadata, datetime.now().astimezone())
 
             elapsed_ms = (time.time() - start_time) * 1000
             logger.debug(f"Metadata calculated for {cache_key} in {elapsed_ms:.1f}ms")
@@ -1723,9 +1722,9 @@ class ProfileManager:
             metadata = {
                 "total_sessions": 0,
                 "last_session_date": None,
-                "last_accessed": datetime.now().isoformat(),
+                "last_accessed": datetime.now().astimezone().isoformat(),
             }
-            self._metadata_cache[cache_key] = (metadata, datetime.now())
+            self._metadata_cache[cache_key] = (metadata, datetime.now().astimezone())
             return metadata
 
     def invalidate_metadata_cache(self, client_id: str | None = None):
@@ -1762,7 +1761,7 @@ class ProfileManager:
             config["metadata"] = {}
 
         # Update timestamp
-        config["metadata"]["last_accessed"] = datetime.now().isoformat()
+        config["metadata"]["last_accessed"] = datetime.now().astimezone().isoformat()
 
         # Save
         return self.save_client_config(client_id, config)

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -1198,7 +1198,7 @@ class ProfileManager:
         return success
 
     def add_set(
-        self, client_id: str, set_sku: str, components: list[dict[str, any]]
+        self, client_id: str, set_sku: str, components: list[dict[str, Any]]
     ) -> bool:
         """Add or update a set/bundle definition.
 

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -20,7 +20,7 @@ import shutil
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from shared.logger import setup_logging
 from shared.server_connection import resolve_server_path, test_path_reachable
@@ -32,19 +32,16 @@ logger = logging.getLogger("ShopifyToolLogger")
 class ProfileManagerError(Exception):
     """Base exception for ProfileManager errors."""
 
-    pass
 
 
 class NetworkError(ProfileManagerError):
     """Raised when file server is not accessible."""
 
-    pass
 
 
 class ValidationError(ProfileManagerError):
     """Raised when validation fails."""
 
-    pass
 
 
 PROD_SERVER_PATH = r"\\192.168.88.101\_Fulfilment_\0UFulfilment"
@@ -73,7 +70,7 @@ class ProfileManager:
     # Class-level cache: key → (data, mtime_float). mtime-based invalidation is more
     # correct than TTL — no stale reads after a write, no unnecessary re-reads within a window.
     # Key includes base_path so multiple instances with different roots don't collide.
-    _config_cache: Dict[str, Tuple[Dict, float]] = {}
+    _config_cache: dict[str, tuple[dict, float]] = {}
 
     # Class-level constants for metadata cache
     METADATA_CACHE_TIMEOUT_SECONDS = 300  # 5 minutes
@@ -118,7 +115,7 @@ class ProfileManager:
         self.logs_dir = self.base_path / "Logs" / "shopify_tool"
 
         # Instance-level metadata cache
-        self._metadata_cache: Dict[str, Tuple[Dict, datetime]] = {}
+        self._metadata_cache: dict[str, tuple[dict, datetime]] = {}
 
         self.connection_timeout = 5
         self.is_network_available = self._test_connection()
@@ -192,7 +189,7 @@ class ProfileManager:
         return False
 
     @staticmethod
-    def validate_client_id(client_id: str) -> Tuple[bool, str]:
+    def validate_client_id(client_id: str) -> tuple[bool, str]:
         """Validate client ID format.
 
         Rules:
@@ -245,7 +242,7 @@ class ProfileManager:
 
         return True, ""
 
-    def list_clients(self) -> List[str]:
+    def list_clients(self) -> list[str]:
         """Get list of available client IDs.
 
         Returns:
@@ -346,7 +343,7 @@ class ProfileManager:
                 shutil.rmtree(client_dir, ignore_errors=True)
             raise ProfileManagerError(f"Failed to create client profile: {e}")
 
-    def _migrate_column_mappings_v1_to_v2(self, client_id: str, config: Dict) -> bool:
+    def _migrate_column_mappings_v1_to_v2(self, client_id: str, config: dict) -> bool:
         """Migrate column mappings from v1 to v2 format.
 
         V1 format (old):
@@ -445,7 +442,7 @@ class ProfileManager:
         logger.info(f"Migration successful for CLIENT_{client_id}")
         return True
 
-    def _migrate_add_tag_categories(self, client_id: str, config: Dict) -> bool:
+    def _migrate_add_tag_categories(self, client_id: str, config: dict) -> bool:
         """Add tag_categories to config if missing (creates v2 format).
 
         Args:
@@ -522,7 +519,7 @@ class ProfileManager:
         logger.info(f"Tag categories (v2) added for CLIENT_{client_id}")
         return True
 
-    def _migrate_tag_categories_v1_to_v2(self, client_id: str, config: Dict) -> bool:
+    def _migrate_tag_categories_v1_to_v2(self, client_id: str, config: dict) -> bool:
         """Migrate tag_categories from v1 to v2 format.
 
         V1 format (old):
@@ -645,7 +642,7 @@ class ProfileManager:
         )
         return True
 
-    def _migrate_delimiter_config_v1_to_v2(self, client_id: str, config: Dict) -> bool:
+    def _migrate_delimiter_config_v1_to_v2(self, client_id: str, config: dict) -> bool:
         """Migrate delimiter configuration from v1 to v2 format.
 
         V1 format (old):
@@ -701,7 +698,7 @@ class ProfileManager:
 
         return migrated
 
-    def _migrate_add_weight_config(self, client_id: str, config: Dict) -> bool:
+    def _migrate_add_weight_config(self, client_id: str, config: dict) -> bool:
         """Add weight_config section if missing (new feature migration).
 
         Returns:
@@ -718,7 +715,7 @@ class ProfileManager:
         logger.info(f"Added default 'weight_config' for CLIENT_{client_id}")
         return True
 
-    def _migrate_add_sku_label_config(self, client_id: str, config: Dict) -> bool:
+    def _migrate_add_sku_label_config(self, client_id: str, config: dict) -> bool:
         """Add sku_label_config section if missing (new feature migration).
 
         Returns:
@@ -731,7 +728,7 @@ class ProfileManager:
         logger.info(f"Added default 'sku_label_config' for CLIENT_{client_id}")
         return True
 
-    def _migrate_add_inventory_memory(self, client_id: str, config: Dict) -> bool:
+    def _migrate_add_inventory_memory(self, client_id: str, config: dict) -> bool:
         """Add inventory_memory section if missing (new feature migration).
 
         Returns:
@@ -757,7 +754,7 @@ class ProfileManager:
         return False
 
     @staticmethod
-    def _create_default_shopify_config(client_id: str, client_name: str) -> Dict:
+    def _create_default_shopify_config(client_id: str, client_name: str) -> dict:
         """Create default Shopify configuration.
 
         Can be called without an instance for dev/test setup scripts.
@@ -881,7 +878,7 @@ class ProfileManager:
             },
         }
 
-    def load_client_config(self, client_id: str) -> Optional[Dict]:
+    def load_client_config(self, client_id: str) -> dict | None:
         """Load general configuration for a client.
 
         Automatically migrates old configs to add ui_settings if missing.
@@ -928,7 +925,7 @@ class ProfileManager:
             )
             return None
 
-    def load_shopify_config(self, client_id: str) -> Optional[Dict]:
+    def load_shopify_config(self, client_id: str) -> dict | None:
         """Load Shopify configuration for a client with mtime-based caching.
 
         Cache is invalidated by file mtime rather than TTL: no stale reads after
@@ -1005,7 +1002,7 @@ class ProfileManager:
             logger.error(f"Failed to load shopify config: {e}", exc_info=True)
             return None
 
-    def save_shopify_config(self, client_id: str, config: Dict) -> bool:
+    def save_shopify_config(self, client_id: str, config: dict) -> bool:
         """Save Shopify configuration with file locking and backup.
 
         Uses file locking to prevent concurrent write conflicts.
@@ -1089,7 +1086,7 @@ class ProfileManager:
                         )
                         time.sleep(retry_delay)
 
-            except (IOError, OSError) as e:
+            except OSError as e:
                 if attempt < max_retries - 1:
                     logger.warning(
                         f"Save failed (attempt {attempt + 1}/{max_retries}), "
@@ -1102,7 +1099,7 @@ class ProfileManager:
                         f"config size: {config_size:,} bytes, {num_sets} sets"
                     , exc_info=True)
                     raise ProfileManagerError(
-                        f"Configuration is locked by another user. Please try again."
+                        "Configuration is locked by another user. Please try again."
                     )
 
         logger.error(
@@ -1157,7 +1154,7 @@ class ProfileManager:
         config = self.load_shopify_config(client_id) or {}
         return config.get("inventory_memory", {})
 
-    def get_set_decoders(self, client_id: str) -> Dict:
+    def get_set_decoders(self, client_id: str) -> dict:
         """Get set/bundle decoder definitions for a client.
 
         Args:
@@ -1174,7 +1171,7 @@ class ProfileManager:
 
         return config.get("set_decoders", {})
 
-    def save_set_decoders(self, client_id: str, set_decoders: Dict) -> bool:
+    def save_set_decoders(self, client_id: str, set_decoders: dict) -> bool:
         """Save set/bundle decoder definitions for a client.
 
         Args:
@@ -1202,7 +1199,7 @@ class ProfileManager:
         return success
 
     def add_set(
-        self, client_id: str, set_sku: str, components: List[Dict[str, any]]
+        self, client_id: str, set_sku: str, components: list[dict[str, any]]
     ) -> bool:
         """Add or update a set/bundle definition.
 
@@ -1292,7 +1289,7 @@ class ProfileManager:
 
         return success
 
-    def _save_with_windows_lock(self, file_path: Path, data: Dict) -> bool:
+    def _save_with_windows_lock(self, file_path: Path, data: dict) -> bool:
         """Save file with Windows file locking (locks entire file).
 
         Args:
@@ -1321,7 +1318,7 @@ class ProfileManager:
                     f.seek(0)
                     msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, file_size)
                     logger.debug(f"Lock acquired for {file_size:,} bytes")
-                except IOError as e:
+                except OSError as e:
                     logger.warning(f"Lock failed: {e}")
                     return False
 
@@ -1330,12 +1327,12 @@ class ProfileManager:
                     f.write(json_str)
                     f.flush()
                     os.fsync(f.fileno())  # Force write to disk
-                    logger.debug(f"File written and flushed successfully")
+                    logger.debug("File written and flushed successfully")
                 finally:
                     # Unlock with same size - must seek to start first
                     f.seek(0)
                     msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, file_size)
-                    logger.debug(f"Lock released")
+                    logger.debug("Lock released")
 
             # Atomic move
             logger.debug(f"Renaming {temp_path.name} → {file_path.name}")
@@ -1349,7 +1346,7 @@ class ProfileManager:
                 temp_path.unlink()
             return False
 
-    def _save_with_unix_lock(self, file_path: Path, data: Dict) -> bool:
+    def _save_with_unix_lock(self, file_path: Path, data: dict) -> bool:
         """Save file with Unix file locking.
 
         Args:
@@ -1369,7 +1366,7 @@ class ProfileManager:
                 # Try to acquire exclusive lock
                 try:
                     fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                except IOError:
+                except OSError:
                     return False
 
                 try:
@@ -1417,7 +1414,7 @@ class ProfileManager:
             logger.warning(f"Failed to create backup: {e}")
 
     @staticmethod
-    def _get_default_ui_settings() -> Dict:
+    def _get_default_ui_settings() -> dict:
         """Return default ui_settings including table_view for client_config.
 
         Can be called without an instance for dev/test setup scripts.
@@ -1447,7 +1444,7 @@ class ProfileManager:
             },
         }
 
-    def _migrate_add_ui_settings(self, client_id: str, config: Dict) -> bool:
+    def _migrate_add_ui_settings(self, client_id: str, config: dict) -> bool:
         """Add ui_settings section if missing, including table_view.
 
         Args:
@@ -1478,7 +1475,7 @@ class ProfileManager:
 
         return migrated
 
-    def save_client_config(self, client_id: str, config: Dict) -> bool:
+    def save_client_config(self, client_id: str, config: dict) -> bool:
         """Save client_config.json with file locking and backup.
 
         Similar to save_shopify_config but for client_config.json.
@@ -1548,7 +1545,7 @@ class ProfileManager:
                         )
                         time.sleep(retry_delay)
 
-            except (IOError, OSError) as e:
+            except OSError as e:
                 if attempt < max_retries - 1:
                     logger.warning(
                         f"Save failed (attempt {attempt + 1}/{max_retries}), "
@@ -1565,7 +1562,7 @@ class ProfileManager:
         logger.error(error_msg)
         raise ProfileManagerError(error_msg)
 
-    def update_ui_settings(self, client_id: str, ui_settings: Dict[str, Any]) -> bool:
+    def update_ui_settings(self, client_id: str, ui_settings: dict[str, Any]) -> bool:
         """Update client UI settings with partial updates support.
 
         Args:
@@ -1608,7 +1605,7 @@ class ProfileManager:
         # Save
         return self.save_client_config(client_id, config)
 
-    def get_ui_settings(self, client_id: str) -> Dict[str, Any]:
+    def get_ui_settings(self, client_id: str) -> dict[str, Any]:
         """Get client UI settings.
 
         Returns default values if not set:
@@ -1652,7 +1649,7 @@ class ProfileManager:
 
     def calculate_metadata(
         self, client_id: str, force_refresh: bool = False
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Calculate client metadata from filesystem with 5-minute caching.
 
         Args:
@@ -1731,7 +1728,7 @@ class ProfileManager:
             self._metadata_cache[cache_key] = (metadata, datetime.now())
             return metadata
 
-    def invalidate_metadata_cache(self, client_id: Optional[str] = None):
+    def invalidate_metadata_cache(self, client_id: str | None = None):
         """Invalidate metadata cache.
 
         Args:
@@ -1770,7 +1767,7 @@ class ProfileManager:
         # Save
         return self.save_client_config(client_id, config)
 
-    def get_client_config_extended(self, client_id: str) -> Dict[str, Any]:
+    def get_client_config_extended(self, client_id: str) -> dict[str, Any]:
         """Load client config with ui_settings and metadata merged.
 
         Automatically adds default ui_settings if missing.

--- a/shopify_tool/reference_labels_history.py
+++ b/shopify_tool/reference_labels_history.py
@@ -6,10 +6,8 @@ Manages processing history for reference labels in JSON format.
 
 import json
 import logging
-from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Optional
-
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +126,7 @@ class ReferenceLabelsHistory:
 
         logger.info(f"Added history entry: {input_pdf} → {output_pdf}")
 
-    def get_entries(self, limit: Optional[int] = None) -> List[Dict]:
+    def get_entries(self, limit: int | None = None) -> list[dict]:
         """
         Get processing history entries.
 
@@ -154,7 +152,7 @@ class ReferenceLabelsHistory:
         self._save_history()
         logger.info("History cleared")
 
-    def get_statistics(self) -> Dict:
+    def get_statistics(self) -> dict:
         """
         Get statistics from history.
 

--- a/shopify_tool/reference_labels_history.py
+++ b/shopify_tool/reference_labels_history.py
@@ -53,8 +53,8 @@ class ReferenceLabelsHistory:
                 f"History loaded: {len(self.data['processed_files'])} entries"
             )
 
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse history JSON: {e}", exc_info=True)
+        except json.JSONDecodeError:
+            logger.exception("Failed to parse history JSON")
             # Create backup of corrupt file
             backup_file = self.history_file.with_suffix('.json.backup')
             self.history_file.rename(backup_file)
@@ -63,8 +63,8 @@ class ReferenceLabelsHistory:
             # Start fresh
             self.data = {'processed_files': []}
 
-        except Exception as e:
-            logger.error(f"Failed to load history: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to load history")
             self.data = {'processed_files': []}
 
     def _save_history(self):
@@ -81,8 +81,8 @@ class ReferenceLabelsHistory:
 
             logger.debug(f"History saved: {len(self.data['processed_files'])} entries")
 
-        except Exception as e:
-            logger.error(f"Failed to save history: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to save history")
             raise
 
     def add_entry(
@@ -110,7 +110,7 @@ class ReferenceLabelsHistory:
             status: Processing status (success/failed)
         """
         entry = {
-            'processed_at': datetime.now().isoformat(),
+            'processed_at': datetime.now().astimezone().isoformat(),
             'input_pdf': input_pdf,
             'input_csv': input_csv,
             'output_pdf': output_pdf,

--- a/shopify_tool/rules.py
+++ b/shopify_tool/rules.py
@@ -1,9 +1,8 @@
 import copy
-import pandas as pd
 import re
 from functools import lru_cache
-from typing import Optional
 
+import pandas as pd
 
 """Implements a configurable rule engine to process and modify order data.
 
@@ -185,7 +184,7 @@ def _op_is_not_empty(series_val, rule_val):
 # --- Helper Functions for New Operators ---
 
 
-def _parse_date_safe(date_str: str) -> Optional[pd.Timestamp]:
+def _parse_date_safe(date_str: str) -> pd.Timestamp | None:
     """Safely parse date string with multiple format support.
 
     Tries 3 common date formats in sequence:
@@ -229,7 +228,7 @@ def _parse_date_safe(date_str: str) -> Optional[pd.Timestamp]:
 
 
 @lru_cache(maxsize=128)
-def _compile_regex_safe(pattern: str) -> Optional[re.Pattern]:
+def _compile_regex_safe(pattern: str) -> re.Pattern | None:
     """Safely compile regex pattern with caching.
 
     Uses LRU cache to avoid recompiling patterns on repeated calls.
@@ -258,7 +257,7 @@ def _compile_regex_safe(pattern: str) -> Optional[re.Pattern]:
         return None
 
 
-def _parse_range(range_str: str) -> Optional[tuple[float, float]]:
+def _parse_range(range_str: str) -> tuple[float, float] | None:
     """Parse range string in format 'start-end'.
 
     Args:
@@ -415,7 +414,7 @@ def _op_between(series_val, rule_val):
         return (series_numeric >= start) & (series_numeric <= end)
     else:
         # Fallback to string comparison
-        logger.info(f"[RULE ENGINE] Using string comparison for 'between' operator")
+        logger.info("[RULE ENGINE] Using string comparison for 'between' operator")
         series_str = series_val.astype(str)
         return (series_str >= str(start)) & (series_str <= str(end))
 
@@ -903,11 +902,7 @@ class RuleEngine:
                         needed_columns.add("Status_Note")
                     elif action_type == "ADD_INTERNAL_TAG":
                         needed_columns.add("Internal_Tags")
-                    elif action_type == "COPY_FIELD":
-                        target = action.get("target")
-                        if target:
-                            needed_columns.add(target)
-                    elif action_type == "CALCULATE":
+                    elif action_type == "COPY_FIELD" or action_type == "CALCULATE":
                         target = action.get("target")
                         if target:
                             needed_columns.add(target)
@@ -978,7 +973,7 @@ class RuleEngine:
 
             # Log data types and sample values
             logger.info(f"[RULE ENGINE] Field '{field}' dtype: {df[field].dtype}")
-            logger.info(f"[RULE ENGINE] Rule value type: {type(value).__name__}, value: {repr(value)}")
+            logger.info(f"[RULE ENGINE] Rule value type: {type(value).__name__}, value: {value!r}")
             unique_vals = df[field].dropna().unique()[:5]
             logger.info(f"[RULE ENGINE] Sample values in '{field}': {list(unique_vals)}")
 
@@ -1079,7 +1074,7 @@ class RuleEngine:
                 tags_value = action.get("tags") or action.get("value")
 
                 if not tags_value:
-                    logger.warning(f"[RULE ENGINE] SET_MULTI_TAGS missing tags/value")
+                    logger.warning("[RULE ENGINE] SET_MULTI_TAGS missing tags/value")
                     continue
 
                 # Parse: підтримка list або comma-separated string
@@ -1112,7 +1107,7 @@ class RuleEngine:
                 severity = action.get("severity", "info").lower()
 
                 if not message:
-                    logger.warning(f"[RULE ENGINE] ALERT_NOTIFICATION missing message")
+                    logger.warning("[RULE ENGINE] ALERT_NOTIFICATION missing message")
                     continue
 
                 # Валідація severity
@@ -1151,7 +1146,7 @@ class RuleEngine:
                     continue
 
                 if field1 not in df.columns or field2 not in df.columns:
-                    logger.warning(f"[RULE ENGINE] CALCULATE fields not found in DataFrame")
+                    logger.warning("[RULE ENGINE] CALCULATE fields not found in DataFrame")
                     continue
 
                 # Створити target column якщо не існує
@@ -1183,7 +1178,7 @@ class RuleEngine:
                 quantity = action.get("quantity", 1)
 
                 if not sku:
-                    logger.warning(f"[RULE ENGINE] ADD_PRODUCT missing SKU")
+                    logger.warning("[RULE ENGINE] ADD_PRODUCT missing SKU")
                     continue
 
                 try:
@@ -1193,7 +1188,7 @@ class RuleEngine:
                     continue
 
                 if quantity <= 0:
-                    logger.warning(f"[RULE ENGINE] ADD_PRODUCT quantity must be positive")
+                    logger.warning("[RULE ENGINE] ADD_PRODUCT quantity must be positive")
                     continue
 
                 # Знайти цей SKU в DataFrame для отримання product info (з stock файлу)

--- a/shopify_tool/rules.py
+++ b/shopify_tool/rules.py
@@ -1,6 +1,7 @@
 import copy
 import re
 from functools import lru_cache
+from typing import ClassVar
 
 import pandas as pd
 
@@ -465,7 +466,7 @@ def _op_date_before(series_val, rule_val):
         dtype: bool
     """
     import logging
-    logger = logging.getLogger(__name__)
+    logging.getLogger(__name__)
 
     rule_date = _parse_date_safe(rule_val)
     if rule_date is None:
@@ -512,7 +513,7 @@ def _op_date_after(series_val, rule_val):
         dtype: bool
     """
     import logging
-    logger = logging.getLogger(__name__)
+    logging.getLogger(__name__)
 
     rule_date = _parse_date_safe(rule_val)
     if rule_date is None:
@@ -559,7 +560,7 @@ def _op_date_equals(series_val, rule_val):
         dtype: bool
     """
     import logging
-    logger = logging.getLogger(__name__)
+    logging.getLogger(__name__)
 
     rule_date = _parse_date_safe(rule_val)
     if rule_date is None:
@@ -605,7 +606,7 @@ def _op_matches_regex(series_val, rule_val):
         dtype: bool
     """
     import logging
-    logger = logging.getLogger(__name__)
+    logging.getLogger(__name__)
 
     compiled_pattern = _compile_regex_safe(rule_val)
     if compiled_pattern is None:
@@ -632,7 +633,7 @@ class RuleEngine:
     """Applies a set of configured rules to a DataFrame of order data."""
 
     # Define order-level fields and their calculation methods
-    ORDER_LEVEL_FIELDS = {
+    ORDER_LEVEL_FIELDS: ClassVar[dict[str, str]] = {
         "item_count": "_calculate_item_count",
         "total_quantity": "_calculate_total_quantity",
         "unique_sku_count": "_calculate_unique_sku_count",
@@ -820,7 +821,7 @@ class RuleEngine:
         if order_rules and "Order_Number" in df.columns:
             for order_number in df["Order_Number"].unique():
                 order_mask = df["Order_Number"] == order_number
-                order_df = df[order_mask]
+                df[order_mask]
 
                 for rule in order_rules:
                     rule_name = rule.get("name", "Unnamed")
@@ -1032,13 +1033,13 @@ class RuleEngine:
             if action_type == "ADD_TAG":
                 # Per user feedback, ADD_TAG should modify Status_Note, not Tags
                 current_notes = df.loc[matches, "Status_Note"].fillna("").astype(str)
-                new_notes = current_notes.apply(lambda n: _append_to_note(n, value))
+                new_notes = current_notes.apply(lambda n, value=value: _append_to_note(n, value))
                 df.loc[matches, "Status_Note"] = new_notes
 
             elif action_type == "ADD_ORDER_TAG":
                 # Add tag to Status_Note (for order-level tagging)
                 current_notes = df.loc[matches, "Status_Note"].fillna("").astype(str)
-                new_notes = current_notes.apply(lambda n: _append_to_note(n, value))
+                new_notes = current_notes.apply(lambda n, value=value: _append_to_note(n, value))
                 df.loc[matches, "Status_Note"] = new_notes
 
             elif action_type == "ADD_INTERNAL_TAG":
@@ -1046,7 +1047,7 @@ class RuleEngine:
                 from shopify_tool.tag_manager import add_tag
 
                 current_tags = df.loc[matches, "Internal_Tags"]
-                new_tags = current_tags.apply(lambda t: add_tag(t, value))
+                new_tags = current_tags.apply(lambda t, value=value: add_tag(t, value))
                 df.loc[matches, "Internal_Tags"] = new_tags
 
             elif action_type == "SET_STATUS":
@@ -1092,7 +1093,7 @@ class RuleEngine:
                 # Додати теги без дублікатів
                 current_notes = df.loc[matches, "Status_Note"].fillna("").astype(str)
 
-                def add_multiple_tags(note):
+                def add_multiple_tags(note, tags_list=tags_list):
                     existing = [t.strip() for t in note.split(", ") if t.strip()]
                     for tag in tags_list:
                         if tag not in existing:

--- a/shopify_tool/sequential_order.py
+++ b/shopify_tool/sequential_order.py
@@ -42,7 +42,7 @@ def _write_sequential_order_map(json_path: Path, order_map: dict[str, int]) -> N
     json_path.parent.mkdir(parents=True, exist_ok=True)
     data = {
         "version": SEQUENTIAL_ORDER_VERSION,
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now().astimezone().isoformat(),
         "total_orders": len(order_map),
         "order_sequence": order_map,
     }
@@ -154,8 +154,8 @@ def load_sequential_order_map(session_path: Path) -> dict[str, int]:
         logger.info(f"Loaded sequential order map: {len(order_map)} orders")
         return order_map
 
-    except (json.JSONDecodeError, KeyError) as e:
-        logger.error(f"Failed to load sequential order map: {e}", exc_info=True)
+    except (json.JSONDecodeError, KeyError):
+        logger.exception("Failed to load sequential order map")
         return {}
 
 

--- a/shopify_tool/sequential_order.py
+++ b/shopify_tool/sequential_order.py
@@ -18,12 +18,11 @@ Usage:
     seq_num = get_sequential_number("ORDER-001", session_path)
 """
 
-import logging
 import json
+import logging
 import re
-from pathlib import Path
-from typing import Dict, Optional
 from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
 
@@ -39,7 +38,7 @@ def _natural_sort_key(s):
             for text in re.split(r'(\d+)', str(s))]
 
 
-def _write_sequential_order_map(json_path: Path, order_map: Dict[str, int]) -> None:
+def _write_sequential_order_map(json_path: Path, order_map: dict[str, int]) -> None:
     json_path.parent.mkdir(parents=True, exist_ok=True)
     data = {
         "version": SEQUENTIAL_ORDER_VERSION,
@@ -55,7 +54,7 @@ def generate_sequential_order_map(
     analysis_results_df: pd.DataFrame,
     session_path: Path,
     force_regenerate: bool = False
-) -> Dict[str, int]:
+) -> dict[str, int]:
     """
     Generate sequential order numbers for all Fulfillable orders.
 
@@ -131,7 +130,7 @@ def generate_sequential_order_map(
     return order_map
 
 
-def load_sequential_order_map(session_path: Path) -> Dict[str, int]:
+def load_sequential_order_map(session_path: Path) -> dict[str, int]:
     """
     Load existing sequential order map from session.
 
@@ -160,7 +159,7 @@ def load_sequential_order_map(session_path: Path) -> Dict[str, int]:
         return {}
 
 
-def get_sequential_number(order_number: str, session_path: Path) -> Optional[int]:
+def get_sequential_number(order_number: str, session_path: Path) -> int | None:
     """
     Get sequential number for specific order.
 
@@ -178,7 +177,7 @@ def get_sequential_number(order_number: str, session_path: Path) -> Optional[int
 def regenerate_sequential_order_map(
     analysis_results_df: pd.DataFrame,
     session_path: Path
-) -> Dict[str, int]:
+) -> dict[str, int]:
     """
     Force regeneration of sequential order map.
 

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -25,14 +25,12 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 
 logger = logging.getLogger("ShopifyToolLogger")
 
 
 class SessionManagerError(Exception):
     """Base exception for SessionManager errors."""
-    pass
 
 
 class SessionManager:
@@ -208,8 +206,8 @@ class SessionManager:
     def list_client_sessions(
         self,
         client_id: str,
-        status_filter: Optional[str] = None
-    ) -> List[Dict]:
+        status_filter: str | None = None
+    ) -> list[dict]:
         """List all sessions for a client.
 
         Args:
@@ -278,7 +276,7 @@ class SessionManager:
             finally:
                 lock_file.close()
 
-    def get_session_info(self, session_path: str) -> Optional[Dict]:
+    def get_session_info(self, session_path: str) -> dict | None:
         """Load session metadata from session_info.json.
 
         Args:
@@ -361,7 +359,7 @@ class SessionManager:
                 logger.error(f"Failed to update session status: {e}", exc_info=True)
                 raise SessionManagerError(f"Failed to update session status: {e}")
 
-    def update_session_info(self, session_path: str, updates: Dict) -> bool:
+    def update_session_info(self, session_path: str, updates: dict) -> bool:
         """Update session metadata with arbitrary fields.
 
         Args:
@@ -601,7 +599,7 @@ class SessionManager:
             logger.error(f"Failed to delete session: {e}", exc_info=True)
             raise SessionManagerError(f"Failed to delete session: {e}")
 
-    def calculate_session_statistics(self, session_path: str) -> Dict:
+    def calculate_session_statistics(self, session_path: str) -> dict:
         """Calculate session statistics by scanning session directory.
 
         Reads analysis_data.json for orders/items count and scans packing_lists

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -25,6 +25,7 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
+from typing import ClassVar
 
 logger = logging.getLogger("ShopifyToolLogger")
 
@@ -48,7 +49,7 @@ class SessionManager:
     """
 
     # Session subdirectories
-    SESSION_SUBDIRS = [
+    SESSION_SUBDIRS: ClassVar[list[str]] = [
         "input",
         "analysis",
         "packing_lists",
@@ -58,7 +59,7 @@ class SessionManager:
     ]
 
     # Valid session statuses
-    VALID_STATUSES = ["active", "completed", "abandoned", "archived"]
+    VALID_STATUSES: ClassVar[list[str]] = ["active", "completed", "abandoned", "archived"]
 
     def __init__(self, profile_manager):
         """Initialize SessionManager with ProfileManager.
@@ -114,7 +115,7 @@ class SessionManager:
             # Create session_info.json
             session_info = {
                 "created_by_tool": "shopify",
-                "created_at": datetime.now().isoformat(),
+                "created_at": datetime.now().astimezone().isoformat(),
                 "client_id": client_id,
                 "session_name": session_name,
                 "status": "active",
@@ -131,7 +132,7 @@ class SessionManager:
                     "packing_lists": []
                 },
                 "comments": "",
-                "last_modified": datetime.now().isoformat()
+                "last_modified": datetime.now().astimezone().isoformat()
             }
 
             session_info_path = session_path / "session_info.json"
@@ -142,7 +143,7 @@ class SessionManager:
             return str(session_path)
 
         except Exception as e:
-            logger.error(f"Failed to create session: {e}", exc_info=True)
+            logger.exception("Failed to create session")
             # Cleanup on failure
             if session_path.exists():
                 import shutil
@@ -160,7 +161,7 @@ class SessionManager:
         Returns:
             str: Unique session name (e.g., "2025-11-05_1")
         """
-        today = datetime.now().strftime("%Y-%m-%d")
+        today = datetime.now().astimezone().strftime("%Y-%m-%d")
 
         # Find existing sessions for today
         existing_sessions = []
@@ -255,17 +256,16 @@ class SessionManager:
         update silently loses the other's change.
         """
         lock_path = session_path_obj / "session_info.json.lock"
-        lock_file = open(lock_path, "a+")
-        try:
-            if os.name == "nt":
-                import msvcrt
-                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
-            else:
-                import fcntl
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-            yield
-        finally:
+        with open(lock_path, "a+") as lock_file:
             try:
+                if os.name == "nt":
+                    import msvcrt
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                yield
+            finally:
                 if os.name == "nt":
                     import msvcrt
                     lock_file.seek(0)
@@ -273,8 +273,6 @@ class SessionManager:
                 else:
                     import fcntl
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-            finally:
-                lock_file.close()
 
     def get_session_info(self, session_path: str) -> dict | None:
         """Load session metadata from session_info.json.
@@ -309,8 +307,8 @@ class SessionManager:
 
             return session_info
 
-        except Exception as e:
-            logger.error(f"Failed to load session info: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Failed to load session info")
             return None
 
     def update_session_status(self, session_path: str, status: str) -> bool:
@@ -340,7 +338,7 @@ class SessionManager:
 
             # Update status
             session_info["status"] = status
-            session_info["status_updated_at"] = datetime.now().isoformat()
+            session_info["status_updated_at"] = datetime.now().astimezone().isoformat()
 
             # Save back
             session_info_path = session_path_obj / "session_info.json"
@@ -356,7 +354,7 @@ class SessionManager:
                 return True
 
             except Exception as e:
-                logger.error(f"Failed to update session status: {e}", exc_info=True)
+                logger.exception("Failed to update session status")
                 raise SessionManagerError(f"Failed to update session status: {e}")
 
     def update_session_info(self, session_path: str, updates: dict) -> bool:
@@ -381,7 +379,7 @@ class SessionManager:
 
             # Apply updates
             session_info.update(updates)
-            session_info["last_updated"] = datetime.now().isoformat()
+            session_info["last_updated"] = datetime.now().astimezone().isoformat()
 
             # Save back
             session_info_path = session_path_obj / "session_info.json"
@@ -397,7 +395,7 @@ class SessionManager:
                 return True
 
             except Exception as e:
-                logger.error(f"Failed to update session info: {e}", exc_info=True)
+                logger.exception("Failed to update session info")
                 raise SessionManagerError(f"Failed to update session info: {e}")
 
     def append_to_session_list(self, session_path: str, field: str, value) -> bool:
@@ -427,7 +425,7 @@ class SessionManager:
                 return False
 
             session_info[field] = current_list + [value]
-            session_info["last_updated"] = datetime.now().isoformat()
+            session_info["last_updated"] = datetime.now().astimezone().isoformat()
 
             session_info_path = session_path_obj / "session_info.json"
             try:
@@ -440,7 +438,7 @@ class SessionManager:
                 return True
 
             except Exception as e:
-                logger.error(f"Failed to update session info: {e}", exc_info=True)
+                logger.exception("Failed to update session info")
                 raise SessionManagerError(f"Failed to update session info: {e}")
 
     def get_session_subdirectory(self, session_path: str, subdir_name: str) -> Path:
@@ -596,7 +594,7 @@ class SessionManager:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to delete session: {e}", exc_info=True)
+            logger.exception("Failed to delete session")
             raise SessionManagerError(f"Failed to delete session: {e}")
 
     def calculate_session_statistics(self, session_path: str) -> dict:

--- a/shopify_tool/set_decoder.py
+++ b/shopify_tool/set_decoder.py
@@ -8,15 +8,16 @@ This module provides functionality to:
 """
 
 import logging
+from typing import Any
+
 import pandas as pd
-from typing import Dict, List, Any
 
 logger = logging.getLogger(__name__)
 
 
 def decode_sets_in_orders(
     orders_df: pd.DataFrame,
-    set_decoders: Dict[str, List[Dict[str, Any]]]
+    set_decoders: dict[str, list[dict[str, Any]]]
 ) -> pd.DataFrame:
     """
     Expand set/bundle SKUs into their component SKUs.
@@ -148,7 +149,7 @@ def decode_sets_in_orders(
     return result_df
 
 
-def import_sets_from_csv(csv_path: str) -> Dict[str, List[Dict[str, Any]]]:
+def import_sets_from_csv(csv_path: str) -> dict[str, list[dict[str, Any]]]:
     """
     Import set definitions from CSV file.
 
@@ -234,7 +235,7 @@ def import_sets_from_csv(csv_path: str) -> Dict[str, List[Dict[str, Any]]]:
 
 
 def export_sets_to_csv(
-    set_decoders: Dict[str, List[Dict[str, Any]]],
+    set_decoders: dict[str, list[dict[str, Any]]],
     csv_path: str
 ) -> None:
     """
@@ -280,4 +281,4 @@ def export_sets_to_csv(
         df.to_csv(csv_path, index=False, encoding="utf-8")
         logger.info(f"Exported {len(set_decoders)} set definitions to {csv_path}")
     except Exception as e:
-        raise IOError(f"Failed to write CSV file: {e}")
+        raise OSError(f"Failed to write CSV file: {e}")

--- a/shopify_tool/sku_label_manager.py
+++ b/shopify_tool/sku_label_manager.py
@@ -205,9 +205,9 @@ class SKULabelManager:
                 logger.warning("pymupdf not installed — falling back to shell backend")
                 return self._print_label_shell(pdf_path, copies, printer_name, sku)
 
+        from PySide6.QtCore import QMarginsF, QSizeF, Qt
+        from PySide6.QtGui import QImage, QPageLayout, QPageSize, QPainter
         from PySide6.QtPrintSupport import QPrinter, QPrinterInfo
-        from PySide6.QtGui import QPainter, QPageSize, QPageLayout, QImage
-        from PySide6.QtCore import QSizeF, QMarginsF, Qt
 
         target_info = None
         for pi in QPrinterInfo.availablePrinters():

--- a/shopify_tool/sku_writeoff.py
+++ b/shopify_tool/sku_writeoff.py
@@ -40,18 +40,17 @@ Example usage:
 """
 
 import logging
-import os
-import pandas as pd
-from typing import Dict, List
 
-from shopify_tool.tag_manager import parse_tags, _normalize_tag_categories
+import pandas as pd
+
+from shopify_tool.tag_manager import _normalize_tag_categories, parse_tags
 
 logger = logging.getLogger("ShopifyToolLogger")
 
 
 def calculate_writeoff_quantities(
     analysis_df: pd.DataFrame,
-    tag_categories: Dict
+    tag_categories: dict
 ) -> pd.DataFrame:
     """Calculate total writeoff quantities from tags in analysis DataFrame.
 
@@ -313,7 +312,7 @@ def apply_writeoff_to_stock_export(
 
 def generate_writeoff_report(
     analysis_df: pd.DataFrame,
-    tag_categories: Dict,
+    tag_categories: dict,
     output_file: str
 ) -> None:
     """Generate detailed writeoff report as .xls file.
@@ -417,7 +416,7 @@ def generate_writeoff_report(
     )
 
 
-def _extract_writeoff_mappings(tag_categories: Dict) -> Dict[str, List[Dict]]:
+def _extract_writeoff_mappings(tag_categories: dict) -> dict[str, list[dict]]:
     """Extract all writeoff mappings from tag categories config.
 
     Internal helper function that normalizes v1/v2 config formats and extracts

--- a/shopify_tool/sku_writeoff.py
+++ b/shopify_tool/sku_writeoff.py
@@ -189,7 +189,7 @@ def calculate_writeoff_quantities(
         rows.append({
             "SKU": sku,
             "Writeoff_Quantity": round(data["quantity"], 2),
-            "Tags_Applied": sorted(list(data["tags"])),
+            "Tags_Applied": sorted(data["tags"]),
             "Order_Count": len(data["orders"])
         })
 

--- a/shopify_tool/stock_export.py
+++ b/shopify_tool/stock_export.py
@@ -1,4 +1,5 @@
 import logging
+
 import pandas as pd
 
 logger = logging.getLogger("ShopifyToolLogger")

--- a/shopify_tool/stock_export.py
+++ b/shopify_tool/stock_export.py
@@ -291,8 +291,8 @@ def create_stock_export(
             f"Stock export '{report_name}' created successfully at '{output_file}'."
         )
 
-    except Exception as e:
-        logger.error(f"Error while creating stock export '{report_name}': {e}", exc_info=True)
+    except Exception:
+        logger.exception(f"Error while creating stock export '{report_name}'")
 
 
 def merge_session_stock_exports(

--- a/shopify_tool/tag_manager.py
+++ b/shopify_tool/tag_manager.py
@@ -1,13 +1,13 @@
 """Tag management utilities for Internal_Tags column."""
 
-import json
 import hashlib
+import json
 from functools import lru_cache
-from typing import List, Optional, Dict, Tuple
+
 import pandas as pd
 
 
-def parse_tags(tags_value) -> List[str]:
+def parse_tags(tags_value) -> list[str]:
     """
     Parse Internal_Tags value to list.
 
@@ -36,7 +36,7 @@ def parse_tags(tags_value) -> List[str]:
     return []
 
 
-def serialize_tags(tags: List[str]) -> str:
+def serialize_tags(tags: list[str]) -> str:
     """
     Serialize tag list to JSON string.
 
@@ -102,7 +102,7 @@ def has_tag(tags_value, tag: str) -> bool:
     return tag in tags
 
 
-def get_tag_category(tag: str, tag_categories: Dict) -> Optional[str]:
+def get_tag_category(tag: str, tag_categories: dict) -> str | None:
     """
     Determine category of a tag.
 
@@ -123,7 +123,7 @@ def get_tag_category(tag: str, tag_categories: Dict) -> Optional[str]:
     return "custom"
 
 
-def get_tag_color(tag: str, tag_categories: Dict) -> str:
+def get_tag_color(tag: str, tag_categories: dict) -> str:
     """
     Get display color for a tag.
 
@@ -146,7 +146,7 @@ def get_tag_color(tag: str, tag_categories: Dict) -> str:
 # ============================================================================
 
 
-def get_config_hash(tag_categories: Dict) -> str:
+def get_config_hash(tag_categories: dict) -> str:
     """
     Generate stable hash of tag_categories config for cache invalidation.
 
@@ -161,7 +161,7 @@ def get_config_hash(tag_categories: Dict) -> str:
     return hashlib.md5(config_str.encode()).hexdigest()
 
 
-def _normalize_tag_categories(tag_categories: Dict) -> Dict:
+def _normalize_tag_categories(tag_categories: dict) -> dict:
     """
     Normalize tag_categories to always return v2 format.
 
@@ -187,7 +187,7 @@ def _normalize_tag_categories(tag_categories: Dict) -> Dict:
 
 
 @lru_cache(maxsize=512)
-def get_tag_category_cached(tag: str, config_hash: str, config_json: str) -> Optional[str]:
+def get_tag_category_cached(tag: str, config_hash: str, config_json: str) -> str | None:
     """
     Cached version of get_tag_category for performance.
 
@@ -210,7 +210,7 @@ def get_tag_category_cached(tag: str, config_hash: str, config_json: str) -> Opt
     return "custom"
 
 
-def get_category_tags(category_id: str, tag_categories: Dict) -> List[str]:
+def get_category_tags(category_id: str, tag_categories: dict) -> list[str]:
     """
     Get list of tags for a specific category.
 
@@ -225,7 +225,7 @@ def get_category_tags(category_id: str, tag_categories: Dict) -> List[str]:
     return categories.get(category_id, {}).get("tags", [])
 
 
-def validate_tag_categories_v2(config: Dict) -> Tuple[bool, List[str]]:
+def validate_tag_categories_v2(config: dict) -> tuple[bool, list[str]]:
     """
     Validate tag_categories v2 structure.
 

--- a/shopify_tool/undo_manager.py
+++ b/shopify_tool/undo_manager.py
@@ -10,10 +10,9 @@ Manages undo history for DataFrame modifications:
 
 import json
 import logging
-import os
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Tuple, Dict, Any, List
+from typing import Any
 
 import pandas as pd
 
@@ -46,7 +45,7 @@ class UndoManager:
         self,
         operation_type: str,
         description: str,
-        params: Dict[str, Any],
+        params: dict[str, Any],
         affected_rows_before: pd.DataFrame
     ):
         """Record operation AFTER it executes.
@@ -116,7 +115,7 @@ class UndoManager:
         """
         return self.current_position > 0 and len(self.operations) > 0
 
-    def get_undo_description(self) -> Optional[str]:
+    def get_undo_description(self) -> str | None:
         """Get description of operation that would be undone.
 
         Returns:
@@ -126,7 +125,7 @@ class UndoManager:
             return self.operations[self.current_position - 1].get("description", "Unknown operation")
         return None
 
-    def undo(self) -> Tuple[bool, str]:
+    def undo(self) -> tuple[bool, str]:
         """Undo last operation.
 
         Returns:
@@ -215,9 +214,9 @@ class UndoManager:
 
         except Exception as e:
             self.log.error(f"Undo failed: {e}", exc_info=True)
-            return False, f"Undo failed: {str(e)}"
+            return False, f"Undo failed: {e!s}"
 
-    def _undo_toggle_status(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_toggle_status(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo toggle status operation.
 
         Args:
@@ -253,7 +252,7 @@ class UndoManager:
             self.log.error(f"Failed to undo toggle status: {e}", exc_info=True)
             return False
 
-    def _undo_add_tag(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_add_tag(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo add tag operation.
 
         Args:
@@ -291,7 +290,7 @@ class UndoManager:
             self.log.error(f"Failed to undo add tag: {e}", exc_info=True)
             return False
 
-    def _undo_add_internal_tag(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_add_internal_tag(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo add internal tag operation.
 
         Args:
@@ -329,7 +328,7 @@ class UndoManager:
             self.log.error(f"Failed to undo add internal tag: {e}", exc_info=True)
             return False
 
-    def _undo_remove_item(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_remove_item(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo remove item operation.
 
         Args:
@@ -356,7 +355,7 @@ class UndoManager:
             self.log.error(f"Failed to undo remove item: {e}", exc_info=True)
             return False
 
-    def _undo_remove_order(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_remove_order(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo remove order operation.
 
         Args:
@@ -382,7 +381,7 @@ class UndoManager:
             self.log.error(f"Failed to undo remove order: {e}", exc_info=True)
             return False
 
-    def _get_history_path(self) -> Optional[Path]:
+    def _get_history_path(self) -> Path | None:
         """Get path to operations_history.json.
 
         Returns:
@@ -487,7 +486,7 @@ class UndoManager:
     # BULK OPERATION UNDO HANDLERS
     # ============================================================================
 
-    def _undo_bulk_change_status(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_bulk_change_status(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo bulk status change operation.
 
         Args:
@@ -521,7 +520,7 @@ class UndoManager:
             self.log.error(f"Failed to undo bulk status change: {e}", exc_info=True)
             return False
 
-    def _undo_bulk_add_tag(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_bulk_add_tag(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo bulk tag addition.
 
         Args:
@@ -549,7 +548,7 @@ class UndoManager:
             self.log.error(f"Failed to undo bulk add tag: {e}", exc_info=True)
             return False
 
-    def _undo_bulk_remove_tag(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_bulk_remove_tag(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo bulk tag removal with order-level forward-fill.
 
         Args:
@@ -577,7 +576,7 @@ class UndoManager:
             self.log.error(f"Failed to undo bulk remove tag: {e}", exc_info=True)
             return False
 
-    def _undo_bulk_remove_sku(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_bulk_remove_sku(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo bulk SKU removal.
 
         Args:
@@ -608,7 +607,7 @@ class UndoManager:
             self.log.error(f"Failed to undo bulk SKU removal: {e}", exc_info=True)
             return False
 
-    def _undo_bulk_remove_orders_with_sku(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_bulk_remove_orders_with_sku(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo bulk order removal (orders containing SKU).
 
         Args:
@@ -639,7 +638,7 @@ class UndoManager:
             self.log.error(f"Failed to undo bulk order removal: {e}", exc_info=True)
             return False
 
-    def _undo_bulk_delete_orders(self, params: Dict, affected_rows_before: pd.DataFrame) -> bool:
+    def _undo_bulk_delete_orders(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
         """Undo bulk order deletion.
 
         Args:

--- a/shopify_tool/undo_manager.py
+++ b/shopify_tool/undo_manager.py
@@ -78,7 +78,7 @@ class UndoManager:
             operation_id = len(self.operations) + 1
             operation = {
                 "id": operation_id,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now().astimezone().isoformat(),
                 "type": operation_type,
                 "description": description,
                 "params": params,
@@ -104,8 +104,8 @@ class UndoManager:
 
             self.log.info(f"Recorded operation #{operation_id}: {description}")
 
-        except Exception as e:
-            self.log.error(f"Failed to record operation: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to record operation")
 
     def can_undo(self) -> bool:
         """Check if undo is possible.
@@ -213,7 +213,7 @@ class UndoManager:
                 return False, f"Failed to undo: {operation['description']}"
 
         except Exception as e:
-            self.log.error(f"Undo failed: {e}", exc_info=True)
+            self.log.exception("Undo failed")
             return False, f"Undo failed: {e!s}"
 
     def _undo_toggle_status(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -248,8 +248,8 @@ class UndoManager:
 
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo toggle status: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo toggle status")
             return False
 
     def _undo_add_tag(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -286,8 +286,8 @@ class UndoManager:
 
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo add tag: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo add tag")
             return False
 
     def _undo_add_internal_tag(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -324,8 +324,8 @@ class UndoManager:
 
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo add internal tag: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo add internal tag")
             return False
 
     def _undo_remove_item(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -351,8 +351,8 @@ class UndoManager:
 
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo remove item: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo remove item")
             return False
 
     def _undo_remove_order(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -377,8 +377,8 @@ class UndoManager:
 
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo remove order: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo remove order")
             return False
 
     def _get_history_path(self) -> Path | None:
@@ -416,8 +416,8 @@ class UndoManager:
 
             self.log.debug(f"Saved history to {history_path}")
 
-        except Exception as e:
-            self.log.error(f"Failed to save history: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to save history")
 
     def _load_history(self):
         """Load history from operations_history.json."""
@@ -441,8 +441,8 @@ class UndoManager:
             self.log.warning(f"Corrupted history file, starting fresh: {e}")
             self.operations = []
             self.current_position = 0
-        except Exception as e:
-            self.log.error(f"Failed to load history: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to load history")
             self.operations = []
             self.current_position = 0
 
@@ -497,7 +497,7 @@ class UndoManager:
             True if successful
         """
         try:
-            affected_indexes = params.get("affected_indexes", [])
+            params.get("affected_indexes", [])
 
             if affected_rows_before.empty:
                 self.log.warning("No affected rows to restore")
@@ -507,17 +507,16 @@ class UndoManager:
             # We need to restore Order_Fulfillment_Status from before state
             for idx, row in affected_rows_before.iterrows():
                 original_status = row.get("Order_Fulfillment_Status")
-                if pd.notna(original_status):
-                    # Find matching row in current DataFrame
-                    # After reset_index, we need to find by other criteria or use iloc
-                    if idx in self.main_window.analysis_results_df.index:
-                        self.main_window.analysis_results_df.loc[idx, "Order_Fulfillment_Status"] = original_status
+                # Find matching row in current DataFrame
+                # After reset_index, we need to find by other criteria or use iloc
+                if pd.notna(original_status) and idx in self.main_window.analysis_results_df.index:
+                    self.main_window.analysis_results_df.loc[idx, "Order_Fulfillment_Status"] = original_status
 
             self.log.info(f"Undid bulk status change for {len(affected_rows_before)} rows")
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo bulk status change: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo bulk status change")
             return False
 
     def _undo_bulk_add_tag(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -544,8 +543,8 @@ class UndoManager:
             self.log.info(f"Undid bulk add tag for {len(affected_rows_before)} orders")
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo bulk add tag: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo bulk add tag")
             return False
 
     def _undo_bulk_remove_tag(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -572,8 +571,8 @@ class UndoManager:
             self.log.info(f"Undid bulk remove tag for {len(affected_rows_before)} orders")
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo bulk remove tag: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo bulk remove tag")
             return False
 
     def _undo_bulk_remove_sku(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -603,8 +602,8 @@ class UndoManager:
 
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo bulk SKU removal: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo bulk SKU removal")
             return False
 
     def _undo_bulk_remove_orders_with_sku(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -634,8 +633,8 @@ class UndoManager:
 
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo bulk order removal: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo bulk order removal")
             return False
 
     def _undo_bulk_delete_orders(self, params: dict, affected_rows_before: pd.DataFrame) -> bool:
@@ -665,6 +664,6 @@ class UndoManager:
 
             return True
 
-        except Exception as e:
-            self.log.error(f"Failed to undo bulk delete: {e}", exc_info=True)
+        except Exception:
+            self.log.exception("Failed to undo bulk delete")
             return False

--- a/shopify_tool/utils.py
+++ b/shopify_tool/utils.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 logger = logging.getLogger("ShopifyToolLogger")
 

--- a/shopify_tool/utils.py
+++ b/shopify_tool/utils.py
@@ -31,9 +31,9 @@ def get_persistent_data_path(filename):
 
     try:
         os.makedirs(app_dir, exist_ok=True)
-    except OSError as e:
+    except OSError:
         # Fallback to current directory if AppData is not writable
-        logger.error(f"Could not create AppData directory: {e}. Falling back to local directory.", exc_info=True)
+        logger.exception("Could not create AppData directory. Falling back to local directory.")
         app_dir = "."
 
     return os.path.join(app_dir, filename)

--- a/shopify_tool/weight_calculator.py
+++ b/shopify_tool/weight_calculator.py
@@ -13,7 +13,6 @@ Physical fit check:
 """
 
 import logging
-from typing import Dict, List, Tuple
 
 import pandas as pd
 
@@ -25,7 +24,7 @@ NO_BOX_FITS = "NO_BOX_FITS"      # items have dimensions but no box is large eno
 UNKNOWN_DIMS = "UNKNOWN_DIMS"     # some SKUs have no dimensions configured
 
 
-def calc_sku_volumetric_weight(sku: str, weight_config: Dict) -> float:
+def calc_sku_volumetric_weight(sku: str, weight_config: dict) -> float:
     """
     Calculate volumetric weight for a single SKU.
 
@@ -55,7 +54,7 @@ def calc_sku_volumetric_weight(sku: str, weight_config: Dict) -> float:
     return (length * width * height) / divisor
 
 
-def calc_order_volumetric_weight(order_df: pd.DataFrame, weight_config: Dict) -> float:
+def calc_order_volumetric_weight(order_df: pd.DataFrame, weight_config: dict) -> float:
     """
     Calculate total volumetric weight for an order group.
 
@@ -80,7 +79,7 @@ def calc_order_volumetric_weight(order_df: pd.DataFrame, weight_config: Dict) ->
     return round(total, 4)
 
 
-def is_all_no_packaging(order_df: pd.DataFrame, weight_config: Dict) -> bool:
+def is_all_no_packaging(order_df: pd.DataFrame, weight_config: dict) -> bool:
     """
     Returns True ONLY if at least one real SKU was found AND all such SKUs
     have no_packaging=True.
@@ -117,8 +116,8 @@ def is_all_no_packaging(order_df: pd.DataFrame, weight_config: Dict) -> bool:
 # Physical fit logic
 # ---------------------------------------------------------------------------
 
-def _item_fits_in_box(item_dims: Tuple[float, float, float],
-                      box_dims: Tuple[float, float, float]) -> bool:
+def _item_fits_in_box(item_dims: tuple[float, float, float],
+                      box_dims: tuple[float, float, float]) -> bool:
     """
     Check if a single item fits in a box, trying all 6 rotations.
 
@@ -131,8 +130,8 @@ def _item_fits_in_box(item_dims: Tuple[float, float, float],
     return si[0] <= sb[0] and si[1] <= sb[1] and si[2] <= sb[2]
 
 
-def _order_fits_in_box(item_list: List[Tuple[float, float, float]],
-                       box_dims: Tuple[float, float, float]) -> bool:
+def _order_fits_in_box(item_list: list[tuple[float, float, float]],
+                       box_dims: tuple[float, float, float]) -> bool:
     """
     Check if a list of items fits in a box using two conditions:
 
@@ -169,7 +168,7 @@ def _order_fits_in_box(item_list: List[Tuple[float, float, float]],
     return total_item_volume <= box_volume
 
 
-def find_min_box_for_order(order_df: pd.DataFrame, weight_config: Dict) -> str:
+def find_min_box_for_order(order_df: pd.DataFrame, weight_config: dict) -> str:
     """
     Find the smallest box (by volume) that physically fits all items in the order.
 
@@ -186,7 +185,7 @@ def find_min_box_for_order(order_df: pd.DataFrame, weight_config: Dict) -> str:
         return UNKNOWN_DIMS
 
     # Collect item dimensions (expanded by quantity, excluding no_packaging items)
-    item_dims_list: List[Tuple[float, float, float]] = []
+    item_dims_list: list[tuple[float, float, float]] = []
     has_packaging_items = False
     has_unknown_dims = False
 
@@ -255,7 +254,7 @@ def find_min_box_for_order(order_df: pd.DataFrame, weight_config: Dict) -> str:
     return NO_BOX_FITS
 
 
-def enrich_dataframe_with_weights(df: pd.DataFrame, weight_config: Dict) -> pd.DataFrame:
+def enrich_dataframe_with_weights(df: pd.DataFrame, weight_config: dict) -> pd.DataFrame:
     """
     Adds volumetric weight and physical box columns to the DataFrame before Rule Engine runs.
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -177,7 +177,7 @@ class TestNoSkuHandling:
 class TestRepeatDetection:
     def test_order_executed_yesterday_is_marked_repeat_with_default_window(self):
         import datetime
-        yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+        yesterday = (datetime.datetime.now().astimezone() - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
         orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 1}])
         stock = _stock([{"Артикул": "A1", "Наличност": 10}])
         history = _history([{"Order_Number": "#1", "Execution_Date": yesterday}])
@@ -186,7 +186,7 @@ class TestRepeatDetection:
 
     def test_order_executed_today_is_not_marked_repeat_with_default_window(self):
         import datetime
-        today = datetime.datetime.now().strftime("%Y-%m-%d")
+        today = datetime.datetime.now().astimezone().strftime("%Y-%m-%d")
         orders = _orders([{"Name": "#1", "Lineitem sku": "A1", "Lineitem quantity": 1}])
         stock = _stock([{"Артикул": "A1", "Наличност": 10}])
         history = _history([{"Order_Number": "#1", "Execution_Date": today}])
@@ -195,7 +195,7 @@ class TestRepeatDetection:
 
     def test_unrelated_order_number_not_flagged(self):
         import datetime
-        yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+        yesterday = (datetime.datetime.now().astimezone() - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
         orders = _orders([{"Name": "#2", "Lineitem sku": "A1", "Lineitem quantity": 1}])
         stock = _stock([{"Артикул": "A1", "Наличност": 10}])
         history = _history([{"Order_Number": "#1", "Execution_Date": yesterday}])

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -4,7 +4,6 @@ Column fixtures use internal (post-analysis) column names since RuleEngine
 operates on the final_df produced by shopify_tool.analysis.run_analysis.
 """
 import pandas as pd
-import pytest
 
 from shopify_tool.rules import RuleEngine
 from shopify_tool.tag_manager import parse_tags

--- a/tests/test_sequential_order.py
+++ b/tests/test_sequential_order.py
@@ -2,7 +2,6 @@
 import json
 
 import pandas as pd
-import pytest
 
 from shopify_tool.sequential_order import (
     generate_sequential_order_map,

--- a/tests/test_stock_export.py
+++ b/tests/test_stock_export.py
@@ -5,7 +5,6 @@ Output columns are positional (Артикул, blank spacer, Мярка, Бро�
 back by column index rather than by header name.
 """
 import pandas as pd
-import pytest
 
 from shopify_tool.stock_export import create_stock_export, merge_session_stock_exports
 


### PR DESCRIPTION
## Summary
- `ruff check . || true` never actually failed CI - lint was decorative. Ran `ruff check . --fix` first (692 mechanical fixes: unused imports, minor style; 69 files) as its own commit, then dropped `|| true`. This left **406 findings** (timezone-naive datetimes, bare excepts, try/except/pass, etc.) for manual triage - now resolved, see Update below. `ruff check . --exclude shared` passes clean as of this PR.
- Dropped the `if [ -d tests ]` guard on the pytest step - it was a bridge for when `tests/` didn't exist yet; there's been a permanent 178+ test suite since PR #246.
- Added a `shared-sync-check` job: checks out `packing-tool` alongside this repo and `diff -r`s `shared/` against `packing-tool/shared/` (the canonical source per CLAUDE.md). Fails the build on drift instead of relying on remembering to re-run `scripts/sync_shared.py`.

## Update: manual triage + shared/ resync
- **`style: manual triage of remaining ruff findings`** - closes out the 406 findings above: `logger.error(msg, exc_info=True)` → `logger.exception(msg)`, naive `datetime.now()` → `.astimezone()` before `isoformat`/`strftime` (tz-aware timestamps), `Optional[X]`/`Dict`/`List` → PEP 604 `X | None`/`dict`/`list`, plus a few manual (non-autofix) judgment calls: an unreachable duplicate `except ParserError` clause removed in `core.py`, nested-if collapse + context-manager cleanup for the file lock in `groups_manager.py`, `sorted(...)[-1]` → `max(...)`, and finishing the `logging.*` → `logger.*` migration in `main_window_pyside.py`. Adds `ruff.toml` recording two intentional rule suppressions (`BLE001` broad-except is a deliberate crash-guard idiom here; `QModelIndex()` as an immutable default arg matches Qt's own convention). Reviewed via a dedicated code-review pass first - no critical/important issues found besides one manual deletion (confirmed safe) and a few harmless no-op statements left by ruff's own autofix, noted for a later cleanup.
- **`chore: sync shared/ from packing-tool`** - pulls packing-tool's equivalent lint cleanup into this repo's mirror (isort ordering, PEP 604 typing, `IOError`→`OSError`, `logger.exception`, merged `with` statements). No behavior change.

## Test plan
- [x] `ruff check . --exclude shared` - all checks pass (the 406 findings above are now resolved)
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest` - 196 passed, no behavior change
- [x] `diff -r shared packing-tool/shared` - clean (pycache dirs aside, which are gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of user-facing error messages and stack-trace logging across import, analysis, report generation, settings updates, and client/group workflows.
  - Improved timestamp handling: reports, JSON entries, and history records now use timezone-aware date/time formatting for more consistent filenames and metadata.

- **Chores**
  - Strengthened CI reliability: stricter linting, headless tests run unconditionally, and an automated check was added to detect drift in the shared folder contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->