### PR TITLE
Fix UI responsiveness on slow file server

### DIFF
--- a/docs/superpowers/plans/2026-07-27-ui-responsiveness.md
+++ b/docs/superpowers/plans/2026-07-27-ui-responsiveness.md
@@ -1,0 +1,1523 @@
+# UI Responsiveness on Slow File Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the app's slow network file server from freezing the GUI on session-browser load, client switch, sidebar refresh, and config save.
+
+**Architecture:** Two independent workstreams sharing one root cause (synchronous per-file-server-call IO). Workstream 1 adds an incrementally-maintained `session_index.json` per client so listing sessions costs one file read instead of one-per-session. Workstream 2 applies the existing `Worker`(`QRunnable`)/`QThreadPool` pattern to the remaining GUI-thread IO (client switch, sidebar refresh, config save) and closes two caching/dedup gaps found during investigation.
+
+**Tech Stack:** Python, PySide6, pytest (`QT_QPA_PLATFORM=offscreen`). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md`
+
+## Global Constraints
+
+- No UI calls from background threads (`gui/*` widgets must never be constructed or mutated outside the GUI thread) — PySide6 crashes. Any code that builds/touches a `QWidget` runs only from a `Worker` `result`/`error` signal handler (main thread), never inside a `Worker`'s wrapped function.
+- Never hand-edit anything under `shared/` — it's one-way synced from `../packing-tool/shared/` via `scripts/sync_shared.py`.
+- No hardcoded colors in stylesheets — use `theme_manager`.
+- Run tests with `QT_QPA_PLATFORM=offscreen python -m pytest`.
+- After any code change, this repo's `CLAUDE.md` asks for `graphify update .` to be run (last step of this plan).
+
+---
+
+### Task 1: Session index — core read/write + wiring into every session_info.json writer
+
+**Files:**
+- Modify: `shopify_tool/session_manager.py`
+- Test: `tests/test_session_manager.py`
+
+**Interfaces:**
+- Produces (used by Task 2): `SessionManager._read_index(client_sessions_dir: Path) -> list[dict] | None`, `SessionManager._rebuild_index(client_sessions_dir: Path) -> list[dict]`, `SessionManager.INDEX_FILENAME: str = "session_index.json"`.
+- Each index entry is a `dict` shaped exactly like `get_session_info()`'s return value minus the `session_path` key, keyed by its own `session_name` field.
+
+- [ ] **Step 1: Write the failing tests for index creation and per-write sync**
+
+Add to `tests/test_session_manager.py`:
+
+```python
+class TestSessionIndex:
+    def test_create_session_adds_index_entry(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        index_path = session_path.parent / SessionManager.INDEX_FILENAME
+        assert index_path.exists()
+        entries = json.loads(index_path.read_text())
+        assert len(entries) == 1
+        assert entries[0]["session_name"] == session_path.name
+        assert entries[0]["status"] == "active"
+        assert "session_path" not in entries[0]
+
+    def test_update_session_status_updates_index_entry(self, session_manager):
+        session_path = session_manager.create_session("M")
+        session_manager.update_session_status(session_path, "completed")
+        index_path = Path(session_path).parent / SessionManager.INDEX_FILENAME
+        entries = json.loads(index_path.read_text())
+        assert entries[0]["status"] == "completed"
+
+    def test_update_session_info_updates_index_entry(self, session_manager):
+        session_path = session_manager.create_session("M")
+        session_manager.update_session_info(session_path, {"comments": "hi"})
+        index_path = Path(session_path).parent / SessionManager.INDEX_FILENAME
+        entries = json.loads(index_path.read_text())
+        assert entries[0]["comments"] == "hi"
+
+    def test_append_to_session_list_updates_index_entry(self, session_manager):
+        session_path = session_manager.create_session("M")
+        session_manager.append_to_session_list(session_path, "packing_lists_generated", "a.xlsx")
+        index_path = Path(session_path).parent / SessionManager.INDEX_FILENAME
+        entries = json.loads(index_path.read_text())
+        assert entries[0]["packing_lists_generated"] == ["a.xlsx"]
+
+    def test_second_session_appends_not_replaces_index(self, session_manager):
+        session_manager.create_session("M")
+        second_path = Path(session_manager.create_session("M"))
+        index_path = second_path.parent / SessionManager.INDEX_FILENAME
+        entries = json.loads(index_path.read_text())
+        assert len(entries) == 2
+
+    def test_rebuild_index_scans_directory_and_writes_index(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        index_path = session_path.parent / SessionManager.INDEX_FILENAME
+        index_path.unlink()  # simulate pre-existing sessions with no index yet
+        entries = session_manager._rebuild_index(session_path.parent)
+        assert len(entries) == 1
+        assert entries[0]["session_name"] == session_path.name
+        assert index_path.exists()
+
+    def test_read_index_returns_none_when_missing(self, session_manager, tmp_path):
+        empty_dir = tmp_path / "CLIENT_NOINDEX"
+        empty_dir.mkdir()
+        assert session_manager._read_index(empty_dir) is None
+
+    def test_index_write_failure_does_not_break_session_update(self, session_manager, monkeypatch):
+        session_path = session_manager.create_session("M")
+        monkeypatch.setattr(
+            session_manager, "_upsert_index_entry",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        # The primary session_info.json write must still succeed even if the
+        # index-cache update fails.
+        assert session_manager.update_session_status(session_path, "completed") is True
+        info = session_manager.get_session_info(session_path)
+        assert info["status"] == "completed"
+```
+
+Add `import json` at the top of `tests/test_session_manager.py` if not already present (check first — `get_session_info` tests may already import it indirectly; this file currently only imports `Path` and `pytest`, so add `import json`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_session_manager.py::TestSessionIndex -v`
+Expected: FAIL — `AttributeError: 'SessionManager' object has no attribute '_read_index'` (or `INDEX_FILENAME` missing).
+
+- [ ] **Step 3: Implement the index core in `shopify_tool/session_manager.py`**
+
+Add `INDEX_FILENAME` as a class attribute next to `VALID_STATUSES` (around line 62):
+
+```python
+    # Per-client session index cache filename (see docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md)
+    INDEX_FILENAME: ClassVar[str] = "session_index.json"
+```
+
+Replace the existing `_locked_session_info` context manager (lines 249-276) with a generalized lock helper plus a thin wrapper, so the same locking primitive can guard the index file too:
+
+```python
+    @contextlib.contextmanager
+    def _exclusive_lock(self, lock_path: Path):
+        """Blocking exclusive lock on an arbitrary sidecar `.lock` file.
+
+        Without this, two near-simultaneous read-modify-write cycles on the
+        file `lock_path` guards each read the same on-disk snapshot before
+        either writes back, and one update silently loses the other's change.
+        """
+        with open(lock_path, "a+") as lock_file:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                yield
+            finally:
+                if os.name == "nt":
+                    import msvcrt
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    @contextlib.contextmanager
+    def _locked_session_info(self, session_path_obj: Path):
+        """Blocking exclusive lock spanning a session_info.json read-modify-write."""
+        with self._exclusive_lock(session_path_obj / "session_info.json.lock"):
+            yield
+```
+
+Add the index helpers right after `get_session_info()` (after line 312, before `update_session_status`):
+
+```python
+    def _index_lock_path(self, client_sessions_dir: Path) -> Path:
+        return client_sessions_dir / f"{self.INDEX_FILENAME}.lock"
+
+    def _read_index(self, client_sessions_dir: Path) -> list[dict] | None:
+        """Read the raw index file, or None if it doesn't exist / is unreadable."""
+        index_path = client_sessions_dir / self.INDEX_FILENAME
+        if not index_path.exists():
+            return None
+        try:
+            with open(index_path, encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            logger.exception("Failed to read session index, treating as missing")
+            return None
+
+    def _write_index(self, client_sessions_dir: Path, entries: list[dict]) -> None:
+        index_path = client_sessions_dir / self.INDEX_FILENAME
+        with open(index_path, "w", encoding="utf-8") as f:
+            json.dump(entries, f, indent=2)
+
+    def _scan_sessions(self, client_sessions_dir: Path) -> list[dict]:
+        """Full folder scan (the old list_client_sessions behavior) -- used only
+        to build/rebuild the index, never on the normal read path."""
+        entries = []
+        for item in client_sessions_dir.iterdir():
+            if not item.is_dir():
+                continue
+            info = self.get_session_info(str(item))
+            if info:
+                info.pop("session_path", None)
+                entries.append(info)
+        return entries
+
+    def _rebuild_index(self, client_sessions_dir: Path) -> list[dict]:
+        """Full scan + persist. Called when no index exists yet, or the
+        directory count no longer matches the index (see list_client_sessions)."""
+        entries = self._scan_sessions(client_sessions_dir)
+        with self._exclusive_lock(self._index_lock_path(client_sessions_dir)):
+            self._write_index(client_sessions_dir, entries)
+        return entries
+
+    def _upsert_index_entry(self, session_path_obj: Path, session_info: dict) -> None:
+        """Insert or replace one session's entry in its client's index.
+
+        Best-effort: index-write failures are logged, not raised, since the
+        index is a read-side cache and must never block the session_info.json
+        write it mirrors.
+        """
+        try:
+            client_sessions_dir = session_path_obj.parent
+            entry = dict(session_info)
+            entry.pop("session_path", None)
+            session_name = session_path_obj.name
+            with self._exclusive_lock(self._index_lock_path(client_sessions_dir)):
+                entries = self._read_index(client_sessions_dir) or []
+                entries = [e for e in entries if e.get("session_name") != session_name]
+                entries.append(entry)
+                self._write_index(client_sessions_dir, entries)
+        except Exception:
+            logger.exception(f"Failed to update session index for {session_path_obj}")
+```
+
+Wire it into the four writers:
+
+In `create_session()`, right before `return str(session_path)` (currently line 143), add:
+
+```python
+            self._upsert_index_entry(session_path, session_info)
+            self.profile_manager.invalidate_metadata_cache(client_id)
+
+            logger.info(f"Session created: CLIENT_{client_id}/{session_name}")
+            return str(session_path)
+```
+
+(This replaces the existing `logger.info(...)` + `return` pair at lines 142-143 — keep the log line, just add the two new calls before it returns.)
+
+In `update_session_status()`, immediately before `return True` (currently line 354), add:
+
+```python
+                self._upsert_index_entry(session_path_obj, session_info)
+                logger.info(f"Session status updated to '{status}': {session_path}")
+                return True
+```
+
+(replaces the existing `logger.info` + `return True` pair at lines 353-354)
+
+In `update_session_info()`, immediately before `return True` (currently line 395), add the same pattern:
+
+```python
+                self._upsert_index_entry(session_path_obj, session_info)
+                logger.info(f"Session info updated: {session_path}")
+                return True
+```
+
+(replaces lines 394-395)
+
+In `append_to_session_list()`, immediately before `return True` (currently line 438), add:
+
+```python
+                self._upsert_index_entry(session_path_obj, session_info)
+                logger.info(f"Session info updated: appended '{value}' to '{field}'")
+                return True
+```
+
+(replaces lines 437-438)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_session_manager.py::TestSessionIndex -v`
+Expected: PASS (all 8 tests)
+
+- [ ] **Step 5: Run the full session manager test suite to check nothing broke**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_session_manager.py -v`
+Expected: PASS (all tests, including the pre-existing `TestAppendToSessionList` concurrency test)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shopify_tool/session_manager.py tests/test_session_manager.py
+git commit -m "Add incrementally-maintained session index alongside session_info.json writes"
+```
+
+---
+
+### Task 2: `list_client_sessions()` reads from the index instead of scanning every session
+
+**Files:**
+- Modify: `shopify_tool/session_manager.py:207-247`
+- Test: `tests/test_session_manager.py`
+
+**Interfaces:**
+- Consumes (from Task 1): `SessionManager._read_index`, `SessionManager._rebuild_index`, `SessionManager.INDEX_FILENAME`.
+- No change to `list_client_sessions()`'s public signature or return shape — same `list[dict]`, same fields, same sort order. Existing callers (`gui/session_browser_widget.py`, `gui/ui_manager.py:refresh_recent_sessions`) need no changes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_session_manager.py`:
+
+```python
+class TestListClientSessionsUsesIndex:
+    def test_list_matches_previous_full_scan_output(self, session_manager):
+        p1 = Path(session_manager.create_session("M"))
+        session_manager.update_session_status(p1, "completed")
+        p2 = session_manager.create_session("M")
+        sessions = session_manager.list_client_sessions("M")
+        assert len(sessions) == 2
+        names = {s["session_name"] for s in sessions}
+        assert names == {p1.name, Path(p2).name}
+        # sorted newest first
+        assert sessions[0]["created_at"] >= sessions[1]["created_at"]
+
+    def test_status_filter_still_works(self, session_manager):
+        p1 = Path(session_manager.create_session("M"))
+        session_manager.update_session_status(p1, "completed")
+        session_manager.create_session("M")
+        active_only = session_manager.list_client_sessions("M", status_filter="active")
+        assert len(active_only) == 1
+
+    def test_missing_index_is_built_transparently(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        index_path = session_path.parent / SessionManager.INDEX_FILENAME
+        index_path.unlink()  # simulate a client dir from before this feature
+        sessions = session_manager.list_client_sessions("M")
+        assert len(sessions) == 1
+        assert index_path.exists()  # self-healed
+
+    def test_manually_added_session_folder_triggers_rebuild(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        # Simulate a session folder restored/copied in without going through
+        # create_session (index has no entry for it).
+        extra = session_path.parent / "2020-01-01_1"
+        extra.mkdir()
+        for subdir in SessionManager.SESSION_SUBDIRS:
+            (extra / subdir).mkdir()
+        (extra / "session_info.json").write_text(json.dumps({
+            "session_name": "2020-01-01_1", "status": "active",
+            "created_at": "2020-01-01T00:00:00", "client_id": "M",
+        }))
+        sessions = session_manager.list_client_sessions("M")
+        assert len(sessions) == 2  # count mismatch caught it, rebuilt
+
+    def test_no_sessions_dir_returns_empty_list(self, session_manager):
+        assert session_manager.list_client_sessions("M") == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_session_manager.py::TestListClientSessionsUsesIndex -v`
+Expected: `test_manually_added_session_folder_triggers_rebuild` fails (old code re-scans every call so it'd pass by accident) — actually all should currently pass under the OLD implementation since it always full-scans. Confirm this by running against the current code — this task's real regression check is Step 4 below, showing the same behavior after switching to index reads. Note this in the PR/commit description rather than expecting a red step here.
+
+- [ ] **Step 3: Rewrite `list_client_sessions()` to use the index**
+
+Replace lines 207-247 (`def list_client_sessions` through its `return sessions`):
+
+```python
+    def list_client_sessions(
+        self,
+        client_id: str,
+        status_filter: str | None = None
+    ) -> list[dict]:
+        """List all sessions for a client.
+
+        Reads the per-client session_index.json cache instead of opening every
+        session's session_info.json (see docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md).
+
+        Args:
+            client_id (str): Client ID
+            status_filter (str, optional): Filter by status ("active", "completed", etc.)
+
+        Returns:
+            List[Dict]: List of session info dictionaries, sorted by creation date (newest first)
+                Each dict contains session metadata including session_name, status, created_at
+        """
+        client_id = client_id.upper()
+        client_sessions_dir = self.sessions_root / f"CLIENT_{client_id}"
+
+        if not client_sessions_dir.exists():
+            return []
+
+        entries = self._read_index(client_sessions_dir)
+        if entries is None:
+            entries = self._rebuild_index(client_sessions_dir)
+        else:
+            actual_count = sum(1 for item in client_sessions_dir.iterdir() if item.is_dir())
+            if actual_count != len(entries):
+                entries = self._rebuild_index(client_sessions_dir)
+
+        sessions = []
+        for entry in entries:
+            session_info = dict(entry)
+            session_info["session_path"] = str(client_sessions_dir / session_info["session_name"])
+            if status_filter and session_info.get("status") != status_filter:
+                continue
+            sessions.append(session_info)
+
+        sessions.sort(key=lambda x: x.get("created_at", ""), reverse=True)
+        return sessions
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_session_manager.py -v`
+Expected: PASS (all tests in the file, including Task 1's and the pre-existing suite)
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest -v`
+Expected: PASS. Pay particular attention to any test that constructs a session folder by hand without going through `create_session()` (bypasses the index) — those should self-heal via the count-mismatch rebuild, but confirm no test asserts on `session_index.json` *not* existing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shopify_tool/session_manager.py tests/test_session_manager.py
+git commit -m "list_client_sessions: read from session index instead of scanning every session folder"
+```
+
+---
+
+### Task 3: Session browser — default to last 30 days, "Show older" toggle, stop refetching on every show
+
+**Files:**
+- Modify: `gui/session_browser_widget.py`
+- Test: `tests/test_session_browser_filter.py` (new — pure-function test, no Qt widgets needed)
+
+**Interfaces:**
+- Produces: module-level function `filter_sessions_by_age(sessions: list[dict], cutoff_days: int, now: datetime) -> list[dict]` in `gui/session_browser_widget.py`, used by `SessionBrowserWidget._populate_table()`.
+- Consumes: `SessionBrowserWidget.sessions_data` (already exists, list of dicts with `created_at` ISO strings, same shape `list_client_sessions()` returns per Task 2).
+
+- [ ] **Step 1: Write the failing test for the pure filter function**
+
+Create `tests/test_session_browser_filter.py`:
+
+```python
+"""Session browser's 30-day default view filter (no Qt needed — pure data)."""
+from datetime import datetime, timedelta
+
+from gui.session_browser_widget import filter_sessions_by_age
+
+
+def _session(days_old: int) -> dict:
+    created = (datetime.now().astimezone() - timedelta(days=days_old)).isoformat()
+    return {"session_name": f"session_{days_old}d", "created_at": created}
+
+
+class TestFilterSessionsByAge:
+    def test_keeps_sessions_within_cutoff(self):
+        sessions = [_session(5), _session(10)]
+        result = filter_sessions_by_age(sessions, cutoff_days=30, now=datetime.now().astimezone())
+        assert len(result) == 2
+
+    def test_drops_sessions_older_than_cutoff(self):
+        sessions = [_session(5), _session(45)]
+        result = filter_sessions_by_age(sessions, cutoff_days=30, now=datetime.now().astimezone())
+        assert len(result) == 1
+        assert result[0]["session_name"] == "session_5d"
+
+    def test_missing_created_at_is_kept_not_dropped(self):
+        # Never hide a session just because its date couldn't be parsed --
+        # that would silently disappear real data from the default view.
+        sessions = [{"session_name": "no_date"}]
+        result = filter_sessions_by_age(sessions, cutoff_days=30, now=datetime.now().astimezone())
+        assert len(result) == 1
+
+    def test_cutoff_none_returns_all_sessions(self):
+        sessions = [_session(5), _session(400)]
+        result = filter_sessions_by_age(sessions, cutoff_days=None, now=datetime.now().astimezone())
+        assert len(result) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_session_browser_filter.py -v`
+Expected: FAIL with `ImportError: cannot import name 'filter_sessions_by_age'`
+
+- [ ] **Step 3: Implement the filter function and wire it into the widget**
+
+Add near the top of `gui/session_browser_widget.py`, after the imports (after line 30's `logger = ...`):
+
+```python
+DEFAULT_SESSION_AGE_CUTOFF_DAYS = 30
+
+
+def filter_sessions_by_age(sessions: list, cutoff_days: int | None, now: datetime) -> list:
+    """Keep sessions created within the last `cutoff_days`. `cutoff_days=None`
+    disables filtering (the "Show older" state). Sessions with an unparsable
+    or missing created_at are kept -- never hide real data because of a
+    formatting issue in a single record.
+    """
+    if cutoff_days is None:
+        return list(sessions)
+    cutoff = now - timedelta(days=cutoff_days)
+    kept = []
+    for session in sessions:
+        created_at = session.get("created_at", "")
+        try:
+            created = datetime.fromisoformat(created_at)
+        except (ValueError, TypeError):
+            kept.append(session)
+            continue
+        if created >= cutoff:
+            kept.append(session)
+    return kept
+```
+
+Add the `timedelta` import — change line 8 from `from datetime import datetime` to:
+
+```python
+from datetime import datetime, timedelta
+```
+
+Add a "Show older" toggle button next to `refresh_btn` in `_init_ui()` (after line 138's `filter_layout.addWidget(self.refresh_btn)`):
+
+```python
+        self.show_older_btn = QPushButton("Show Older (30+ days)")
+        self.show_older_btn.setCheckable(True)
+        self.show_older_btn.setToolTip("Show sessions older than 30 days")
+        self.show_older_btn.toggled.connect(self._on_show_older_toggled)
+        filter_layout.addWidget(self.show_older_btn)
+```
+
+Add the toggle handler and a dirty-flag mechanism. Add to `__init__` (after line 106's `self.worker = None`):
+
+```python
+        self._show_older = False
+        self._is_dirty = True  # forces one load on first show
+```
+
+Add after `_apply_filter` (after line 432, before `_on_selection_changed`):
+
+```python
+    def _on_show_older_toggled(self, checked: bool):
+        """Toggling this only re-filters the already-loaded self.sessions_data --
+        no new file-server call, since the whole index is already in memory."""
+        self._show_older = checked
+        self._populate_table()
+
+    def mark_dirty(self):
+        """Call this whenever a session is created/updated for the client this
+        widget is currently showing, so the next showEvent() actually refreshes
+        instead of reusing a stale table."""
+        self._is_dirty = True
+```
+
+Change `_populate_table()`'s first two lines (currently lines 326-329) to filter before rendering:
+
+```python
+    def _populate_table(self):
+        """Populate the table with sessions data."""
+        cutoff_days = None if self._show_older else DEFAULT_SESSION_AGE_CUTOFF_DAYS
+        visible_sessions = filter_sessions_by_age(
+            self.sessions_data, cutoff_days, datetime.now().astimezone()
+        )
+        self.sessions_table.setSortingEnabled(False)
+        self.sessions_table.setRowCount(len(visible_sessions))
+
+        for row, session_info in enumerate(visible_sessions):
+```
+
+(the rest of the method body is unchanged — it already iterates `enumerate(...)`, just now over `visible_sessions` instead of `self.sessions_data`)
+
+Change `refresh_sessions()` to clear the dirty flag once a load starts (add right after the existing docstring, before the `if not self.current_client_id:` check at line 229):
+
+```python
+    def refresh_sessions(self):
+        """Reload sessions from the session manager."""
+        self._is_dirty = False
+        if not self.current_client_id:
+```
+
+Change `showEvent()` (currently line 546) to only refresh when dirty:
+
+```python
+    def showEvent(self, event):
+        """Refresh only if something changed since the last load -- avoids
+        re-fetching from the file server every time this widget becomes
+        visible with nothing new to show."""
+        super().showEvent(event)
+        if self._is_dirty:
+            self.refresh_sessions()
+```
+
+(Read the existing `showEvent()` body first — `Read gui/session_browser_widget.py` around line 546-554 — and replace its unconditional refresh call with the above, preserving any existing `super().showEvent(event)` call already there.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_session_browser_filter.py -v`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 5: Wire `mark_dirty()` where session data changes without the browser knowing**
+
+Session creation (`gui/actions_handler.py:78-92`) already calls `self.mw.session_browser.refresh_sessions()` directly right after `create_session()` succeeds (line 92) — that path needs no `mark_dirty()` call, it already forces a fresh load regardless of the dirty flag.
+
+The gap `mark_dirty()` actually closes: `gui/actions_handler.py:832-835` updates a session's `statistics.packing_lists_count`/`packing_lists` via `update_session_info()` after generating a packing-list report, but never tells the session browser — if that widget was already loaded and is later shown again (e.g. the user was on a different tab while the report was generated), it would display stale packing-list counts. Add the call right after the existing `update_session_info()` call:
+
+```python
+                            # Save updated statistics
+                            self.mw.session_manager.update_session_info(
+                                str(session_path), {"statistics": current_stats}
+                            )
+                            if hasattr(self.mw, "session_browser"):
+                                self.mw.session_browser.mark_dirty()
+
+                            self.log.info(
+                                f"Updated session statistics: {len(packing_lists_files)} packing lists"
+                            )
+```
+
+(This replaces lines 832-839, inserting the two new lines between the existing `update_session_info()` call and the existing `self.log.info(...)` line — no other lines in this block change.)
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/session_browser_widget.py gui/main_window_pyside.py tests/test_session_browser_filter.py
+git commit -m "Session browser: default to last 30 days, add Show Older toggle, avoid refetch on every show"
+```
+
+---
+
+### Task 4: Cache `load_client_config()` the same way `load_shopify_config()` is already cached
+
+**Files:**
+- Modify: `shopify_tool/profile_manager.py:881-925` (`load_client_config`), `:1477-1562` (`save_client_config`)
+- Test: `tests/test_profile_manager.py`
+
+**Interfaces:**
+- No signature change to `load_client_config()` or `save_client_config()`. Uses the existing `_config_cache: ClassVar[dict[str, tuple[dict, float]]]` (already defined at `profile_manager.py:73`), with a new cache-key prefix `client_` (parallel to the existing `shopify_` prefix used by `load_shopify_config`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_profile_manager.py`:
+
+```python
+class TestLoadClientConfigCaching:
+    def test_second_load_is_served_from_cache(self, profile_manager, monkeypatch):
+        profile_manager.create_client_profile("M", "Client")
+        first = profile_manager.load_client_config("M")
+        call_count = {"n": 0}
+        original_open = open
+
+        def counting_open(*args, **kwargs):
+            if "client_config.json" in str(args[0]):
+                call_count["n"] += 1
+            return original_open(*args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", counting_open)
+        second = profile_manager.load_client_config("M")
+        assert second == first
+        assert call_count["n"] == 0  # served from cache, file not reopened
+
+    def test_cache_invalidated_after_save(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        config = profile_manager.load_client_config("M")
+        config["client_name"] = "Renamed"
+        profile_manager.save_client_config("M", config)
+        reloaded = profile_manager.load_client_config("M")
+        assert reloaded["client_name"] == "Renamed"
+
+    def test_cache_reflects_external_mtime_change(self, profile_manager):
+        # Simulates another PC on the file server saving a change: same
+        # mtime-based invalidation load_shopify_config already relies on.
+        profile_manager.create_client_profile("M", "Client")
+        profile_manager.load_client_config("M")  # warm the cache
+        config_path = profile_manager.get_client_directory("M") / "client_config.json"
+        data = json.loads(config_path.read_text())
+        data["client_name"] = "Changed Externally"
+        config_path.write_text(json.dumps(data))
+        import os
+        import time
+        # Ensure a distinct mtime on filesystems with coarse mtime resolution.
+        newer = os.path.getmtime(config_path) + 1
+        os.utime(config_path, (newer, newer))
+        reloaded = profile_manager.load_client_config("M")
+        assert reloaded["client_name"] == "Changed Externally"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_profile_manager.py::TestLoadClientConfigCaching -v`
+Expected: `test_second_load_is_served_from_cache` FAILS (`call_count["n"] == 1`, not 0) since there's no cache yet. The other two should pass already (harmless to include — they lock in behavior the cache must not break).
+
+- [ ] **Step 3: Add mtime-based caching to `load_client_config()`, matching `load_shopify_config()`'s pattern**
+
+Read `shopify_tool/profile_manager.py:927-1002` (`load_shopify_config`) first to copy its exact cache-check/cache-store shape. Replace `load_client_config()` (lines 881-925) with:
+
+```python
+    def load_client_config(self, client_id: str) -> dict | None:
+        """Load general configuration for a client, with mtime-based caching.
+
+        Cache is invalidated by file mtime rather than TTL: no stale reads after
+        another PC saves a change, and no unnecessary re-reads while the file is
+        stable. Mirrors load_shopify_config()'s cache exactly.
+
+        Automatically migrates old configs to add ui_settings if missing.
+
+        Args:
+            client_id (str): Client ID
+
+        Returns:
+            Optional[Dict]: Configuration dictionary or None if not found
+        """
+        client_id = client_id.upper()
+        cache_key = f"{self.base_path}::client_{client_id}"
+        config_path = self.clients_dir / f"CLIENT_{client_id}" / "client_config.json"
+
+        if not config_path.exists():
+            logger.warning(f"Client config not found: CLIENT_{client_id}")
+            return None
+
+        try:
+            current_mtime = config_path.stat().st_mtime
+        except OSError:
+            current_mtime = None
+
+        if current_mtime is not None and cache_key in self._config_cache:
+            cached_data, cached_mtime = self._config_cache[cache_key]
+            if cached_mtime == current_mtime:
+                logger.debug(f"Using cached client config for {client_id}")
+                return cached_data.copy()
+
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                config = json.load(f)
+
+            # Check if migrations are needed
+            migrated = self._migrate_add_ui_settings(client_id, config)
+
+            if migrated:
+                # If config was migrated, save it immediately
+                self.save_client_config(client_id, config)
+                logger.info(f"Config migrations completed for CLIENT_{client_id}")
+                # save_client_config() invalidates cache_key; re-stat so this
+                # call still populates the cache with the post-migration mtime.
+                try:
+                    current_mtime = config_path.stat().st_mtime
+                except OSError:
+                    current_mtime = None
+
+            if current_mtime is not None:
+                self._config_cache[cache_key] = (config.copy(), current_mtime)
+
+            return config
+
+        except PermissionError:
+            logger.exception(
+                f"Permission denied reading client config for CLIENT_{client_id}"
+            )
+            return None
+        except json.JSONDecodeError:
+            logger.exception(f"Invalid JSON in client config for CLIENT_{client_id}")
+            return None
+        except Exception:
+            logger.exception(
+                f"Unexpected error loading client config for CLIENT_{client_id}",
+            )
+            return None
+```
+
+- [ ] **Step 4: Invalidate the cache in `save_client_config()`**
+
+In `save_client_config()`, find the `if success:` block (currently lines 1532-1537) and add the cache invalidation, matching `save_shopify_config()`'s pattern at line 1069-1071:
+
+```python
+                if success:
+                    # Invalidate cache
+                    cache_key = f"{self.base_path}::client_{client_id}"
+                    self._config_cache.pop(cache_key, None)
+
+                    logger.info(
+                        f"Client config saved successfully for CLIENT_{client_id} "
+                        f"(attempt {attempt + 1}/{max_retries})"
+                    )
+                    return True
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_profile_manager.py -v`
+Expected: PASS (all tests, including the new `TestLoadClientConfigCaching` class and every pre-existing test — this is a purely additive caching layer with no behavior change for callers)
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest -v`
+Expected: PASS. Watch specifically `tests/test_groups_manager.py` (its `get_clients_in_group()` calls `load_client_config()` per client — should still pass unchanged, just faster on repeat calls) and `tests/test_session_manager.py` (unaffected, different config file).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shopify_tool/profile_manager.py tests/test_profile_manager.py
+git commit -m "Cache load_client_config() with the same mtime pattern load_shopify_config() already uses"
+```
+
+---
+
+### Task 5: Move `on_client_changed()`'s IO off the GUI thread, drop the redundant duplicate load
+
+**Files:**
+- Modify: `gui/main_window_pyside.py:804-881`
+- Test: manual (see Step 4) — this task wires GUI-thread scheduling around already-tested `profile_manager`/`table_config_manager` calls; no new pure logic to unit test. Per the "lazy code without its check is unfinished" rule, the runnable check here is the manual verification in Step 4, since this task has no branch/loop/parser logic of its own to assert on — it only reorders where already-tested calls happen.
+
+**Interfaces:**
+- Consumes: `gui.worker.Worker(fn, *args, **kwargs)` (existing, `gui/worker.py:22`), `self.threadpool` (existing `QThreadPool`, `main_window_pyside.py:86`), `profile_manager.load_shopify_config`, `table_config_manager.load_config` (both already covered by existing tests — unchanged).
+- Produces: `MainWindow._load_client_data(client_id: str) -> tuple[dict | None, object]` — the new IO-only function run inside the `Worker`, returning `(shopify_config, table_config)`.
+
+- [ ] **Step 1: Extract the IO into a plain function with no UI calls**
+
+In `gui/main_window_pyside.py`, add a new method right before `on_client_changed` (before line 804):
+
+```python
+    def _load_client_data(self, client_id: str):
+        """Pure IO for a client switch -- no UI calls, safe to run in a Worker.
+
+        Returns (shopify_config, table_config). table_config is None if
+        table_config_manager isn't set up yet (mirrors the existing
+        `hasattr(self, "table_config_manager")` guard).
+        """
+        shopify_config = self.profile_manager.load_shopify_config(client_id)
+        table_config = None
+        if hasattr(self, "table_config_manager"):
+            table_config = self.table_config_manager.load_config(client_id)
+        return shopify_config, table_config
+```
+
+- [ ] **Step 2: Rewrite `on_client_changed()` to run that function in a `Worker`**
+
+Replace `on_client_changed()` (lines 804-881) with:
+
+```python
+    def on_client_changed(self, client_id: str):
+        """Handle client selection change.
+
+        Args:
+            client_id: Newly selected client ID
+        """
+        logger.info(f"Client changed to: {client_id}")
+
+        if hasattr(self, "statusBar"):
+            self.statusBar().showMessage(f"Loading CLIENT_{client_id}...", 5000)
+
+        if hasattr(self, "client_sidebar"):
+            self.client_sidebar.set_active_client(client_id)
+
+        if hasattr(self, "current_client_label"):
+            self.current_client_label.setText(f"CLIENT_{client_id}")
+
+        self.current_client_id = client_id
+
+        worker = Worker(self._load_client_data, client_id)
+        worker.signals.result.connect(
+            lambda result, cid=client_id: self._on_client_data_loaded(cid, result)
+        )
+        worker.signals.error.connect(self._on_client_data_load_error)
+        self.threadpool.start(worker)
+
+    def _on_client_data_loaded(self, client_id: str, result):
+        """Apply client-switch IO results to the UI (main thread only)."""
+        shopify_config, table_config = result
+
+        if client_id != self.current_client_id:
+            # User switched again before this load finished -- discard stale result.
+            logger.debug(f"Discarding stale client-load result for {client_id}")
+            return
+
+        if not shopify_config:
+            QMessageBox.warning(
+                self,
+                "Configuration Error",
+                f"Failed to load configuration for client {client_id}",
+            )
+            return
+
+        try:
+            self.current_client_config = shopify_config
+            if table_config is not None:
+                logger.info(f"Table configuration loaded for CLIENT_{client_id}")
+
+            # Clear currently loaded files (they're for different client)
+            self.orders_file_path = None
+            self.stock_file_path = None
+            self.orders_file_path_label.setText("No file loaded")
+            self.stock_file_path_label.setText("No file loaded")
+            self.orders_file_status_label.setText("")
+            self.stock_file_status_label.setText("")
+
+            # Clear session
+            self.session_path = None
+            if hasattr(self, "undo_manager"):
+                self.undo_manager.reset_for_session()
+            self.update_session_info_label()
+
+            # Update session browser to show this client's sessions
+            self.session_browser.set_client(client_id, auto_refresh=False)
+
+            # Update the Recent Sessions quick-pick in the right panel (Tab 1)
+            self.ui_manager.refresh_recent_sessions(client_id)
+
+            self.update_ui_state()
+
+            logger.info(f"Client {client_id} loaded successfully")
+
+            if hasattr(self, "statusBar"):
+                self.statusBar().showMessage(f"CLIENT_{client_id} loaded", 2000)
+
+        except Exception as e:
+            logger.exception("Error applying loaded client data")
+            QMessageBox.critical(self, "Error", f"Failed to change client: {e!s}")
+
+    def _on_client_data_load_error(self, error):
+        exctype, value, tb = error
+        logger.error(f"Error loading client data: {value}\n{tb}")
+        QMessageBox.critical(self, "Error", f"Failed to change client: {value!s}")
+```
+
+Note what was dropped versus the original: the second `self.load_client_config(client_id)` call (previously line 841, marked "for backward compatibility") is gone — `self.current_client_config` is now set directly from the `load_shopify_config()` result already fetched by `_load_client_data`, which is what that redundant call was duplicating.
+
+Confirm `Worker` is imported in this file (`from gui.worker import Worker`) — add it near the top if it's not already there (check the existing import block first; `gui/actions_handler.py` already imports it as `from gui.worker import Worker`, use the same import path).
+
+- [ ] **Step 3: Search for other callers of `self.load_client_config(` in this file**
+
+Run: `grep -n "load_client_config" gui/main_window_pyside.py`
+
+If `MainWindow.load_client_config()` (the method previously called for "backward compatibility") has no other callers left after this change, leave it in place (out of scope to remove unused methods not part of this task) — just confirm `on_client_changed`'s removal of the call doesn't break anything else that depended on a side effect of that call (read its body to check: does it set any instance attribute other threads/methods read? If yes, ensure `_on_client_data_loaded` sets that same attribute directly from `shopify_config` instead).
+
+- [ ] **Step 4: Manual verification**
+
+Run: `python gui_main.py` (or `python run_dev.py` against the dev fixture).
+- Switch between at least two clients (e.g. CLIENT_ALMADERM, CLIENT_HERBAR from `dev-server/`).
+- Confirm the client config, table columns, and recent-sessions list all update correctly for each.
+- Confirm the GUI does not freeze during the switch (drag the window while switching, on a client with a large `shopify_config.json` like CLIENT_WATERDROP, to feel responsiveness).
+- Switch clients twice in rapid succession; confirm no crash and the final UI state matches the *last* client selected (tests the stale-result guard in `_on_client_data_loaded`).
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest -v`
+Expected: PASS (no test directly calls `on_client_changed`, but confirm no import errors)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/main_window_pyside.py
+git commit -m "Move client-switch IO off the GUI thread, drop redundant duplicate config load"
+```
+
+---
+
+### Task 6: Move `ClientSidebar.refresh()`'s data gathering off the GUI thread
+
+**Files:**
+- Modify: `gui/client_sidebar.py:292-509`
+- Test: manual (see Step 5) — same rationale as Task 5: this task reorders existing, already-covered profile_manager/groups_manager calls around a thread boundary; it introduces one new pure function (`_gather_refresh_data`) worth a direct test since it's plain data logic with no Qt dependency.
+- Test: `tests/test_client_sidebar_refresh.py` (new)
+
+**Interfaces:**
+- Produces: `ClientSidebar._gather_refresh_data() -> dict` — no Qt objects, safe to run in a `Worker`. Shape:
+  ```python
+  {
+      "special_groups": dict,       # from groups_manager.load_groups()
+      "custom_groups": list[dict],  # from groups_manager.list_groups()
+      "all_clients": list[str],     # from profile_manager.list_clients()
+      "pinned_client_ids": set[str],
+      "group_members": dict[str, list[str]],   # group_id -> client_ids
+      "card_data": dict[str, dict], # client_id -> profile_manager.get_client_config_extended(client_id)
+  }
+  ```
+- Consumes: `_create_pinned_section`, `_create_group_section`, `_create_all_section`, `_create_client_card` (all modified in this task to accept the gathered data instead of calling `profile_manager`/`groups_manager` themselves).
+
+- [ ] **Step 1: Write the failing test for the data-gathering function**
+
+Create `tests/test_client_sidebar_refresh.py`. This needs a real `QApplication` instance because `ClientSidebar` is a `QWidget` even though `_gather_refresh_data()` itself touches no Qt state — use the `qtbot`-free minimal pattern already used elsewhere in this test suite (check `tests/conftest.py` for an existing `qapp`/`QApplication` fixture first; if none exists, add one scoped to this file):
+
+```python
+"""ClientSidebar's pure data-gathering step (no widget construction --
+must be safe to run off the GUI thread per this repo's threading rule)."""
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from gui.client_sidebar import ClientSidebar
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def sidebar(qapp, profile_manager, groups_manager):
+    return ClientSidebar(profile_manager, groups_manager)
+
+
+class TestGatherRefreshData:
+    def test_gather_includes_all_clients(self, sidebar, profile_manager):
+        profile_manager.create_client_profile("M", "Client M")
+        profile_manager.create_client_profile("N", "Client N")
+        data = sidebar._gather_refresh_data()
+        assert set(data["all_clients"]) == {"M", "N"}
+
+    def test_gather_flags_pinned_clients(self, sidebar, profile_manager):
+        profile_manager.create_client_profile("M", "Client M")
+        profile_manager.update_ui_settings("M", {"is_pinned": True})
+        data = sidebar._gather_refresh_data()
+        assert "M" in data["pinned_client_ids"]
+
+    def test_gather_returns_no_qt_objects(self, sidebar, profile_manager):
+        profile_manager.create_client_profile("M", "Client M")
+        data = sidebar._gather_refresh_data()
+        import json
+        json.dumps(data, default=str)  # must be plain-data serializable
+```
+
+Confirmed signatures: `ClientSidebar.__init__(self, profile_manager: ProfileManager, groups_manager: GroupsManager, parent=None)` (`gui/client_sidebar.py:169-174`) and `GroupsManager.__init__(self, base_path: str)` (`shopify_tool/groups_manager.py:48`) — `GroupsManager` takes a base path, not a `profile_manager`. If `conftest.py` has no `groups_manager` fixture, add one:
+
+```python
+@pytest.fixture
+def groups_manager(profile_manager):
+    from shopify_tool.groups_manager import GroupsManager
+    return GroupsManager(profile_manager.base_path)
+```
+
+Note `ClientSidebar.__init__` calls `self.refresh()` at the end of construction (`gui/client_sidebar.py:198`) — after this task, that means construction kicks off a background `Worker` rather than blocking; the widget starts with empty sections until the result arrives. This is expected (it's the whole point), just don't be surprised by it in the test or in Step 5's manual check.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_client_sidebar_refresh.py -v`
+Expected: FAIL — `AttributeError: 'ClientSidebar' object has no attribute '_gather_refresh_data'`
+
+- [ ] **Step 3: Implement `_gather_refresh_data()` and rewire the `_create_*` methods**
+
+Read `gui/client_sidebar.py:292-509` in full first (already read during planning — reproduced above) before editing, to preserve every existing line not called out below.
+
+Add `_gather_refresh_data()` right before `refresh()` (before line 292):
+
+```python
+    def _gather_refresh_data(self) -> dict:
+        """All the file-server IO refresh() needs, with zero Qt object
+        construction -- safe to run in a background Worker.
+        """
+        groups_data = self.groups_manager.load_groups()
+        special_groups = groups_data.get("special_groups", {})
+        custom_groups = self.groups_manager.list_groups()
+        all_clients = self.profile_manager.list_clients()
+
+        pinned_client_ids = set()
+        card_data = {}
+        for client_id in all_clients:
+            ui_settings = self.profile_manager.get_ui_settings(client_id)
+            if ui_settings.get("is_pinned", False):
+                pinned_client_ids.add(client_id)
+            card_data[client_id] = self.profile_manager.get_client_config_extended(client_id)
+
+        group_members = {}
+        for group in custom_groups:
+            group_id = group.get("id")
+            group_members[group_id] = self.groups_manager.get_clients_in_group(
+                group_id, self.profile_manager
+            )
+
+        return {
+            "special_groups": special_groups,
+            "custom_groups": custom_groups,
+            "all_clients": all_clients,
+            "pinned_client_ids": pinned_client_ids,
+            "group_members": group_members,
+            "card_data": card_data,
+        }
+```
+
+Replace `refresh()` (lines 292-395) to start a `Worker` running `_gather_refresh_data`, and move the widget-building portion into a new `_apply_refresh_data()`:
+
+```python
+    def refresh(self):
+        """Refresh client list and rebuild sections.
+
+        Data gathering runs off the GUI thread (Worker); section/card widget
+        construction stays on the GUI thread (Qt requirement) and happens in
+        _apply_refresh_data() once the data is ready.
+        """
+        self.refresh_btn.setEnabled(False)
+        worker = Worker(self._gather_refresh_data)
+        worker.signals.result.connect(self._apply_refresh_data)
+        worker.signals.error.connect(self._on_refresh_error)
+        QThreadPool.globalInstance().start(worker)
+
+    def _on_refresh_error(self, error):
+        exctype, value, tb = error
+        logger.error(f"Sidebar refresh failed: {value}\n{tb}")
+        self.refresh_btn.setEnabled(True)
+        QMessageBox.warning(self, "Refresh Error", f"Failed to refresh sidebar:\n{value!s}")
+
+    def _apply_refresh_data(self, data: dict):
+        """Build section/card widgets from already-fetched data (main thread only)."""
+        import time
+
+        theme = get_theme_manager().get_current_theme()
+
+        try:
+            overall_start = time.time()
+            logger.info("Applying sidebar refresh data")
+
+            self.setUpdatesEnabled(False)
+
+            while self.sections_layout.count() > 1:
+                item = self.sections_layout.takeAt(0)
+                if item.widget():
+                    item.widget().deleteLater()
+            self.client_cards.clear()
+
+            all_clients = data["all_clients"]
+            special_groups = data["special_groups"]
+            custom_groups = data["custom_groups"]
+            clients_in_sections = set()
+
+            # 1. Pinned section
+            pinned_config = special_groups.get("pinned", {})
+            pinned_section = self._create_pinned_section(all_clients, pinned_config, data)
+            if pinned_section.card_count() > 0:
+                self.sections_layout.insertWidget(self.sections_layout.count() - 1, pinned_section)
+                clients_in_sections.update(self._get_section_client_ids(pinned_section))
+
+            # 2. Custom groups
+            for group in custom_groups:
+                group_id = group.get("id")
+                group_name = group.get("name", "Unknown")
+                group_color = group.get("color", theme.accent_blue)
+                group_section = self._create_group_section(group_id, group_name, group_color, all_clients, data)
+                if group_section.card_count() > 0:
+                    self.sections_layout.insertWidget(self.sections_layout.count() - 1, group_section)
+                    clients_in_sections.update(self._get_section_client_ids(group_section))
+
+            # 3. All Clients section
+            all_config = special_groups.get("all", {})
+            remaining_clients = [c for c in all_clients if c not in clients_in_sections]
+            if remaining_clients:
+                all_section = self._create_all_section(remaining_clients, all_config, data)
+                self.sections_layout.insertWidget(self.sections_layout.count() - 1, all_section)
+
+            self.setUpdatesEnabled(True)
+
+            if self.active_client_id:
+                self.set_active_client(self.active_client_id)
+
+            overall_elapsed = (time.time() - overall_start) * 1000
+            logger.info(
+                f"Sidebar refresh applied: {len(all_clients)} clients, "
+                f"{len(custom_groups)} groups in {overall_elapsed:.1f}ms"
+            )
+
+        except Exception as e:
+            self.setUpdatesEnabled(True)
+            logger.exception("Failed to apply sidebar refresh data")
+            QMessageBox.warning(self, "Refresh Error", f"Failed to refresh sidebar:\n{e!s}")
+        finally:
+            self.refresh_btn.setEnabled(True)
+```
+
+Update `_create_pinned_section`, `_create_group_section`, `_create_all_section`, `_create_client_card` to take the pre-fetched `data` dict instead of calling `profile_manager`/`groups_manager`:
+
+```python
+    def _create_pinned_section(self, all_clients: list[str], config: dict, data: dict) -> SectionWidget:
+        theme = get_theme_manager().get_current_theme()
+        section = SectionWidget(
+            config.get("name", "Pinned"),
+            config.get("color", theme.accent_orange)
+        )
+        for client_id in all_clients:
+            if client_id in data["pinned_client_ids"]:
+                card = self._create_client_card(client_id, data)
+                section.add_card(card)
+        return section
+
+    def _create_group_section(
+        self,
+        group_id: str,
+        group_name: str,
+        group_color: str,
+        all_clients: list[str],
+        data: dict,
+    ) -> SectionWidget:
+        section = SectionWidget(group_name, group_color)
+        clients_in_group = data["group_members"].get(group_id, [])
+        for client_id in clients_in_group:
+            if client_id in all_clients:
+                card = self._create_client_card(client_id, data)
+                section.add_card(card)
+        return section
+
+    def _create_all_section(self, clients: list[str], config: dict, data: dict) -> SectionWidget:
+        theme = get_theme_manager().get_current_theme()
+        default_color = theme.border
+        section = SectionWidget(
+            config.get("name", "All Clients"),
+            config.get("color", default_color)
+        )
+        for client_id in clients:
+            card = self._create_client_card(client_id, data)
+            section.add_card(card)
+        return section
+
+    def _create_client_card(self, client_id: str, data: dict) -> ClientCard:
+        config = data["card_data"][client_id]
+
+        client_name = config.get("client_name", f"CLIENT_{client_id}")
+        metadata = config.get("metadata", {})
+        ui_settings = config.get("ui_settings", {})
+
+        is_active = (client_id == self.active_client_id)
+
+        card = ClientCard(
+            client_id=client_id,
+            client_name=client_name,
+            metadata=metadata,
+            ui_settings=ui_settings,
+            is_active=is_active
+        )
+        card.client_selected.connect(self.client_selected.emit)
+        card.context_menu_requested.connect(self._show_context_menu)
+
+        if client_id not in self.client_cards:
+            self.client_cards[client_id] = []
+        self.client_cards[client_id].append(card)
+
+        return card
+```
+
+Confirmed via `grep -n "_create_client_card\|_create_pinned_section\|_create_group_section\|_create_all_section" gui/client_sidebar.py`: the only callers of these four methods are inside `refresh()`'s own body (now `_apply_refresh_data()`, already updated above) — no other call sites exist, so no further updates are needed elsewhere in the file.
+
+Ensure `QThreadPool` and `Worker` are imported at the top of `gui/client_sidebar.py`:
+
+```python
+from PySide6.QtCore import QThreadPool
+from gui.worker import Worker
+```
+
+(check existing imports first and merge rather than duplicate)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_client_sidebar_refresh.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Manual verification**
+
+Run: `python run_dev.py`.
+- Confirm the sidebar populates correctly on startup (pinned/groups/all sections, correct client names and metadata).
+- Pin/unpin a client, create a custom group and move a client into it, confirm sections update correctly after each action (each of these already calls `refresh()` per the existing code — confirm they still work through the new async path).
+- Confirm no UI freeze (or a much shorter one) during refresh, and no crash/warning in the console about cross-thread widget access.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/client_sidebar.py tests/test_client_sidebar_refresh.py
+git commit -m "Move ClientSidebar.refresh() data gathering to a background Worker"
+```
+
+---
+
+### Task 7: Wrap config save calls in a Worker so Save doesn't block on lock-retry
+
+**Files:**
+- Modify: `gui/client_settings_dialog.py:599-633` (`_save_and_accept`)
+- Modify: `gui/settings_window_pyside.py:2975-3271` (`save_settings`)
+- Test: manual (see Step 4) — both changes wrap already-tested `profile_manager.save_*` calls in a `Worker`; no new branching logic to unit test.
+
+**Interfaces:**
+- Consumes: `gui.worker.Worker`, `QThreadPool.globalInstance()` (matching the convention already used in `gui/barcode_generator_widget.py:390`, `gui/sku_label_widget.py:351`, `gui/reference_labels_widget.py:430`, `gui/client_reports_widget.py:290`).
+
+- [ ] **Step 1: Wrap `client_settings_dialog.py`'s save call**
+
+This dialog uses a `QDialogButtonBox` (`gui/client_settings_dialog.py:413-418`), not a standalone `QPushButton` — there is no `save_btn` attribute today. Confirmed via `grep -n "QDialogButtonBox\|_save_and_accept" gui/client_settings_dialog.py`:
+
+```python
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.Save | QDialogButtonBox.Cancel
+        )
+        button_box.accepted.connect(self._save_and_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+```
+
+Change this block (still at construction time, lines 413-418) to keep a reference to the Save button so the new save handlers below can disable/relabel it:
+
+```python
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.Save | QDialogButtonBox.Cancel
+        )
+        self.save_button = button_box.button(QDialogButtonBox.Save)
+        button_box.accepted.connect(self._save_and_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+```
+
+Read `gui/client_settings_dialog.py:599-640` in full first (already read during planning) to preserve the exact surrounding structure. Replace `_save_and_accept()` (lines 599-633, plus whatever the `except` block at 635+ contains) with:
+
+```python
+    def _save_and_accept(self):
+        """Gather form data on the GUI thread, save in the background."""
+        try:
+            self.config["client_name"] = self.client_name_input.text().strip()
+            self.config["ui_settings"]["is_pinned"] = self.pin_checkbox.isChecked()
+            self.config["ui_settings"]["group_id"] = self.group_combo.currentData()
+            self.config["ui_settings"]["custom_color"] = self.current_color
+
+            badges_text = self.badges_input.text().strip()
+            if badges_text:
+                badges = [b.strip() for b in badges_text.split(",") if b.strip()]
+            else:
+                badges = []
+            self.config["ui_settings"]["custom_badges"] = badges
+
+            self.save_button.setEnabled(False)
+            self.save_button.setText("Saving...")
+
+            worker = Worker(self.profile_manager.save_client_config, self.client_id, self.config)
+            worker.signals.result.connect(self._on_save_result)
+            worker.signals.error.connect(self._on_save_error)
+            QThreadPool.globalInstance().start(worker)
+
+        except Exception as e:
+            logger.exception("Failed to save client settings")
+            QMessageBox.critical(
+                self,
+                "Error",
+                f"Failed to save client settings:\n{e!s}",
+            )
+
+    def _on_save_result(self, success: bool):
+        self.save_button.setEnabled(True)
+        self.save_button.setText("Save")
+        if success:
+            QMessageBox.information(
+                self,
+                "Success",
+                f"Settings for CLIENT_{self.client_id} saved successfully!"
+            )
+            self.accept()
+        else:
+            QMessageBox.warning(
+                self,
+                "Save Failed",
+                "Failed to save client settings. Please try again."
+            )
+
+    def _on_save_error(self, error):
+        exctype, value, tb = error
+        logger.error(f"Failed to save client settings: {value}\n{tb}")
+        self.save_button.setEnabled(True)
+        self.save_button.setText("Save")
+        QMessageBox.critical(self, "Error", f"Failed to save client settings:\n{value!s}")
+```
+
+Ensure imports at the top of the file include:
+
+```python
+from PySide6.QtCore import QThreadPool
+from gui.worker import Worker
+```
+
+- [ ] **Step 2: Wrap `settings_window_pyside.py`'s save call**
+
+This dialog also uses a `QDialogButtonBox` (`gui/settings_window_pyside.py:224-227`), no standalone Save `QPushButton`:
+
+```python
+        button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        button_box.accepted.connect(self.save_settings)
+        button_box.rejected.connect(self.reject)
+        main_layout.addWidget(button_box)
+```
+
+Change it the same way, to keep a reference to the Save button:
+
+```python
+        button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        self.save_button = button_box.button(QDialogButtonBox.Save)
+        button_box.accepted.connect(self.save_settings)
+        button_box.rejected.connect(self.reject)
+        main_layout.addWidget(button_box)
+```
+
+(There is a second, unrelated `QDialogButtonBox` at `gui/settings_window_pyside.py:3537` inside a different dialog class in the same file, for set-component validation — leave that one alone; it belongs to `_validate_and_save`, not `save_settings`.)
+
+Read `gui/settings_window_pyside.py:2975-3271` in full first (the complete `save_settings()` method — most of it is synchronous form-gathering across many tabs, already read in part above). The only change needed: keep every existing form-gathering line (2975-3227) exactly as-is — all of that reads Qt widgets and must stay on the GUI thread — and change just the save+response section (lines 3225-3271, currently):
+
+```python
+            # ========================================
+            # Save to server via ProfileManager
+            # ========================================
+            success = self.profile_manager.save_shopify_config(
+                self.client_id,
+                self.config_data
+            )
+
+            if success:
+                QMessageBox.information(...)
+                self.accept()
+            else:
+                ...(diagnostic QMessageBox)...
+
+        except ValueError as e:
+            ...
+        except Exception as e:
+            ...
+```
+
+to:
+
+```python
+            # ========================================
+            # Save to server via ProfileManager (background -- avoids blocking
+            # the GUI thread on the lock-contention retry sleep)
+            # ========================================
+            self.save_button.setEnabled(False)
+            self.save_button.setText("Saving...")
+
+            worker = Worker(self.profile_manager.save_shopify_config, self.client_id, self.config_data)
+            worker.signals.result.connect(self._on_save_settings_result)
+            worker.signals.error.connect(self._on_save_settings_error)
+            QThreadPool.globalInstance().start(worker)
+
+        except ValueError as e:
+            QMessageBox.critical(
+                self,
+                "Validation Error",
+                f"Invalid value entered:\n\n{e!s}\n\nPlease check your inputs."
+            )
+        except Exception as e:
+            import traceback
+            QMessageBox.critical(
+                self,
+                "Error",
+                f"Failed to save settings:\n\n{e!s}\n\n{traceback.format_exc()}"
+            )
+
+    def _on_save_settings_result(self, success: bool):
+        self.save_button.setEnabled(True)
+        self.save_button.setText("Save")
+        if success:
+            QMessageBox.information(self, "Success", "Settings saved successfully!")
+            self.accept()
+        else:
+            import json
+            config_size = len(json.dumps(self.config_data, ensure_ascii=False))
+            num_sets = len(self.config_data.get("set_decoders", {}))
+            QMessageBox.critical(
+                self,
+                "Save Error",
+                f"Failed to save settings to server.\n\n"
+                f"Configuration size: {config_size:,} bytes\n"
+                f"Number of sets: {num_sets}\n\n"
+                f"Possible causes:\n"
+                f"• File is locked by another user\n"
+                f"• Network connection issue\n"
+                f"• Insufficient permissions\n\n"
+                f"Please wait a few seconds and try again."
+            )
+
+    def _on_save_settings_error(self, error):
+        exctype, value, tb = error
+        logger.error(f"Failed to save settings: {value}\n{tb}")
+        self.save_button.setEnabled(True)
+        self.save_button.setText("Save")
+        QMessageBox.critical(self, "Error", f"Failed to save settings:\n\n{value!s}")
+```
+
+Ensure `QThreadPool` and `Worker` are imported (check existing imports; `gui/settings_window_pyside.py` likely already imports several PySide6 QtCore names).
+
+- [ ] **Step 3: Confirm `ValueError`/validation still happens before the async save starts**
+
+Re-read the full pre-save portion of `save_settings()` (lines 2975-3224) to confirm no `ValueError` can be raised *after* the `Worker` is started (it shouldn't be, since all validation happens while gathering `self.config_data` from widgets, before the save call) — if any validation logic was interleaved after the old synchronous save call in the original code, move it before the `Worker` construction so it still runs on the GUI thread and still blocks accept() on failure.
+
+- [ ] **Step 4: Manual verification**
+
+Run: `python run_dev.py`.
+- Open Client Settings for a client, change a value, click Save. Confirm the button shows "Saving..." briefly, then the dialog closes with the success message, and the GUI doesn't freeze during the save.
+- Repeat for the full Settings window (`settings_window_pyside.py`) — change something on one tab, Save, confirm same behavior.
+- Force a save conflict if feasible (e.g. hold `client_config.json.lock`/`shopify_config.json`'s lock open in another process) to confirm the retry-sleep now happens without freezing the window, and the error path still shows the diagnostic dialog correctly.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/client_settings_dialog.py gui/settings_window_pyside.py
+git commit -m "Run client/shopify config save in a background Worker instead of blocking the GUI thread"
+```
+
+---
+
+### Task 8: Update the knowledge graph and do a final full-suite pass
+
+**Files:** none (tooling only)
+
+- [ ] **Step 1: Update the graphify knowledge graph**
+
+Run: `graphify update .`
+
+This repo's `CLAUDE.md` requires this after code changes — a stale graph silently returns wrong answers about file relationships in future sessions.
+
+- [ ] **Step 2: Run the full test suite one final time**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest -v`
+Expected: PASS, all tests across all 7 tasks.
+
+- [ ] **Step 3: Run lint**
+
+Check `.github/workflows/build_release.yml` for the exact lint command this repo's CI uses (mentioned in `CLAUDE.md`: "CI runs lint + this suite + a headless smoke test") and run it locally; fix any findings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "Update graphify knowledge graph after UI responsiveness changes"
+```

--- a/docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md
+++ b/docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md
@@ -84,36 +84,52 @@ documented, designed-for scenario per `packing-tool/README.md`).
 
 ## Workstream 1 — Session index
 
-Add `Sessions/CLIENT_{ID}/session_index.json`: a JSON array of small per-session summaries
-(`session_name`, `created_at`, `status`) maintained incrementally instead of rebuilt from a
-folder scan on every read. `session_info.json` has no separate `session_id` field —
-`shared/session_id.py::derive_session_id()` defines the session id as the folder name, i.e.
-`session_name` — so the index uses `session_name` as its key, matching directory iteration.
+Add `Sessions/CLIENT_{ID}/session_index.json`: a JSON array where each entry **mirrors the full
+per-session dict `get_session_info()` already returns** (`session_name`, `status`, `created_at`,
+`statistics`, `comments`, `pc_name`, etc. — everything except the synthetic `session_path`,
+which is derived as `client_sessions_dir / session_name`), keyed by `session_name`.
+`session_info.json` has no separate `session_id` field — `shared/session_id.py::derive_session_id()`
+defines the session id as the folder name, i.e. `session_name` — so the index uses that as its key.
 
-- **Write path**: hook index maintenance into the three functions in
-  `shopify_tool/session_manager.py` that already own writes to `session_info.json`'s top-level
-  fields under the existing `_locked_session_info()` lock — `create_session()` (append an
-  entry), `update_session_status()` (update the entry keyed by `session_name`),
-  `update_session_info()` (update the entry keyed by `session_name`, only if the update touches
-  `status`). Because these are the *only* writers of the fields the index tracks (confirmed
-  above), the index can't drift from normal operation. The index file itself gets its own
-  sidecar lock (`session_index.json.lock`), following the exact pattern
-  `_locked_session_info()` already uses, to stay correct under concurrent writes from multiple
-  PCs.
+A smaller summary (just `session_name`/`created_at`/`status`) was considered first, but the
+session browser table's Orders/Items/Packing Lists/Comments columns are populated from
+`statistics`/`comments`, which change on their own schedule — a packing-list report regenerates
+`statistics.packing_lists_count` (`gui/actions_handler.py:834`), analysis completion sets
+`statistics.total_orders`/`total_items` (`shopify_tool/core.py:1009`), and inline edits set
+`comments` (`gui/session_browser_widget.py:520`) — a summary-only index would go stale on the
+columns users look at most. Mirroring the full record avoids that: every one of those writers
+already goes through `update_session_info()`/`append_to_session_list()`, so the index entry can
+be refreshed with the exact dict just written, by construction, not re-derived from partial data.
+
+- **Write path**: hook index maintenance into the four functions in
+  `shopify_tool/session_manager.py` that already own every write to `session_info.json`'s
+  top-level fields — `create_session()` (append), and, under the existing
+  `_locked_session_info()` lock, `update_session_status()`, `update_session_info()`,
+  `append_to_session_list()` (replace the entry keyed by `session_name` with the dict just
+  written). Because these are confirmed to be the *only* writers of the fields the index
+  carries, the index can't drift from normal operation. The index file gets its own sidecar
+  lock (`session_index.json.lock`), reusing the same lock primitive `_locked_session_info()`
+  already uses (generalized into a small shared `_exclusive_lock(path)` helper), to stay correct
+  under concurrent writes from multiple PCs. An index-write failure is logged and swallowed, not
+  raised — the index is a cache, and a failed cache update must not fail the underlying
+  `session_info.json` write it's mirroring.
 - **Read path**: `list_client_sessions()` reads `session_index.json` directly instead of
   iterating the directory and opening every session's JSON. If the index file doesn't exist
   (first run against existing data), do the current full scan once, write the index, and use it
   from then on — self-healing, no explicit migration script.
 - **Staleness guard**: before trusting the index, compare its entry count against a cheap
   `iterdir()` directory count (no JSON opens). On mismatch (manual folder add/delete/restore),
-  rebuild the index via the full scan. This keeps the guard itself cheap.
+  rebuild the index via the full scan. This keeps the guard itself cheap. (A count match doesn't
+  prove per-entry freshness, but per-entry freshness is already guaranteed by the write-path
+  argument above — the count check only catches folders added/removed outside this code, e.g.
+  manual copy or delete.)
 - **Default view / "archive" behavior**: `SessionBrowserWidget` filters the loaded index to the
   last 30 days client-side by default; a "Show older" control lifts the filter over the same
   already-loaded list — no additional file-server round trip, since the whole index is cheap to
   read at this scale.
-- Full `statistics` (computed via `calculate_session_statistics()`,
-  `shopify_tool/session_manager.py:600-654`) stays lazy — computed only when a session is
-  actually opened, not stored in the index, so the index stays small.
+- Legacy sessions predating this feature (or the `statistics` field) get their `statistics`
+  filled in the usual way — `get_session_info()`'s existing backward-compat computation
+  (`shopify_tool/session_manager.py:301-302`) — once, at index-build time, not per read.
 
 ## Workstream 2 — Consistent worker usage, caching, dedup
 
@@ -134,9 +150,18 @@ main thread.
   `result` signal. Drop the redundant second `load_client_config()` call currently marked
   "backward compatibility" — with `load_shopify_config()`'s result already available, that
   second load is fetching data already in hand.
-- **`ClientSidebar.refresh()`**: move the group/client/pin-status/metadata gathering into a
-  `Worker`; apply the built sidebar model to the UI from its `result` signal, replacing the
-  wait-cursor.
+- **`ClientSidebar.refresh()`**: per this repo's "no UI calls from background threads" rule,
+  `_create_pinned_section()`/`_create_group_section()`/`_create_all_section()`/
+  `_create_client_card()` (which construct `SectionWidget`/`ClientCard` QWidgets) must stay on
+  the GUI thread — only the data they read (`groups_manager.load_groups()`,
+  `profile_manager.list_clients()`, per-client `get_ui_settings()`, per-group
+  `get_clients_in_group()`, per-client `get_client_config_extended()`) can move off it. Split
+  `refresh()` into a new data-only method (no Qt objects, safe to run in a `Worker`) that
+  prefetches all of the above into plain dicts, and change the four `_create_*` methods to take
+  that prefetched data as a parameter instead of calling `profile_manager`/`groups_manager`
+  themselves. `refresh()` becomes: start the `Worker`, and on its `result` signal, run the
+  existing widget-clearing + `_create_*` calls (now reading from the passed-in data) on the main
+  thread, replacing the wait-cursor.
 - **Config save**: wrap `save_client_config()`/`save_shopify_config()` calls in a `Worker`;
   disable the Save button and show a small "Saving…" state until the `finished` signal fires.
   This also removes the up-to-2.5s retry-sleep block as a side effect, since the sleep now

--- a/docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md
+++ b/docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md
@@ -1,0 +1,172 @@
+# UI Responsiveness on Slow File Server — Design
+
+## Problem
+
+The app's only persistence is a network file server (UNC share), and it's slow. Several
+user-facing actions block the GUI thread while they do file-server IO:
+
+- **Session browser**: already loads sessions off the GUI thread (`SessionLoaderWorker` in
+  `gui/session_browser_widget.py:33`), but `SessionManager.list_client_sessions()`
+  (`shopify_tool/session_manager.py:207-247`) does a full `iterdir()` over the client's session
+  directory and opens **one JSON file per session** every single call — no cache, no index.
+  `showEvent()` (`gui/session_browser_widget.py:546`) also re-triggers this on every time the
+  widget becomes visible, even with nothing changed.
+- **Client switching**: `on_client_changed()` (`gui/main_window_pyside.py:804-881`) runs
+  synchronously on the GUI thread and reads the same client's config three times (once via
+  `profile_manager.load_shopify_config()` at line 829, again via `self.load_client_config()` at
+  line 841 — explicitly commented "for backward compatibility" — and again inside
+  `table_config_manager.load_config()` at line 845). It also calls
+  `ui_manager.refresh_recent_sessions()` (`gui/ui_manager.py:339-350`), which calls the same
+  unpaginated `list_client_sessions()` from above and throws away all but 5 results.
+- **Sidebar refresh**: `ClientSidebar.refresh()` (`gui/client_sidebar.py:292-395`) runs
+  synchronously (wait-cursor only) and calls `profile_manager.load_client_config()` — which has
+  **no cache** — once per client for pin-status, again per client per custom group for group
+  membership, and again per client when building each card: O(N) to O(G·N) uncached network
+  reads per refresh.
+- **Config save**: `_save_and_accept()` (`gui/client_settings_dialog.py:599-633`) and the
+  Client Settings "Save" handler (`gui/settings_window_pyside.py:3228`) call
+  `profile_manager.save_client_config()` / `save_shopify_config()` directly and synchronously.
+  Those methods retry on lock contention up to 5 times with `time.sleep(0.5)`
+  (`shopify_tool/profile_manager.py`, `save_shopify_config()`/`save_client_config()`) — up to
+  ~2.5s of blocking sleep on the GUI thread in the worst case — and do a synchronous backup
+  copy + prune before the write.
+
+Scale: dozens of clients, hundreds of sessions per client, 1-3 concurrent users. This does not
+justify new infrastructure (a local DB mirror, a caching service) — it justifies applying
+patterns already proven in this codebase more consistently, plus one small incremental index.
+
+## Goals
+
+1. Session browser's default view loads in roughly one file read, not N.
+2. "Switch client" and "save config" don't freeze the GUI.
+3. No new dependencies, no new architectural layer, no data migration.
+
+## Non-goals
+
+- Physically moving old sessions into an `Archive/` folder. An index makes the same "fast
+  default view, browse older on demand" outcome achievable without moving any files, and
+  without touching every place that currently references a session path.
+- A local disk/sqlite mirror of file-server state. Overkill at hundreds of sessions and
+  1-3 concurrent users; revisit only if scale grows an order of magnitude.
+- Merging `profile_manager.py`'s hand-rolled atomic write with `shared/atomic_write.py`'s
+  `atomic_write_json()`. Real duplication, found during investigation, but unrelated to this
+  goal — separate follow-up.
+- Any change to `packing-tool` or `shared/` (which is one-way synced from `packing-tool` and
+  must not be hand-edited from this repo, per this repo's `CLAUDE.md`).
+
+## Cross-tool compatibility (verified, not assumed)
+
+`packing-tool` also reads/writes inside a session folder (`Sessions/CLIENT_{ID}/{session}/`),
+via its `SessionManager.update_session_metadata()`
+(`packing-tool/src/session_manager.py:671-714`). Confirmed by reading that code and the dev
+fixture data:
+
+- It only ever writes a nested `session_info['packing_progress'][list_name]` block. It never
+  reads or writes the top-level `status`/`created_at`/`session_name` fields that
+  shopify-fulfillment-tool owns and that the new index will track.
+- It does not use shopify-fulfillment-tool's `session_info.json.lock` protocol
+  (`shopify_tool/session_manager.py:249-276`) — a pre-existing lost-update race between the two
+  tools' writes to `session_info.json` exists independent of this work. Out of scope here.
+- `packing-tool` maintains its own analogous incremental index,
+  `Sessions/CLIENT_{ID}/registry_index.json` (`packing-tool/src/session_registry_manager.py`),
+  keyed per packing-list rather than per session, updated via targeted mutation on each event
+  with a one-time full-scan migration if the file is missing
+  (`SessionRegistryManager.build_from_scan()`, called only from `ensure_registry()` when
+  `registry_index.json` doesn't exist yet). This validates the incremental-index approach below
+  against the same file server, but its schema doesn't fit shopify-fulfillment-tool's
+  per-session listing need, so it isn't reused directly — a separate, differently-named file
+  avoids any collision.
+
+Conclusion: `session_index.json` is exclusively owned and written by shopify-fulfillment-tool.
+No coordination with `packing-tool` is required for this design; the only concurrency to guard
+against is **multiple shopify-fulfillment-tool instances** on different warehouse PCs (a
+documented, designed-for scenario per `packing-tool/README.md`).
+
+## Workstream 1 — Session index
+
+Add `Sessions/CLIENT_{ID}/session_index.json`: a JSON array of small per-session summaries
+(`session_name`, `created_at`, `status`) maintained incrementally instead of rebuilt from a
+folder scan on every read. `session_info.json` has no separate `session_id` field —
+`shared/session_id.py::derive_session_id()` defines the session id as the folder name, i.e.
+`session_name` — so the index uses `session_name` as its key, matching directory iteration.
+
+- **Write path**: hook index maintenance into the three functions in
+  `shopify_tool/session_manager.py` that already own writes to `session_info.json`'s top-level
+  fields under the existing `_locked_session_info()` lock — `create_session()` (append an
+  entry), `update_session_status()` (update the entry keyed by `session_name`),
+  `update_session_info()` (update the entry keyed by `session_name`, only if the update touches
+  `status`). Because these are the *only* writers of the fields the index tracks (confirmed
+  above), the index can't drift from normal operation. The index file itself gets its own
+  sidecar lock (`session_index.json.lock`), following the exact pattern
+  `_locked_session_info()` already uses, to stay correct under concurrent writes from multiple
+  PCs.
+- **Read path**: `list_client_sessions()` reads `session_index.json` directly instead of
+  iterating the directory and opening every session's JSON. If the index file doesn't exist
+  (first run against existing data), do the current full scan once, write the index, and use it
+  from then on — self-healing, no explicit migration script.
+- **Staleness guard**: before trusting the index, compare its entry count against a cheap
+  `iterdir()` directory count (no JSON opens). On mismatch (manual folder add/delete/restore),
+  rebuild the index via the full scan. This keeps the guard itself cheap.
+- **Default view / "archive" behavior**: `SessionBrowserWidget` filters the loaded index to the
+  last 30 days client-side by default; a "Show older" control lifts the filter over the same
+  already-loaded list — no additional file-server round trip, since the whole index is cheap to
+  read at this scale.
+- Full `statistics` (computed via `calculate_session_statistics()`,
+  `shopify_tool/session_manager.py:600-654`) stays lazy — computed only when a session is
+  actually opened, not stored in the index, so the index stays small.
+
+## Workstream 2 — Consistent worker usage, caching, dedup
+
+No new pattern. `gui/worker.py`'s `Worker(QRunnable)` + `WorkerSignals` (`result`/`error`/
+`finished`, run via `QThreadPool.globalInstance()`) already exists and is used in
+`gui/actions_handler.py:171` and others — reuse it for the flows below instead of running them
+on the GUI thread. Per this repo's `CLAUDE.md`, no UI calls happen from inside worker `run()`
+bodies; results are applied to the UI only from the `result`/`error` signal handlers on the
+main thread.
+
+- **Cache `load_client_config()`**: copy the exact mtime-cache shape
+  `load_shopify_config()`/`save_shopify_config()` already use (`_config_cache` class dict,
+  keyed `f"{base_path}::client_{client_id}"`, invalidated on `save_client_config()`). Removes
+  most of the sidebar's and client-switch's redundant reads without adding a new caching
+  mechanism.
+- **`on_client_changed()`**: move the IO (`load_shopify_config`, `load_client_config`,
+  `table_config_manager.load_config`) into one `Worker` call; apply results to the UI from its
+  `result` signal. Drop the redundant second `load_client_config()` call currently marked
+  "backward compatibility" — with `load_shopify_config()`'s result already available, that
+  second load is fetching data already in hand.
+- **`ClientSidebar.refresh()`**: move the group/client/pin-status/metadata gathering into a
+  `Worker`; apply the built sidebar model to the UI from its `result` signal, replacing the
+  wait-cursor.
+- **Config save**: wrap `save_client_config()`/`save_shopify_config()` calls in a `Worker`;
+  disable the Save button and show a small "Saving…" state until the `finished` signal fires.
+  This also removes the up-to-2.5s retry-sleep block as a side effect, since the sleep now
+  happens off the GUI thread.
+- **One-line fix**: call `profile_manager.invalidate_metadata_cache()` after
+  `SessionManager.create_session()` succeeds — currently missing, so a newly created session's
+  count doesn't show up in the sidebar for up to `METADATA_CACHE_TIMEOUT_SECONDS` (5 minutes).
+- **`showEvent()` fix** (`gui/session_browser_widget.py:546`): only call `refresh_sessions()` if
+  a dirty flag is set (set when a session is created/updated for the currently-displayed
+  client) rather than unconditionally on every show.
+
+## Error handling
+
+- Index rebuild-on-mismatch (Workstream 1) covers a corrupted or manually-edited index: worst
+  case is one full-scan rebuild, not silent wrong data.
+- `Worker`'s existing `error` signal path (already wired in current consumers, e.g.
+  `gui/actions_handler.py:171`) is reused as-is for the newly-wrapped flows — errors surface via
+  the same `QMessageBox`-on-error pattern already in use, not swallowed.
+- Background workers follow the existing `BackgroundWorker.cleanup()` lifecycle
+  (`gui/background_worker.py:28-192`: disconnect signals → `quit()` → `wait(2000)` →
+  `terminate()` fallback → `deleteLater()`) where `BackgroundWorker` is used; `Worker`
+  (`QRunnable`) instances are pooled by `QThreadPool` and don't need the same teardown.
+
+## Testing
+
+- Extend `tests/test_session_manager.py`: index built on first run from an existing session
+  directory with no index file, updated on `create_session`/`update_session_status`/
+  `update_session_info`, rebuilt on a deliberately introduced count mismatch, 30-day filter
+  applied correctly.
+- Extend `tests/test_profile_manager.py`: `load_client_config()` cache hit on unchanged mtime,
+  cache invalidated after `save_client_config()`, mirroring whatever existing test coverage
+  `load_shopify_config()`'s cache already has.
+- No new test framework or fixtures — extend the existing files with the existing patterns.

--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -833,6 +833,8 @@ class ActionsHandler(QObject):
                             self.mw.session_manager.update_session_info(
                                 str(session_path), {"statistics": current_stats}
                             )
+                            if hasattr(self.mw, "session_browser"):
+                                self.mw.session_browser.mark_dirty()
 
                             self.log.info(
                                 f"Updated session statistics: {len(packing_lists_files)} packing lists"

--- a/gui/client_settings_dialog.py
+++ b/gui/client_settings_dialog.py
@@ -363,6 +363,7 @@ class ClientSettingsDialog(QDialog):
         self.profile_manager = profile_manager
         self.groups_manager = groups_manager
         self._save_worker = None  # keeps the in-flight save Worker alive
+        self._is_saving = False
 
         self.setWindowTitle(f"Client Settings - CLIENT_{client_id}")
         self.setModal(True)
@@ -599,6 +600,11 @@ class ClientSettingsDialog(QDialog):
             f"background-color: {color_hex}; border: 1px solid {theme.border_subtle};"
         )
 
+    def reject(self):
+        if self._is_saving:
+            return
+        super().reject()
+
     def _save_and_accept(self):
         """Gather form data on the GUI thread, save in the background."""
         try:
@@ -616,6 +622,7 @@ class ClientSettingsDialog(QDialog):
 
             self.save_button.setEnabled(False)
             self.save_button.setText("Saving...")
+            self._is_saving = True
 
             worker = Worker(self.profile_manager.save_client_config, self.client_id, self.config)
             worker.signals.result.connect(self._on_save_result)
@@ -638,6 +645,7 @@ class ClientSettingsDialog(QDialog):
             )
 
     def _on_save_result(self, success: bool):
+        self._is_saving = False
         self.save_button.setEnabled(True)
         self.save_button.setText("Save")
         if success:
@@ -657,6 +665,7 @@ class ClientSettingsDialog(QDialog):
     def _on_save_error(self, error):
         _exctype, value, tb = error
         logger.error(f"Failed to save client settings: {value}\n{tb}")
+        self._is_saving = False
         self.save_button.setEnabled(True)
         self.save_button.setText("Save")
         QMessageBox.critical(self, "Error", f"Failed to save client settings:\n{value!s}")

--- a/gui/client_settings_dialog.py
+++ b/gui/client_settings_dialog.py
@@ -6,7 +6,7 @@ tabbed interface for Basic Info, Appearance, Statistics, and Advanced settings.
 
 import logging
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QThreadPool, Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -27,6 +27,7 @@ from PySide6.QtWidgets import (
 
 from gui.theme_manager import get_theme_manager
 from gui.wheel_ignore_combobox import WheelIgnoreComboBox
+from gui.worker import Worker
 from shopify_tool.groups_manager import GroupsManager
 from shopify_tool.profile_manager import (
     ProfileManager,
@@ -361,6 +362,7 @@ class ClientSettingsDialog(QDialog):
         self.client_id = client_id
         self.profile_manager = profile_manager
         self.groups_manager = groups_manager
+        self._save_worker = None  # keeps the in-flight save Worker alive
 
         self.setWindowTitle(f"Client Settings - CLIENT_{client_id}")
         self.setModal(True)
@@ -413,6 +415,7 @@ class ClientSettingsDialog(QDialog):
         button_box = QDialogButtonBox(
             QDialogButtonBox.Save | QDialogButtonBox.Cancel
         )
+        self.save_button = button_box.button(QDialogButtonBox.Save)
         button_box.accepted.connect(self._save_and_accept)
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
@@ -597,17 +600,13 @@ class ClientSettingsDialog(QDialog):
         )
 
     def _save_and_accept(self):
-        """Save changes and close dialog."""
+        """Gather form data on the GUI thread, save in the background."""
         try:
-            # Update config
             self.config["client_name"] = self.client_name_input.text().strip()
-
-            # Update ui_settings
             self.config["ui_settings"]["is_pinned"] = self.pin_checkbox.isChecked()
             self.config["ui_settings"]["group_id"] = self.group_combo.currentData()
             self.config["ui_settings"]["custom_color"] = self.current_color
 
-            # Parse badges
             badges_text = self.badges_input.text().strip()
             if badges_text:
                 badges = [b.strip() for b in badges_text.split(",") if b.strip()]
@@ -615,27 +614,49 @@ class ClientSettingsDialog(QDialog):
                 badges = []
             self.config["ui_settings"]["custom_badges"] = badges
 
-            # Save config
-            success = self.profile_manager.save_client_config(self.client_id, self.config)
+            self.save_button.setEnabled(False)
+            self.save_button.setText("Saving...")
 
-            if success:
-                QMessageBox.information(
-                    self,
-                    "Success",
-                    f"Settings for CLIENT_{self.client_id} saved successfully!"
-                )
-                self.accept()
-            else:
-                QMessageBox.warning(
-                    self,
-                    "Save Failed",
-                    "Failed to save client settings. Please try again."
-                )
+            worker = Worker(self.profile_manager.save_client_config, self.client_id, self.config)
+            worker.signals.result.connect(self._on_save_result)
+            worker.signals.error.connect(self._on_save_error)
+            # Keep a strong reference until the worker finishes -- a bare
+            # local var is garbage-collected the instant this method returns,
+            # which (in this PySide6 build) destroys the QRunnable's
+            # unparented signals object before its queued result reaches the
+            # main thread. See MainWindow._client_load_worker for the
+            # verified repro.
+            self._save_worker = worker
+            QThreadPool.globalInstance().start(worker)
 
         except Exception as e:
             logger.exception("Failed to save client settings")
             QMessageBox.critical(
                 self,
                 "Error",
-                f"An error occurred while saving:\n{e!s}"
+                f"Failed to save client settings:\n{e!s}",
             )
+
+    def _on_save_result(self, success: bool):
+        self.save_button.setEnabled(True)
+        self.save_button.setText("Save")
+        if success:
+            QMessageBox.information(
+                self,
+                "Success",
+                f"Settings for CLIENT_{self.client_id} saved successfully!"
+            )
+            self.accept()
+        else:
+            QMessageBox.warning(
+                self,
+                "Save Failed",
+                "Failed to save client settings. Please try again."
+            )
+
+    def _on_save_error(self, error):
+        _exctype, value, tb = error
+        logger.error(f"Failed to save client settings: {value}\n{tb}")
+        self.save_button.setEnabled(True)
+        self.save_button.setText("Save")
+        QMessageBox.critical(self, "Error", f"Failed to save client settings:\n{value!s}")

--- a/gui/client_sidebar.py
+++ b/gui/client_sidebar.py
@@ -185,7 +185,7 @@ class ClientSidebar(QWidget):
         self.groups_manager = groups_manager
         self.is_expanded = True
         self.active_client_id = None
-        self._refresh_worker = None  # keeps the in-flight refresh Worker alive
+        self._refresh_workers = set()  # keeps in-flight refresh Workers alive
 
         # Track all ClientCard instances (for highlighting across sections)
         self.client_cards: dict[str, list[ClientCard]] = {}
@@ -339,8 +339,11 @@ class ClientSidebar(QWidget):
         # var is garbage-collected the instant this method returns, which (in
         # this PySide6 build) destroys the QRunnable's unparented signals
         # object before its queued result reaches the main thread. See
-        # MainWindow._client_load_worker for the verified repro.
-        self._refresh_worker = worker
+        # MainWindow._client_load_worker for the verified repro. Tracked in a
+        # set, not a single slot: a second refresh before this one finishes
+        # must not drop the first worker's reference out from under it.
+        self._refresh_workers.add(worker)
+        worker.signals.finished.connect(lambda: self._refresh_workers.discard(worker))
         QThreadPool.globalInstance().start(worker)
 
     def _on_refresh_error(self, error):

--- a/gui/client_sidebar.py
+++ b/gui/client_sidebar.py
@@ -20,7 +20,6 @@ from PySide6.QtCore import (
 )
 from PySide6.QtGui import QColor, QPainter, QPen
 from PySide6.QtWidgets import (
-    QApplication,
     QHBoxLayout,
     QLabel,
     QMenu,
@@ -345,7 +344,7 @@ class ClientSidebar(QWidget):
         QThreadPool.globalInstance().start(worker)
 
     def _on_refresh_error(self, error):
-        exctype, value, tb = error
+        _exctype, value, tb = error
         logger.error(f"Sidebar refresh failed: {value}\n{tb}")
         self.refresh_btn.setEnabled(True)
         QMessageBox.warning(self, "Refresh Error", f"Failed to refresh sidebar:\n{value!s}")

--- a/gui/client_sidebar.py
+++ b/gui/client_sidebar.py
@@ -15,6 +15,7 @@ from PySide6.QtCore import (
     QPropertyAnimation,
     QSettings,
     Qt,
+    QThreadPool,
     Signal,
 )
 from PySide6.QtGui import QColor, QPainter, QPen
@@ -34,6 +35,7 @@ from gui.client_card import ClientCard
 from gui.client_settings_dialog import ClientCreationDialog, ClientSettingsDialog
 from gui.groups_management_dialog import GroupsManagementDialog
 from gui.theme_manager import get_theme_manager
+from gui.worker import Worker
 from shopify_tool.groups_manager import GroupsManager
 from shopify_tool.profile_manager import ProfileManager
 
@@ -184,6 +186,7 @@ class ClientSidebar(QWidget):
         self.groups_manager = groups_manager
         self.is_expanded = True
         self.active_client_id = None
+        self._refresh_worker = None  # keeps the in-flight refresh Worker alive
 
         # Track all ClientCard instances (for highlighting across sections)
         self.client_cards: dict[str, list[ClientCard]] = {}
@@ -289,117 +292,136 @@ class ClientSidebar(QWidget):
 
         layout.addWidget(self.header_widget)
 
-    def refresh(self):
-        """Refresh client list and rebuild sections with performance logging."""
-        import time
+    def _gather_refresh_data(self) -> dict:
+        """All the file-server IO refresh() needs, with zero Qt object
+        construction -- safe to run in a background Worker.
+        """
+        groups_data = self.groups_manager.load_groups()
+        special_groups = groups_data.get("special_groups", {})
+        custom_groups = self.groups_manager.list_groups()
+        all_clients = self.profile_manager.list_clients()
 
-        from PySide6.QtCore import Qt
+        pinned_client_ids = set()
+        card_data = {}
+        for client_id in all_clients:
+            ui_settings = self.profile_manager.get_ui_settings(client_id)
+            if ui_settings.get("is_pinned", False):
+                pinned_client_ids.add(client_id)
+            card_data[client_id] = self.profile_manager.get_client_config_extended(client_id)
+
+        group_members = {}
+        for group in custom_groups:
+            group_id = group.get("id")
+            group_members[group_id] = self.groups_manager.get_clients_in_group(
+                group_id, self.profile_manager
+            )
+
+        return {
+            "special_groups": special_groups,
+            "custom_groups": custom_groups,
+            "all_clients": all_clients,
+            "pinned_client_ids": pinned_client_ids,
+            "group_members": group_members,
+            "card_data": card_data,
+        }
+
+    def refresh(self):
+        """Refresh client list and rebuild sections.
+
+        Data gathering runs off the GUI thread (Worker); section/card widget
+        construction stays on the GUI thread (Qt requirement) and happens in
+        _apply_refresh_data() once the data is ready.
+        """
+        self.refresh_btn.setEnabled(False)
+        worker = Worker(self._gather_refresh_data)
+        worker.signals.result.connect(self._apply_refresh_data)
+        worker.signals.error.connect(self._on_refresh_error)
+        # Keep a strong reference until the worker finishes -- a bare local
+        # var is garbage-collected the instant this method returns, which (in
+        # this PySide6 build) destroys the QRunnable's unparented signals
+        # object before its queued result reaches the main thread. See
+        # MainWindow._client_load_worker for the verified repro.
+        self._refresh_worker = worker
+        QThreadPool.globalInstance().start(worker)
+
+    def _on_refresh_error(self, error):
+        exctype, value, tb = error
+        logger.error(f"Sidebar refresh failed: {value}\n{tb}")
+        self.refresh_btn.setEnabled(True)
+        QMessageBox.warning(self, "Refresh Error", f"Failed to refresh sidebar:\n{value!s}")
+
+    def _apply_refresh_data(self, data: dict):
+        """Build section/card widgets from already-fetched data (main thread only)."""
+        import time
 
         theme = get_theme_manager().get_current_theme()
 
-        # Show wait cursor during potentially slow operation
-        QApplication.setOverrideCursor(Qt.WaitCursor)
-
         try:
             overall_start = time.time()
-            logger.info("Starting sidebar refresh")
+            logger.info("Applying sidebar refresh data")
 
-            # Disable updates during rebuild
             self.setUpdatesEnabled(False)
 
-            # Clear existing sections
-            clear_start = time.time()
             while self.sections_layout.count() > 1:
                 item = self.sections_layout.takeAt(0)
                 if item.widget():
                     item.widget().deleteLater()
-
             self.client_cards.clear()
-            clear_elapsed = (time.time() - clear_start) * 1000
-            logger.debug(f"Cleared sections in {clear_elapsed:.1f}ms")
 
-            # Load groups
-            groups_start = time.time()
-            groups_data = self.groups_manager.load_groups()
-            special_groups = groups_data.get("special_groups", {})
-            custom_groups = self.groups_manager.list_groups()
-            groups_elapsed = (time.time() - groups_start) * 1000
-            logger.debug(f"Loaded groups in {groups_elapsed:.1f}ms")
-
-            # Get all clients
-            clients_start = time.time()
-            all_clients = self.profile_manager.list_clients()
-            clients_elapsed = (time.time() - clients_start) * 1000
-            logger.debug(f"Listed {len(all_clients)} clients in {clients_elapsed:.1f}ms")
-
-            # Build sections
+            all_clients = data["all_clients"]
+            special_groups = data["special_groups"]
+            custom_groups = data["custom_groups"]
             clients_in_sections = set()
-            sections_start = time.time()
 
             # 1. Pinned section
-            pinned_start = time.time()
             pinned_config = special_groups.get("pinned", {})
-            pinned_section = self._create_pinned_section(all_clients, pinned_config)
+            pinned_section = self._create_pinned_section(all_clients, pinned_config, data)
             if pinned_section.card_count() > 0:
                 self.sections_layout.insertWidget(self.sections_layout.count() - 1, pinned_section)
                 clients_in_sections.update(self._get_section_client_ids(pinned_section))
-            pinned_elapsed = (time.time() - pinned_start) * 1000
-            logger.debug(f"Created pinned section ({pinned_section.card_count()} cards) in {pinned_elapsed:.1f}ms")
 
             # 2. Custom groups
-            groups_section_start = time.time()
             for group in custom_groups:
                 group_id = group.get("id")
                 group_name = group.get("name", "Unknown")
                 group_color = group.get("color", theme.accent_blue)
-
-                group_section = self._create_group_section(group_id, group_name, group_color, all_clients)
+                group_section = self._create_group_section(group_id, group_name, group_color, all_clients, data)
                 if group_section.card_count() > 0:
                     self.sections_layout.insertWidget(self.sections_layout.count() - 1, group_section)
                     clients_in_sections.update(self._get_section_client_ids(group_section))
-            groups_section_elapsed = (time.time() - groups_section_start) * 1000
-            logger.debug(f"Created {len(custom_groups)} group sections in {groups_section_elapsed:.1f}ms")
 
             # 3. All Clients section
-            all_start = time.time()
             all_config = special_groups.get("all", {})
             remaining_clients = [c for c in all_clients if c not in clients_in_sections]
             if remaining_clients:
-                all_section = self._create_all_section(remaining_clients, all_config)
+                all_section = self._create_all_section(remaining_clients, all_config, data)
                 self.sections_layout.insertWidget(self.sections_layout.count() - 1, all_section)
-            all_elapsed = (time.time() - all_start) * 1000
-            logger.debug(f"Created all section ({len(remaining_clients)} cards) in {all_elapsed:.1f}ms")
 
-            sections_elapsed = (time.time() - sections_start) * 1000
-
-            # Re-enable updates
             self.setUpdatesEnabled(True)
 
-            # Re-highlight active client
             if self.active_client_id:
                 self.set_active_client(self.active_client_id)
 
             overall_elapsed = (time.time() - overall_start) * 1000
             logger.info(
-                f"Sidebar refresh complete: {len(all_clients)} clients, "
-                f"{len(custom_groups)} groups in {overall_elapsed:.1f}ms "
-                f"(sections: {sections_elapsed:.1f}ms)"
+                f"Sidebar refresh applied: {len(all_clients)} clients, "
+                f"{len(custom_groups)} groups in {overall_elapsed:.1f}ms"
             )
 
         except Exception as e:
             self.setUpdatesEnabled(True)
-            logger.exception("Failed to refresh sidebar")
+            logger.exception("Failed to apply sidebar refresh data")
             QMessageBox.warning(self, "Refresh Error", f"Failed to refresh sidebar:\n{e!s}")
         finally:
-            # Restore cursor after refresh completes (success or error)
-            QApplication.restoreOverrideCursor()
+            self.refresh_btn.setEnabled(True)
 
-    def _create_pinned_section(self, all_clients: list[str], config: dict) -> SectionWidget:
+    def _create_pinned_section(self, all_clients: list[str], config: dict, data: dict) -> SectionWidget:
         """Create Pinned section.
 
         Args:
             all_clients: List of all client IDs
             config: Pinned section config
+            data: Pre-fetched data from _gather_refresh_data()
 
         Returns:
             SectionWidget with pinned clients
@@ -411,9 +433,8 @@ class ClientSidebar(QWidget):
         )
 
         for client_id in all_clients:
-            ui_settings = self.profile_manager.get_ui_settings(client_id)
-            if ui_settings.get("is_pinned", False):
-                card = self._create_client_card(client_id)
+            if client_id in data["pinned_client_ids"]:
+                card = self._create_client_card(client_id, data)
                 section.add_card(card)
 
         return section
@@ -423,7 +444,8 @@ class ClientSidebar(QWidget):
         group_id: str,
         group_name: str,
         group_color: str,
-        all_clients: list[str]
+        all_clients: list[str],
+        data: dict,
     ) -> SectionWidget:
         """Create custom group section.
 
@@ -432,27 +454,29 @@ class ClientSidebar(QWidget):
             group_name: Group display name
             group_color: Group color (hex)
             all_clients: List of all client IDs
+            data: Pre-fetched data from _gather_refresh_data()
 
         Returns:
             SectionWidget with group clients
         """
         section = SectionWidget(group_name, group_color)
 
-        clients_in_group = self.groups_manager.get_clients_in_group(group_id, self.profile_manager)
+        clients_in_group = data["group_members"].get(group_id, [])
 
         for client_id in clients_in_group:
             if client_id in all_clients:
-                card = self._create_client_card(client_id)
+                card = self._create_client_card(client_id, data)
                 section.add_card(card)
 
         return section
 
-    def _create_all_section(self, clients: list[str], config: dict) -> SectionWidget:
+    def _create_all_section(self, clients: list[str], config: dict, data: dict) -> SectionWidget:
         """Create All Clients section.
 
         Args:
             clients: List of client IDs to include
             config: All section config
+            data: Pre-fetched data from _gather_refresh_data()
 
         Returns:
             SectionWidget with all clients
@@ -467,21 +491,22 @@ class ClientSidebar(QWidget):
         )
 
         for client_id in clients:
-            card = self._create_client_card(client_id)
+            card = self._create_client_card(client_id, data)
             section.add_card(card)
 
         return section
 
-    def _create_client_card(self, client_id: str) -> ClientCard:
+    def _create_client_card(self, client_id: str, data: dict) -> ClientCard:
         """Create ClientCard for a client.
 
         Args:
             client_id: Client ID
+            data: Pre-fetched data from _gather_refresh_data()
 
         Returns:
             ClientCard instance
         """
-        config = self.profile_manager.get_client_config_extended(client_id)
+        config = data["card_data"][client_id]
 
         client_name = config.get("client_name", f"CLIENT_{client_id}")
         metadata = config.get("metadata", {})

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -917,7 +917,7 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(self, "Error", f"Failed to change client: {e!s}")
 
     def _on_client_data_load_error(self, error):
-        exctype, value, tb = error
+        _exctype, value, tb = error
         logger.error(f"Error loading client data: {value}\n{tb}")
         QMessageBox.critical(self, "Error", f"Failed to change client: {value!s}")
 

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -24,6 +24,7 @@ from gui.pandas_model import FulfillmentFilterProxy
 from gui.selection_helper import SelectionHelper
 from gui.theme_manager import get_theme_manager
 from gui.ui_manager import UIManager
+from gui.worker import Worker
 from shared.server_connection import prompt_for_recovery_path
 from shopify_tool.analysis import recalculate_statistics
 from shopify_tool.groups_manager import GroupsManager
@@ -84,6 +85,7 @@ class MainWindow(QMainWindow):
         self.analysis_results_df = None
         self.analysis_stats = None
         self.threadpool = QThreadPool()
+        self._client_load_worker = None  # keeps the in-flight client-switch Worker alive
         self._analysis_running = False  # Guard against duplicate analysis runs
 
         # Table display attributes
@@ -801,6 +803,19 @@ class MainWindow(QMainWindow):
             logger.warning(f"Failed to save inventory memory toggle: {e}")
 
     # --- Client and Session Management (New Architecture) ---
+    def _load_client_data(self, client_id: str):
+        """Pure IO for a client switch -- no UI calls, safe to run in a Worker.
+
+        Returns (shopify_config, table_config). table_config is None if
+        table_config_manager isn't set up yet (mirrors the existing
+        `hasattr(self, "table_config_manager")` guard).
+        """
+        shopify_config = self.profile_manager.load_shopify_config(client_id)
+        table_config = None
+        if hasattr(self, "table_config_manager"):
+            table_config = self.table_config_manager.load_config(client_id)
+        return shopify_config, table_config
+
     def on_client_changed(self, client_id: str):
         """Handle client selection change.
 
@@ -809,40 +824,65 @@ class MainWindow(QMainWindow):
         """
         logger.info(f"Client changed to: {client_id}")
 
-        # Show loading status in status bar
         if hasattr(self, "statusBar"):
             self.statusBar().showMessage(f"Loading CLIENT_{client_id}...", 5000)
 
-        # Update sidebar active state if sidebar exists
         if hasattr(self, "client_sidebar"):
             self.client_sidebar.set_active_client(client_id)
 
-        # Update header label if it exists
         if hasattr(self, "current_client_label"):
             self.current_client_label.setText(f"CLIENT_{client_id}")
 
-        # Store current client ID
         self.current_client_id = client_id
 
-        # Load configuration for this client
-        try:
-            self.current_client_config = self.profile_manager.load_shopify_config(
-                client_id
-            )
-            if not self.current_client_config:
-                QMessageBox.warning(
-                    self,
-                    "Configuration Error",
-                    f"Failed to load configuration for client {client_id}",
-                )
-                return
+        worker = Worker(self._load_client_data, client_id)
+        worker.signals.result.connect(
+            lambda result, cid=client_id: self._on_client_data_loaded(cid, result)
+        )
+        worker.signals.error.connect(self._on_client_data_load_error)
+        # Keep a strong reference until the worker finishes: a bare local var
+        # gets garbage-collected the instant this method returns, which -- in
+        # this PySide6 build -- destroys the QRunnable's unparented
+        # WorkerSignals object before its already-queued cross-thread result
+        # signal is dispatched to the main thread, silently dropping the
+        # client switch. Verified via a minimal repro; the existing bare
+        # `worker = Worker(...)` pattern elsewhere in this codebase
+        # (e.g. barcode_generator_widget.py) has the same latent exposure.
+        self._client_load_worker = worker
+        self.threadpool.start(worker)
 
-            # Also load it via the existing method for backward compatibility
+    def _on_client_data_loaded(self, client_id: str, result):
+        """Apply client-switch IO results to the UI (main thread only)."""
+        shopify_config, table_config = result
+
+        if client_id != self.current_client_id:
+            # User switched again before this load finished -- discard stale result.
+            logger.debug(f"Discarding stale client-load result for {client_id}")
+            return
+
+        if not shopify_config:
+            QMessageBox.warning(
+                self,
+                "Configuration Error",
+                f"Failed to load configuration for client {client_id}",
+            )
+            return
+
+        try:
+            self.current_client_config = shopify_config
+
+            # load_client_config() re-reads shopify_config via profile_manager --
+            # now a cache hit, since _load_client_data() already warmed the mtime
+            # cache above -- and applies every widget-facing side effect this
+            # class depends on (active_profile_config, analysis_mode_combo sync,
+            # inventory_memory_checkbox restore, per-client button enable/disable,
+            # _update_all_views()). Dropping it (as a naive port of this method
+            # might) would leave active_profile_config stale after every client
+            # switch -- it's read throughout actions_handler.py/file_handler.py
+            # for delimiters, column mappings, and tag categories.
             self.load_client_config(client_id)
 
-            # Load table configuration for this client
-            if hasattr(self, "table_config_manager"):
-                self.table_config_manager.load_config(client_id)
+            if table_config is not None:
                 logger.info(f"Table configuration loaded for CLIENT_{client_id}")
 
             # Clear currently loaded files (they're for different client)
@@ -855,30 +895,31 @@ class MainWindow(QMainWindow):
 
             # Clear session
             self.session_path = None
-            # Clear undo history when switching clients
             if hasattr(self, "undo_manager"):
                 self.undo_manager.reset_for_session()
             self.update_session_info_label()
 
             # Update session browser to show this client's sessions
-            # Don't auto-refresh here - let the second call handle it
             self.session_browser.set_client(client_id, auto_refresh=False)
 
             # Update the Recent Sessions quick-pick in the right panel (Tab 1)
             self.ui_manager.refresh_recent_sessions(client_id)
 
-            # Update UI state
             self.update_ui_state()
 
             logger.info(f"Client {client_id} loaded successfully")
 
-            # Update status bar with success message
             if hasattr(self, "statusBar"):
                 self.statusBar().showMessage(f"CLIENT_{client_id} loaded", 2000)
 
         except Exception as e:
-            logger.exception("Error changing client")
+            logger.exception("Error applying loaded client data")
             QMessageBox.critical(self, "Error", f"Failed to change client: {e!s}")
+
+    def _on_client_data_load_error(self, error):
+        exctype, value, tb = error
+        logger.error(f"Error loading client data: {value}\n{tb}")
+        QMessageBox.critical(self, "Error", f"Failed to change client: {value!s}")
 
     def on_sidebar_refresh(self):
         """Handle manual sidebar refresh request."""

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -85,7 +85,7 @@ class MainWindow(QMainWindow):
         self.analysis_results_df = None
         self.analysis_stats = None
         self.threadpool = QThreadPool()
-        self._client_load_worker = None  # keeps the in-flight client-switch Worker alive
+        self._client_load_workers = set()  # keeps in-flight client-switch Workers alive
         self._analysis_running = False  # Guard against duplicate analysis runs
 
         # Table display attributes
@@ -848,7 +848,10 @@ class MainWindow(QMainWindow):
         # client switch. Verified via a minimal repro; the existing bare
         # `worker = Worker(...)` pattern elsewhere in this codebase
         # (e.g. barcode_generator_widget.py) has the same latent exposure.
-        self._client_load_worker = worker
+        # Tracked in a set, not a single slot: a second switch before this one
+        # finishes must not drop the first worker's reference out from under it.
+        self._client_load_workers.add(worker)
+        worker.signals.finished.connect(lambda: self._client_load_workers.discard(worker))
         self.threadpool.start(worker)
 
     def _on_client_data_loaded(self, client_id: str, result):

--- a/gui/session_browser_widget.py
+++ b/gui/session_browser_widget.py
@@ -5,7 +5,7 @@ with filtering by status and the ability to open existing sessions.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from PySide6.QtCore import QEvent, Qt, Signal
 from PySide6.QtWidgets import (
@@ -28,6 +28,30 @@ from gui.wheel_ignore_combobox import WheelIgnoreComboBox
 from shopify_tool.session_manager import SessionManager
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_SESSION_AGE_CUTOFF_DAYS = 30
+
+
+def filter_sessions_by_age(sessions: list, cutoff_days: int | None, now: datetime) -> list:
+    """Keep sessions created within the last `cutoff_days`. `cutoff_days=None`
+    disables filtering (the "Show older" state). Sessions with an unparsable
+    or missing created_at are kept -- never hide real data because of a
+    formatting issue in a single record.
+    """
+    if cutoff_days is None:
+        return list(sessions)
+    cutoff = now - timedelta(days=cutoff_days)
+    kept = []
+    for session in sessions:
+        created_at = session.get("created_at", "")
+        try:
+            created = datetime.fromisoformat(created_at)
+        except (ValueError, TypeError):
+            kept.append(session)
+            continue
+        if created >= cutoff:
+            kept.append(session)
+    return kept
 
 
 class SessionLoaderWorker(BackgroundWorker):
@@ -105,6 +129,8 @@ class SessionBrowserWidget(QWidget):
         self.current_client_id = None
         self.sessions_data = []
         self.worker = None  # Track active background worker
+        self._show_older = False
+        self._is_dirty = True  # forces one load on first show
 
         self._init_ui()
         logger.info("SessionBrowserWidget initialized")
@@ -136,6 +162,12 @@ class SessionBrowserWidget(QWidget):
         self.refresh_btn.setToolTip("Reload sessions from server")
         self.refresh_btn.clicked.connect(self.refresh_sessions)
         filter_layout.addWidget(self.refresh_btn)
+
+        self.show_older_btn = QPushButton("Show Older (30+ days)")
+        self.show_older_btn.setCheckable(True)
+        self.show_older_btn.setToolTip("Show sessions older than 30 days")
+        self.show_older_btn.toggled.connect(self._on_show_older_toggled)
+        filter_layout.addWidget(self.show_older_btn)
 
         group_layout.addLayout(filter_layout)
 
@@ -226,6 +258,7 @@ class SessionBrowserWidget(QWidget):
 
     def refresh_sessions(self):
         """Reload sessions from the session manager."""
+        self._is_dirty = False
         if not self.current_client_id:
             self.sessions_table.setRowCount(0)
             logger.debug("No client selected, clearing sessions table")
@@ -325,10 +358,14 @@ class SessionBrowserWidget(QWidget):
 
     def _populate_table(self):
         """Populate the table with sessions data."""
+        cutoff_days = None if self._show_older else DEFAULT_SESSION_AGE_CUTOFF_DAYS
+        visible_sessions = filter_sessions_by_age(
+            self.sessions_data, cutoff_days, datetime.now().astimezone()
+        )
         self.sessions_table.setSortingEnabled(False)
-        self.sessions_table.setRowCount(len(self.sessions_data))
+        self.sessions_table.setRowCount(len(visible_sessions))
 
-        for row, session_info in enumerate(self.sessions_data):
+        for row, session_info in enumerate(visible_sessions):
             session_path = session_info.get("session_path", "")
             stats = session_info.get("statistics", {})
 
@@ -430,6 +467,18 @@ Comments: {comments if comments else "None"}"""
     def _apply_filter(self):
         """Apply the status filter."""
         self.refresh_sessions()
+
+    def _on_show_older_toggled(self, checked: bool):
+        """Toggling this only re-filters the already-loaded self.sessions_data --
+        no new file-server call, since the whole index is already in memory."""
+        self._show_older = checked
+        self._populate_table()
+
+    def mark_dirty(self):
+        """Call this whenever a session is created/updated for the client this
+        widget is currently showing, so the next showEvent() actually refreshes
+        instead of reusing a stale table."""
+        self._is_dirty = True
 
     def _on_selection_changed(self, current=None, previous=None):
         """Handle table selection change (fires on click/keyboard, not hover)."""
@@ -544,13 +593,12 @@ Comments: {comments if comments else "None"}"""
         return super().eventFilter(watched, event)
 
     def showEvent(self, event):
-        """Refresh sessions when widget becomes visible.
-
-        Args:
-            event: Show event
+        """Refresh only if something changed since the last load -- avoids
+        re-fetching from the file server every time this widget becomes
+        visible with nothing new to show.
         """
         super().showEvent(event)
-        if self.current_client_id:
+        if self._is_dirty and self.current_client_id:
             self.refresh_sessions()
 
     def closeEvent(self, event):

--- a/gui/session_browser_widget.py
+++ b/gui/session_browser_widget.py
@@ -253,6 +253,7 @@ class SessionBrowserWidget(QWidget):
         """
         if client_id != self.current_client_id:
             self.current_client_id = client_id
+            self._is_dirty = True
             if auto_refresh:
                 self.refresh_sessions()
 
@@ -529,11 +530,11 @@ Comments: {comments if comments else "None"}"""
             str: Session path or empty string if none selected
         """
         current_row = self.sessions_table.currentRow()
-        if current_row < 0 or current_row >= len(self.sessions_data):
+        if current_row < 0:
             return ""
 
-        session_info = self.sessions_data[current_row]
-        return session_info.get("session_path", "")
+        item = self.sessions_table.item(current_row, 0)
+        return item.data(Qt.UserRole) if item else ""
 
     def _on_status_changed(self, session_path: str, new_status: str):
         """Handle status change in table.

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -155,6 +155,7 @@ class SettingsWindow(QDialog):
         self.profile_manager = profile_manager
         self.analysis_df = analysis_df if analysis_df is not None else pd.DataFrame()
         self._save_worker = None  # keeps the in-flight save Worker alive
+        self._is_saving = False
 
         # Ensure config structure exists
         if not isinstance(self.config_data.get("column_mappings"), dict):
@@ -2978,6 +2979,11 @@ class SettingsWindow(QDialog):
             "boxes": boxes,
         }
 
+    def reject(self):
+        if self._is_saving:
+            return
+        super().reject()
+
     def save_settings(self):
         """Saves all settings from the UI back into the config dictionary."""
         try:
@@ -3234,6 +3240,7 @@ class SettingsWindow(QDialog):
             # ========================================
             self.save_button.setEnabled(False)
             self.save_button.setText("Saving...")
+            self._is_saving = True
 
             worker = Worker(self.profile_manager.save_shopify_config, self.client_id, self.config_data)
             worker.signals.result.connect(self._on_save_settings_result)
@@ -3262,6 +3269,7 @@ class SettingsWindow(QDialog):
             )
 
     def _on_save_settings_result(self, success: bool):
+        self._is_saving = False
         self.save_button.setEnabled(True)
         self.save_button.setText("Save")
         if success:
@@ -3269,7 +3277,7 @@ class SettingsWindow(QDialog):
             self.accept()
         else:
             import json
-            config_size = len(json.dumps(self.config_data, ensure_ascii=False))
+            config_size = len(json.dumps(self.config_data, ensure_ascii=False).encode("utf-8"))
             num_sets = len(self.config_data.get("set_decoders", {}))
             QMessageBox.critical(
                 self,
@@ -3287,6 +3295,7 @@ class SettingsWindow(QDialog):
     def _on_save_settings_error(self, error):
         _exctype, value, tb = error
         logger.error(f"Failed to save settings: {value}\n{tb}")
+        self._is_saving = False
         self.save_button.setEnabled(True)
         self.save_button.setText("Save")
         QMessageBox.critical(self, "Error", f"Failed to save settings:\n\n{value!s}")

--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -1,9 +1,10 @@
 import json
+import logging
 import sys
 from typing import ClassVar
 
 import pandas as pd
-from PySide6.QtCore import QDate, Qt, QTimer
+from PySide6.QtCore import QDate, Qt, QThreadPool, QTimer
 from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -34,8 +35,11 @@ from PySide6.QtWidgets import (
 
 from gui.column_mapping_widget import ColumnMappingWidget
 from gui.wheel_ignore_combobox import WheelIgnoreComboBox
+from gui.worker import Worker
 from shopify_tool.core import get_unique_column_values
 from shopify_tool.set_decoder import export_sets_to_csv, import_sets_from_csv
+
+logger = logging.getLogger(__name__)
 
 
 class SettingsWindow(QDialog):
@@ -150,6 +154,7 @@ class SettingsWindow(QDialog):
         self.config_data = json.loads(json.dumps(client_config))
         self.profile_manager = profile_manager
         self.analysis_df = analysis_df if analysis_df is not None else pd.DataFrame()
+        self._save_worker = None  # keeps the in-flight save Worker alive
 
         # Ensure config structure exists
         if not isinstance(self.config_data.get("column_mappings"), dict):
@@ -222,6 +227,7 @@ class SettingsWindow(QDialog):
         self._build_settings_nav()
 
         button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        self.save_button = button_box.button(QDialogButtonBox.Save)
         button_box.accepted.connect(self.save_settings)
         button_box.rejected.connect(self.reject)
         main_layout.addWidget(button_box)
@@ -3223,38 +3229,23 @@ class SettingsWindow(QDialog):
                 }
 
             # ========================================
-            # Save to server via ProfileManager
+            # Save to server via ProfileManager (background -- avoids blocking
+            # the GUI thread on the lock-contention retry sleep)
             # ========================================
-            success = self.profile_manager.save_shopify_config(
-                self.client_id,
-                self.config_data
-            )
+            self.save_button.setEnabled(False)
+            self.save_button.setText("Saving...")
 
-            if success:
-                QMessageBox.information(
-                    self,
-                    "Success",
-                    "Settings saved successfully!"
-                )
-                self.accept()  # Close dialog
-            else:
-                # Calculate config size for diagnostic info
-                import json
-                config_size = len(json.dumps(self.config_data, ensure_ascii=False))
-                num_sets = len(self.config_data.get("set_decoders", {}))
-
-                QMessageBox.critical(
-                    self,
-                    "Save Error",
-                    f"Failed to save settings to server.\n\n"
-                    f"Configuration size: {config_size:,} bytes\n"
-                    f"Number of sets: {num_sets}\n\n"
-                    f"Possible causes:\n"
-                    f"• File is locked by another user\n"
-                    f"• Network connection issue\n"
-                    f"• Insufficient permissions\n\n"
-                    f"Please wait a few seconds and try again."
-                )
+            worker = Worker(self.profile_manager.save_shopify_config, self.client_id, self.config_data)
+            worker.signals.result.connect(self._on_save_settings_result)
+            worker.signals.error.connect(self._on_save_settings_error)
+            # Keep a strong reference until the worker finishes -- a bare
+            # local var is garbage-collected the instant this method returns,
+            # which (in this PySide6 build) destroys the QRunnable's
+            # unparented signals object before its queued result reaches the
+            # main thread. See MainWindow._client_load_worker for the
+            # verified repro.
+            self._save_worker = worker
+            QThreadPool.globalInstance().start(worker)
 
         except ValueError as e:
             QMessageBox.critical(
@@ -3269,6 +3260,36 @@ class SettingsWindow(QDialog):
                 "Error",
                 f"Failed to save settings:\n\n{e!s}\n\n{traceback.format_exc()}"
             )
+
+    def _on_save_settings_result(self, success: bool):
+        self.save_button.setEnabled(True)
+        self.save_button.setText("Save")
+        if success:
+            QMessageBox.information(self, "Success", "Settings saved successfully!")
+            self.accept()
+        else:
+            import json
+            config_size = len(json.dumps(self.config_data, ensure_ascii=False))
+            num_sets = len(self.config_data.get("set_decoders", {}))
+            QMessageBox.critical(
+                self,
+                "Save Error",
+                f"Failed to save settings to server.\n\n"
+                f"Configuration size: {config_size:,} bytes\n"
+                f"Number of sets: {num_sets}\n\n"
+                f"Possible causes:\n"
+                f"• File is locked by another user\n"
+                f"• Network connection issue\n"
+                f"• Insufficient permissions\n\n"
+                f"Please wait a few seconds and try again."
+            )
+
+    def _on_save_settings_error(self, error):
+        _exctype, value, tb = error
+        logger.error(f"Failed to save settings: {value}\n{tb}")
+        self.save_button.setEnabled(True)
+        self.save_button.setText("Save")
+        QMessageBox.critical(self, "Error", f"Failed to save settings:\n\n{value!s}")
     # ========================================
     # TAG CATEGORIES TAB
     # ========================================

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -12,6 +12,7 @@ Key Features:
     - Validation of client IDs and configurations
 """
 
+import copy
 import json
 import logging
 import os
@@ -910,7 +911,7 @@ class ProfileManager:
             cached_data, cached_mtime = self._config_cache[cache_key]
             if cached_mtime == current_mtime:
                 logger.debug(f"Using cached client config for {client_id}")
-                return cached_data.copy()
+                return copy.deepcopy(cached_data)
 
         try:
             with open(config_path, "r", encoding="utf-8") as f:
@@ -931,7 +932,7 @@ class ProfileManager:
                     current_mtime = None
 
             if current_mtime is not None:
-                self._config_cache[cache_key] = (config.copy(), current_mtime)
+                self._config_cache[cache_key] = (copy.deepcopy(config), current_mtime)
 
             return config
 

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -980,7 +980,7 @@ class ProfileManager:
             cached_data, cached_mtime = self._config_cache[cache_key]
             if cached_mtime == current_mtime:
                 logger.debug(f"Using cached shopify config for {client_id}")
-                return cached_data
+                return copy.deepcopy(cached_data)
 
         try:
             with open(config_path, "r", encoding="utf-8") as f:
@@ -1019,7 +1019,7 @@ class ProfileManager:
 
             # Update cache with current mtime
             if current_mtime is not None:
-                self._config_cache[cache_key] = (config, current_mtime)
+                self._config_cache[cache_key] = (copy.deepcopy(config), current_mtime)
 
             return config
 

--- a/shopify_tool/profile_manager.py
+++ b/shopify_tool/profile_manager.py
@@ -879,7 +879,11 @@ class ProfileManager:
         }
 
     def load_client_config(self, client_id: str) -> dict | None:
-        """Load general configuration for a client.
+        """Load general configuration for a client, with mtime-based caching.
+
+        Cache is invalidated by file mtime rather than TTL: no stale reads after
+        another PC saves a change, and no unnecessary re-reads while the file is
+        stable. Mirrors load_shopify_config()'s cache exactly.
 
         Automatically migrates old configs to add ui_settings if missing.
 
@@ -890,11 +894,23 @@ class ProfileManager:
             Optional[Dict]: Configuration dictionary or None if not found
         """
         client_id = client_id.upper()
+        cache_key = f"{self.base_path}::client_{client_id}"
         config_path = self.clients_dir / f"CLIENT_{client_id}" / "client_config.json"
 
         if not config_path.exists():
             logger.warning(f"Client config not found: CLIENT_{client_id}")
             return None
+
+        try:
+            current_mtime = config_path.stat().st_mtime
+        except OSError:
+            current_mtime = None
+
+        if current_mtime is not None and cache_key in self._config_cache:
+            cached_data, cached_mtime = self._config_cache[cache_key]
+            if cached_mtime == current_mtime:
+                logger.debug(f"Using cached client config for {client_id}")
+                return cached_data.copy()
 
         try:
             with open(config_path, "r", encoding="utf-8") as f:
@@ -907,6 +923,15 @@ class ProfileManager:
                 # If config was migrated, save it immediately
                 self.save_client_config(client_id, config)
                 logger.info(f"Config migrations completed for CLIENT_{client_id}")
+                # save_client_config() invalidates cache_key; re-stat so this
+                # call still populates the cache with the post-migration mtime.
+                try:
+                    current_mtime = config_path.stat().st_mtime
+                except OSError:
+                    current_mtime = None
+
+            if current_mtime is not None:
+                self._config_cache[cache_key] = (config.copy(), current_mtime)
 
             return config
 
@@ -1530,6 +1555,10 @@ class ProfileManager:
                     success = self._save_with_unix_lock(config_path, config)
 
                 if success:
+                    # Invalidate cache
+                    cache_key = f"{self.base_path}::client_{client_id}"
+                    self._config_cache.pop(cache_key, None)
+
                     logger.info(
                         f"Client config saved successfully for CLIENT_{client_id} "
                         f"(attempt {attempt + 1}/{max_retries})"

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -61,6 +61,9 @@ class SessionManager:
     # Valid session statuses
     VALID_STATUSES: ClassVar[list[str]] = ["active", "completed", "abandoned", "archived"]
 
+    # Per-client session index cache filename (see docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md)
+    INDEX_FILENAME: ClassVar[str] = "session_index.json"
+
     def __init__(self, profile_manager):
         """Initialize SessionManager with ProfileManager.
 
@@ -138,6 +141,12 @@ class SessionManager:
             session_info_path = session_path / "session_info.json"
             with open(session_info_path, 'w', encoding='utf-8') as f:
                 json.dump(session_info, f, indent=2)
+
+            try:
+                self._upsert_index_entry(session_path, session_info)
+            except Exception:
+                logger.exception(f"Failed to update session index for {session_path}")
+            self.profile_manager.invalidate_metadata_cache(client_id)
 
             logger.info(f"Session created: CLIENT_{client_id}/{session_name}")
             return str(session_path)
@@ -247,15 +256,13 @@ class SessionManager:
         return sessions
 
     @contextlib.contextmanager
-    def _locked_session_info(self, session_path_obj: Path):
-        """Blocking exclusive lock spanning a session_info.json read-modify-write.
+    def _exclusive_lock(self, lock_path: Path):
+        """Blocking exclusive lock on an arbitrary sidecar `.lock` file.
 
-        Without this, two near-simultaneous updates (e.g. packing list and
-        stock export generation both appending to their own list field) each
-        read the same on-disk snapshot before either writes back, and one
-        update silently loses the other's change.
+        Without this, two near-simultaneous read-modify-write cycles on the
+        file `lock_path` guards each read the same on-disk snapshot before
+        either writes back, and one update silently loses the other's change.
         """
-        lock_path = session_path_obj / "session_info.json.lock"
         with open(lock_path, "a+") as lock_file:
             try:
                 if os.name == "nt":
@@ -273,6 +280,12 @@ class SessionManager:
                 else:
                     import fcntl
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    @contextlib.contextmanager
+    def _locked_session_info(self, session_path_obj: Path):
+        """Blocking exclusive lock spanning a session_info.json read-modify-write."""
+        with self._exclusive_lock(session_path_obj / "session_info.json.lock"):
+            yield
 
     def get_session_info(self, session_path: str) -> dict | None:
         """Load session metadata from session_info.json.
@@ -310,6 +323,67 @@ class SessionManager:
         except Exception:
             logger.exception("Failed to load session info")
             return None
+
+    def _index_lock_path(self, client_sessions_dir: Path) -> Path:
+        return client_sessions_dir / f"{self.INDEX_FILENAME}.lock"
+
+    def _read_index(self, client_sessions_dir: Path) -> list[dict] | None:
+        """Read the raw index file, or None if it doesn't exist / is unreadable."""
+        index_path = client_sessions_dir / self.INDEX_FILENAME
+        if not index_path.exists():
+            return None
+        try:
+            with open(index_path, encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            logger.exception("Failed to read session index, treating as missing")
+            return None
+
+    def _write_index(self, client_sessions_dir: Path, entries: list[dict]) -> None:
+        index_path = client_sessions_dir / self.INDEX_FILENAME
+        with open(index_path, "w", encoding="utf-8") as f:
+            json.dump(entries, f, indent=2)
+
+    def _scan_sessions(self, client_sessions_dir: Path) -> list[dict]:
+        """Full folder scan (the old list_client_sessions behavior) -- used only
+        to build/rebuild the index, never on the normal read path."""
+        entries = []
+        for item in client_sessions_dir.iterdir():
+            if not item.is_dir():
+                continue
+            info = self.get_session_info(str(item))
+            if info:
+                info.pop("session_path", None)
+                entries.append(info)
+        return entries
+
+    def _rebuild_index(self, client_sessions_dir: Path) -> list[dict]:
+        """Full scan + persist. Called when no index exists yet, or the
+        directory count no longer matches the index (see list_client_sessions)."""
+        entries = self._scan_sessions(client_sessions_dir)
+        with self._exclusive_lock(self._index_lock_path(client_sessions_dir)):
+            self._write_index(client_sessions_dir, entries)
+        return entries
+
+    def _upsert_index_entry(self, session_path_obj: Path, session_info: dict) -> None:
+        """Insert or replace one session's entry in its client's index.
+
+        Best-effort: index-write failures are logged, not raised, since the
+        index is a read-side cache and must never block the session_info.json
+        write it mirrors.
+        """
+        try:
+            client_sessions_dir = session_path_obj.parent
+            entry = dict(session_info)
+            entry.pop("session_path", None)
+            session_name = session_path_obj.name
+            with self._exclusive_lock(self._index_lock_path(client_sessions_dir)):
+                entries = self._read_index(client_sessions_dir) or []
+                entries = [e for e in entries if e.get("session_name") != session_name]
+                entries.append(entry)
+                self._write_index(client_sessions_dir, entries)
+        except Exception:
+            logger.exception(f"Failed to update session index for {session_path_obj}")
 
     def update_session_status(self, session_path: str, status: str) -> bool:
         """Update session status in session_info.json.
@@ -350,6 +424,10 @@ class SessionManager:
                 with open(session_info_path, 'w', encoding='utf-8') as f:
                     json.dump(session_info, f, indent=2)
 
+                try:
+                    self._upsert_index_entry(session_path_obj, session_info)
+                except Exception:
+                    logger.exception(f"Failed to update session index for {session_path_obj}")
                 logger.info(f"Session status updated to '{status}': {session_path}")
                 return True
 
@@ -391,6 +469,10 @@ class SessionManager:
                 with open(session_info_path, 'w', encoding='utf-8') as f:
                     json.dump(session_info, f, indent=2)
 
+                try:
+                    self._upsert_index_entry(session_path_obj, session_info)
+                except Exception:
+                    logger.exception(f"Failed to update session index for {session_path_obj}")
                 logger.info(f"Session info updated: {session_path}")
                 return True
 
@@ -434,6 +516,10 @@ class SessionManager:
                 with open(session_info_path, 'w', encoding='utf-8') as f:
                     json.dump(session_info, f, indent=2)
 
+                try:
+                    self._upsert_index_entry(session_path_obj, session_info)
+                except Exception:
+                    logger.exception(f"Failed to update session index for {session_path_obj}")
                 logger.info(f"Session info updated: appended '{value}' to '{field}'")
                 return True
 

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -220,6 +220,9 @@ class SessionManager:
     ) -> list[dict]:
         """List all sessions for a client.
 
+        Reads the per-client session_index.json cache instead of opening every
+        session's session_info.json (see docs/superpowers/specs/2026-07-27-ui-responsiveness-design.md).
+
         Args:
             client_id (str): Client ID
             status_filter (str, optional): Filter by status ("active", "completed", etc.)
@@ -234,25 +237,23 @@ class SessionManager:
         if not client_sessions_dir.exists():
             return []
 
+        entries = self._read_index(client_sessions_dir)
+        if entries is None:
+            entries = self._rebuild_index(client_sessions_dir)
+        else:
+            actual_count = sum(1 for item in client_sessions_dir.iterdir() if item.is_dir())
+            if actual_count != len(entries):
+                entries = self._rebuild_index(client_sessions_dir)
+
         sessions = []
-        for item in client_sessions_dir.iterdir():
-            if not item.is_dir():
+        for entry in entries:
+            session_info = dict(entry)
+            session_info["session_path"] = str(client_sessions_dir / session_info["session_name"])
+            if status_filter and session_info.get("status") != status_filter:
                 continue
+            sessions.append(session_info)
 
-            session_info = self.get_session_info(str(item))
-            if session_info:
-                # Apply status filter if specified
-                if status_filter and session_info.get("status") != status_filter:
-                    continue
-
-                sessions.append(session_info)
-
-        # Sort by creation date (newest first)
-        sessions.sort(
-            key=lambda x: x.get("created_at", ""),
-            reverse=True
-        )
-
+        sessions.sort(key=lambda x: x.get("created_at", ""), reverse=True)
         return sessions
 
     @contextlib.contextmanager

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -361,9 +361,15 @@ class SessionManager:
 
     def _rebuild_index(self, client_sessions_dir: Path) -> list[dict]:
         """Full scan + persist. Called when no index exists yet, or the
-        directory count no longer matches the index (see list_client_sessions)."""
-        entries = self._scan_sessions(client_sessions_dir)
+        directory count no longer matches the index (see list_client_sessions).
+
+        Scan and write both happen under the index lock: an unlocked scan
+        could read a stale snapshot, then overwrite a concurrent
+        _upsert_index_entry() write for an unrelated session with that
+        stale data once the lock is finally taken for the write.
+        """
         with self._exclusive_lock(self._index_lock_path(client_sessions_dir)):
+            entries = self._scan_sessions(client_sessions_dir)
             self._write_index(client_sessions_dir, entries)
         return entries
 

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -27,6 +27,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import ClassVar
 
+from shared.atomic_write import atomic_write_json
+
 logger = logging.getLogger("ShopifyToolLogger")
 
 
@@ -342,8 +344,7 @@ class SessionManager:
 
     def _write_index(self, client_sessions_dir: Path, entries: list[dict]) -> None:
         index_path = client_sessions_dir / self.INDEX_FILENAME
-        with open(index_path, "w", encoding="utf-8") as f:
-            json.dump(entries, f, indent=2)
+        atomic_write_json(index_path, entries)
 
     def _scan_sessions(self, client_sessions_dir: Path) -> list[dict]:
         """Full folder scan (the old list_client_sessions behavior) -- used only

--- a/tests/test_client_sidebar_refresh.py
+++ b/tests/test_client_sidebar_refresh.py
@@ -1,0 +1,43 @@
+"""ClientSidebar's pure data-gathering step (no widget construction --
+must be safe to run off the GUI thread per this repo's threading rule)."""
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from gui.client_sidebar import ClientSidebar
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def groups_manager(profile_manager):
+    from shopify_tool.groups_manager import GroupsManager
+    return GroupsManager(profile_manager.base_path)
+
+
+@pytest.fixture
+def sidebar(qapp, profile_manager, groups_manager):
+    return ClientSidebar(profile_manager, groups_manager)
+
+
+class TestGatherRefreshData:
+    def test_gather_includes_all_clients(self, sidebar, profile_manager):
+        profile_manager.create_client_profile("M", "Client M")
+        profile_manager.create_client_profile("N", "Client N")
+        data = sidebar._gather_refresh_data()
+        assert set(data["all_clients"]) == {"M", "N"}
+
+    def test_gather_flags_pinned_clients(self, sidebar, profile_manager):
+        profile_manager.create_client_profile("M", "Client M")
+        profile_manager.update_ui_settings("M", {"is_pinned": True})
+        data = sidebar._gather_refresh_data()
+        assert "M" in data["pinned_client_ids"]
+
+    def test_gather_returns_no_qt_objects(self, sidebar, profile_manager):
+        profile_manager.create_client_profile("M", "Client M")
+        data = sidebar._gather_refresh_data()
+        import json
+        json.dumps(data, default=str)  # must be plain-data serializable

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -138,3 +138,46 @@ class TestColumnMappingsMigrationBug:
 
         reloaded = profile_manager.load_shopify_config("M")
         assert reloaded["column_mappings"]["orders"] == {"MyCol": "SKU"}
+
+
+class TestLoadClientConfigCaching:
+    def test_second_load_is_served_from_cache(self, profile_manager, monkeypatch):
+        profile_manager.create_client_profile("M", "Client")
+        first = profile_manager.load_client_config("M")
+        call_count = {"n": 0}
+        original_open = open
+
+        def counting_open(*args, **kwargs):
+            if "client_config.json" in str(args[0]):
+                call_count["n"] += 1
+            return original_open(*args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", counting_open)
+        second = profile_manager.load_client_config("M")
+        assert second == first
+        assert call_count["n"] == 0  # served from cache, file not reopened
+
+    def test_cache_invalidated_after_save(self, profile_manager):
+        profile_manager.create_client_profile("M", "Client")
+        config = profile_manager.load_client_config("M")
+        config["client_name"] = "Renamed"
+        profile_manager.save_client_config("M", config)
+        reloaded = profile_manager.load_client_config("M")
+        assert reloaded["client_name"] == "Renamed"
+
+    def test_cache_reflects_external_mtime_change(self, profile_manager):
+        # Simulates another PC on the file server saving a change: same
+        # mtime-based invalidation load_shopify_config already relies on.
+        profile_manager.create_client_profile("M", "Client")
+        profile_manager.load_client_config("M")  # warm the cache
+        config_path = profile_manager.get_client_directory("M") / "client_config.json"
+        data = json.loads(config_path.read_text())
+        data["client_name"] = "Changed Externally"
+        config_path.write_text(json.dumps(data))
+        import os
+        import time
+        # Ensure a distinct mtime on filesystems with coarse mtime resolution.
+        newer = os.path.getmtime(config_path) + 1
+        os.utime(config_path, (newer, newer))
+        reloaded = profile_manager.load_client_config("M")
+        assert reloaded["client_name"] == "Changed Externally"

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -180,3 +180,25 @@ class TestLoadClientConfigCaching:
         os.utime(config_path, (newer, newer))
         reloaded = profile_manager.load_client_config("M")
         assert reloaded["client_name"] == "Changed Externally"
+
+    def test_mutating_returned_config_does_not_corrupt_cache(self, profile_manager):
+        # ui_settings is a nested dict; a shallow cache copy would share it
+        # across calls, so mutating one caller's copy would corrupt the next.
+        profile_manager.create_client_profile("M", "Client")
+        first = profile_manager.load_client_config("M")
+        first["ui_settings"]["is_pinned"] = True
+
+        second = profile_manager.load_client_config("M")
+        assert second["ui_settings"]["is_pinned"] is False
+
+
+class TestLoadShopifyConfigCaching:
+    def test_mutating_returned_config_does_not_corrupt_cache(self, profile_manager):
+        # Same shallow-copy-cache hazard as load_client_config(), on the
+        # nested inventory_memory dict.
+        profile_manager.create_client_profile("M", "Client")
+        first = profile_manager.load_shopify_config("M")
+        first["inventory_memory"]["enabled"] = True
+
+        second = profile_manager.load_shopify_config("M")
+        assert second["inventory_memory"]["enabled"] is False

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -175,7 +175,6 @@ class TestLoadClientConfigCaching:
         data["client_name"] = "Changed Externally"
         config_path.write_text(json.dumps(data))
         import os
-        import time
         # Ensure a distinct mtime on filesystems with coarse mtime resolution.
         newer = os.path.getmtime(config_path) + 1
         os.utime(config_path, (newer, newer))

--- a/tests/test_session_browser_filter.py
+++ b/tests/test_session_browser_filter.py
@@ -1,0 +1,34 @@
+"""Session browser's 30-day default view filter (no Qt needed — pure data)."""
+from datetime import datetime, timedelta
+
+from gui.session_browser_widget import filter_sessions_by_age
+
+
+def _session(days_old: int) -> dict:
+    created = (datetime.now().astimezone() - timedelta(days=days_old)).isoformat()
+    return {"session_name": f"session_{days_old}d", "created_at": created}
+
+
+class TestFilterSessionsByAge:
+    def test_keeps_sessions_within_cutoff(self):
+        sessions = [_session(5), _session(10)]
+        result = filter_sessions_by_age(sessions, cutoff_days=30, now=datetime.now().astimezone())
+        assert len(result) == 2
+
+    def test_drops_sessions_older_than_cutoff(self):
+        sessions = [_session(5), _session(45)]
+        result = filter_sessions_by_age(sessions, cutoff_days=30, now=datetime.now().astimezone())
+        assert len(result) == 1
+        assert result[0]["session_name"] == "session_5d"
+
+    def test_missing_created_at_is_kept_not_dropped(self):
+        # Never hide a session just because its date couldn't be parsed --
+        # that would silently disappear real data from the default view.
+        sessions = [{"session_name": "no_date"}]
+        result = filter_sessions_by_age(sessions, cutoff_days=30, now=datetime.now().astimezone())
+        assert len(result) == 1
+
+    def test_cutoff_none_returns_all_sessions(self):
+        sessions = [_session(5), _session(400)]
+        result = filter_sessions_by_age(sessions, cutoff_days=None, now=datetime.now().astimezone())
+        assert len(result) == 2

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -205,6 +205,48 @@ class TestSessionIndex:
         assert entries[0]["session_name"] == session_path.name
         assert index_path.exists()
 
+    def test_rebuild_holds_index_lock_across_scan_and_write(self, session_manager):
+        """A rebuild that only locks the write (not the scan) can capture a
+        stale snapshot and then overwrite a concurrent _upsert_index_entry()
+        write with it once the lock is finally taken -- the directory-count
+        staleness guard can't catch that, since an existing session's info
+        changing doesn't change the count. Proven directly: while the scan is
+        in flight, a second lock attempt on the same file must not succeed.
+        """
+        import fcntl
+        import threading
+
+        session_path = Path(session_manager.create_session("M"))
+        client_sessions_dir = session_path.parent
+        index_path = client_sessions_dir / SessionManager.INDEX_FILENAME
+        index_path.unlink()  # force list_client_sessions() to rebuild
+
+        scan_started = threading.Event()
+        release_scan = threading.Event()
+        original_scan = session_manager._scan_sessions
+
+        def blocking_scan(dir_path):
+            entries = original_scan(dir_path)
+            scan_started.set()
+            release_scan.wait(timeout=2)
+            return entries
+
+        session_manager._scan_sessions = blocking_scan
+
+        t1 = threading.Thread(target=lambda: session_manager.list_client_sessions("M"))
+        t1.start()
+        assert scan_started.wait(timeout=2), "rebuild's scan never started"
+
+        lock_path = session_manager._index_lock_path(client_sessions_dir)
+        with open(lock_path, "a+") as probe:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
+
+        release_scan.set()
+        t1.join()
+        session_manager._scan_sessions = original_scan
+
     def test_read_index_returns_none_when_missing(self, session_manager, tmp_path):
         empty_dir = tmp_path / "CLIENT_NOINDEX"
         empty_dir.mkdir()

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -221,3 +221,49 @@ class TestSessionIndex:
         assert session_manager.update_session_status(session_path, "completed") is True
         info = session_manager.get_session_info(session_path)
         assert info["status"] == "completed"
+
+
+class TestListClientSessionsUsesIndex:
+    def test_list_matches_previous_full_scan_output(self, session_manager):
+        p1 = Path(session_manager.create_session("M"))
+        session_manager.update_session_status(p1, "completed")
+        p2 = session_manager.create_session("M")
+        sessions = session_manager.list_client_sessions("M")
+        assert len(sessions) == 2
+        names = {s["session_name"] for s in sessions}
+        assert names == {p1.name, Path(p2).name}
+        # sorted newest first
+        assert sessions[0]["created_at"] >= sessions[1]["created_at"]
+
+    def test_status_filter_still_works(self, session_manager):
+        p1 = Path(session_manager.create_session("M"))
+        session_manager.update_session_status(p1, "completed")
+        session_manager.create_session("M")
+        active_only = session_manager.list_client_sessions("M", status_filter="active")
+        assert len(active_only) == 1
+
+    def test_missing_index_is_built_transparently(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        index_path = session_path.parent / SessionManager.INDEX_FILENAME
+        index_path.unlink()  # simulate a client dir from before this feature
+        sessions = session_manager.list_client_sessions("M")
+        assert len(sessions) == 1
+        assert index_path.exists()  # self-healed
+
+    def test_manually_added_session_folder_triggers_rebuild(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        # Simulate a session folder restored/copied in without going through
+        # create_session (index has no entry for it).
+        extra = session_path.parent / "2020-01-01_1"
+        extra.mkdir()
+        for subdir in SessionManager.SESSION_SUBDIRS:
+            (extra / subdir).mkdir()
+        (extra / "session_info.json").write_text(json.dumps({
+            "session_name": "2020-01-01_1", "status": "active",
+            "created_at": "2020-01-01T00:00:00", "client_id": "M",
+        }))
+        sessions = session_manager.list_client_sessions("M")
+        assert len(sessions) == 2  # count mismatch caught it, rebuilt
+
+    def test_no_sessions_dir_returns_empty_list(self, session_manager):
+        assert session_manager.list_client_sessions("M") == []

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,4 +1,5 @@
 """Session lifecycle & session_info.json accuracy (part of priority 6: app config)."""
+import json
 from pathlib import Path
 
 import pytest
@@ -154,3 +155,69 @@ class TestConfirmedBugs:
         with pytest.raises(SessionManagerError):
             session_manager.delete_session(str(outside_dir))
         assert outside_dir.exists()
+
+
+class TestSessionIndex:
+    def test_create_session_adds_index_entry(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        index_path = session_path.parent / SessionManager.INDEX_FILENAME
+        assert index_path.exists()
+        entries = json.loads(index_path.read_text())
+        assert len(entries) == 1
+        assert entries[0]["session_name"] == session_path.name
+        assert entries[0]["status"] == "active"
+        assert "session_path" not in entries[0]
+
+    def test_update_session_status_updates_index_entry(self, session_manager):
+        session_path = session_manager.create_session("M")
+        session_manager.update_session_status(session_path, "completed")
+        index_path = Path(session_path).parent / SessionManager.INDEX_FILENAME
+        entries = json.loads(index_path.read_text())
+        assert entries[0]["status"] == "completed"
+
+    def test_update_session_info_updates_index_entry(self, session_manager):
+        session_path = session_manager.create_session("M")
+        session_manager.update_session_info(session_path, {"comments": "hi"})
+        index_path = Path(session_path).parent / SessionManager.INDEX_FILENAME
+        entries = json.loads(index_path.read_text())
+        assert entries[0]["comments"] == "hi"
+
+    def test_append_to_session_list_updates_index_entry(self, session_manager):
+        session_path = session_manager.create_session("M")
+        session_manager.append_to_session_list(session_path, "packing_lists_generated", "a.xlsx")
+        index_path = Path(session_path).parent / SessionManager.INDEX_FILENAME
+        entries = json.loads(index_path.read_text())
+        assert entries[0]["packing_lists_generated"] == ["a.xlsx"]
+
+    def test_second_session_appends_not_replaces_index(self, session_manager):
+        session_manager.create_session("M")
+        second_path = Path(session_manager.create_session("M"))
+        index_path = second_path.parent / SessionManager.INDEX_FILENAME
+        entries = json.loads(index_path.read_text())
+        assert len(entries) == 2
+
+    def test_rebuild_index_scans_directory_and_writes_index(self, session_manager):
+        session_path = Path(session_manager.create_session("M"))
+        index_path = session_path.parent / SessionManager.INDEX_FILENAME
+        index_path.unlink()  # simulate pre-existing sessions with no index yet
+        entries = session_manager._rebuild_index(session_path.parent)
+        assert len(entries) == 1
+        assert entries[0]["session_name"] == session_path.name
+        assert index_path.exists()
+
+    def test_read_index_returns_none_when_missing(self, session_manager, tmp_path):
+        empty_dir = tmp_path / "CLIENT_NOINDEX"
+        empty_dir.mkdir()
+        assert session_manager._read_index(empty_dir) is None
+
+    def test_index_write_failure_does_not_break_session_update(self, session_manager, monkeypatch):
+        session_path = session_manager.create_session("M")
+        monkeypatch.setattr(
+            session_manager, "_upsert_index_entry",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        # The primary session_info.json write must still succeed even if the
+        # index-cache update fails.
+        assert session_manager.update_session_status(session_path, "completed") is True
+        info = session_manager.get_session_info(session_path)
+        assert info["status"] == "completed"


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/plans/2026-07-27-ui-responsiveness.md` — stops the app's slow network file server from freezing the GUI on session-browser load, client switch, sidebar refresh, and config save.

- **Session index** (`shopify_tool/session_manager.py`): adds an incrementally-maintained `session_index.json` per client so `list_client_sessions()` costs one file read instead of one-per-session. Self-heals via full-scan rebuild on count mismatch or missing index.
- **Session browser** (`gui/session_browser_widget.py`): defaults to last 30 days with a "Show Older" toggle, and only refetches from the file server when a dirty flag is set (session created/updated) instead of on every `showEvent()`.
- **Client config caching** (`shopify_tool/profile_manager.py`): `load_client_config()` now uses the same mtime-based cache `load_shopify_config()` already had.
- **Client switch, sidebar refresh, config saves** (`gui/main_window_pyside.py`, `gui/client_sidebar.py`, `gui/client_settings_dialog.py`, `gui/settings_window_pyside.py`): moves remaining GUI-thread file-server IO onto background `Worker`/`QThreadPool` tasks, matching the existing pattern used elsewhere in this codebase.

### Deviations from the plan (both verified necessary, details in commit messages)

- Kept `MainWindow.load_client_config()`'s call in the client-switch flow instead of dropping it as "redundant" — it's the only thing that updates `active_profile_config`, which is read throughout `actions_handler.py`/`file_handler.py`. Dropping it would leave that config stale after every client switch.
- Every new `Worker` call site holds a persistent instance-attribute reference to the worker (e.g. `self._client_load_worker`, `self._refresh_worker`, `self._save_worker`). Verified via scripted repro that a bare local `worker` variable — the pattern used elsewhere in this codebase (`barcode_generator_widget.py`, etc.) — gets garbage-collected the instant the calling method returns, which in this PySide6 build destroys the `QRunnable`'s unparented `WorkerSignals` object before its already-queued cross-thread result reaches the main thread, silently dropping the operation every time. The persistent reference fixes it deterministically.

## Test plan

- [x] Full test suite passes: `QT_QPA_PLATFORM=offscreen python -m pytest` (219 passed)
- [x] `ruff check . --exclude shared` clean
- [x] CI-style headless smoke test passes: `CI=1 python run_dev.py`
- [x] Manual verification of async client-switch, sidebar refresh, and config-save flows via scripted event-loop-pumped repros against the real `Worker`/`QThreadPool` machinery (rapid double-switch discards stale results correctly; pin/group changes reflected after sidebar refresh; save button shows "Saving..." and persists correctly for both dialogs)
- [x] `graphify update .` run after code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session browsing now defaults to the last 30 days, with a “Show Older” toggle and smarter refresh behavior.
  - Faster session listing via a per-client session index with self-healing when stale or missing.
- **Bug Fixes**
  - Session browser reliably updates after packing-list changes and avoids unnecessary refreshes when returning to the session view.
- **New Features / Improvements**
  - Client switching, sidebar refresh, and settings/client config saves now run asynchronously to prevent UI freezes, with clearer success/error handling.
  - Client config loading is now mtime-cached and properly invalidated after saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->