### PR TITLE
Phase 2 investigation spikes: fix undo bulk-op index mismatch, Order_Min_Box mislabeling, add dimension Quick Add

### DIFF
--- a/gui/settings_window_pyside.py
+++ b/gui/settings_window_pyside.py
@@ -2251,6 +2251,44 @@ class SettingsWindow(QDialog):
         prod_toolbar.addStretch()
         products_layout.addLayout(prod_toolbar)
 
+        # ---- Quick Add (fast one-at-a-time entry) ----
+        quick_add_box = QGroupBox("Quick Add")
+        quick_add_row = QHBoxLayout(quick_add_box)
+        quick_add_row.setContentsMargins(8, 4, 8, 4)
+
+        self.weight_quick_sku = QLineEdit()
+        self.weight_quick_sku.setPlaceholderText("SKU")
+        self.weight_quick_sku.setMaximumWidth(140)
+        quick_add_row.addWidget(self.weight_quick_sku)
+
+        self.weight_quick_name = QLineEdit()
+        self.weight_quick_name.setPlaceholderText("Name (optional)")
+        quick_add_row.addWidget(self.weight_quick_name, 1)
+
+        self.weight_quick_l = QDoubleSpinBox()
+        self.weight_quick_w = QDoubleSpinBox()
+        self.weight_quick_h = QDoubleSpinBox()
+        for label_text, spin in (("L:", self.weight_quick_l), ("W:", self.weight_quick_w), ("H:", self.weight_quick_h)):
+            quick_add_row.addWidget(QLabel(label_text))
+            spin.setRange(0, 1000)
+            spin.setDecimals(1)
+            spin.setSuffix(" cm")
+            spin.setMaximumWidth(90)
+            quick_add_row.addWidget(spin)
+
+        self.weight_quick_no_pkg = QCheckBox("No Packaging")
+        quick_add_row.addWidget(self.weight_quick_no_pkg)
+
+        quick_add_btn = QPushButton("Add")
+        quick_add_btn.setToolTip("Add this SKU and keep the form open for the next one (Enter also works)")
+        quick_add_btn.clicked.connect(self._weight_quick_add_product)
+        quick_add_row.addWidget(quick_add_btn)
+
+        self.weight_quick_sku.returnPressed.connect(self._weight_quick_add_product)
+        self.weight_quick_name.returnPressed.connect(self._weight_quick_add_product)
+
+        products_layout.addWidget(quick_add_box)
+
         self.products_search = QLineEdit()
         self.products_search.setPlaceholderText("Search by SKU or name...")
         self.products_search.setClearButtonEnabled(True)
@@ -2438,22 +2476,72 @@ class SettingsWindow(QDialog):
             visible = not text or text in name_text
             self.weight_boxes_table.setRowHidden(row, not visible)
 
-    def _weight_add_product_row(self):
-        """Add a blank product row to the products table."""
+    def _weight_append_product_row(self, sku="", name="", l="", w="", h="", no_pkg=False):
+        """Append one product row to the products table, filled with the given values."""
+        divisor = float(self.weight_divisor_spin.value() or 6000)
         row = self.weight_products_table.rowCount()
         self.weight_products_table.insertRow(row)
-        for col in range(6):
-            self.weight_products_table.setItem(row, col, QTableWidgetItem(""))
-        vol_item = QTableWidgetItem("0.0")
+        self.weight_products_table.setItem(row, 0, QTableWidgetItem(sku))
+        self.weight_products_table.setItem(row, 1, QTableWidgetItem(name))
+        self.weight_products_table.setItem(row, 2, QTableWidgetItem(str(l) if l else ""))
+        self.weight_products_table.setItem(row, 3, QTableWidgetItem(str(w) if w else ""))
+        self.weight_products_table.setItem(row, 4, QTableWidgetItem(str(h) if h else ""))
+        try:
+            vol_w = round((float(l or 0) * float(w or 0) * float(h or 0)) / divisor, 4) if divisor > 0 else 0.0
+        except ValueError:
+            vol_w = 0.0
+        vol_item = QTableWidgetItem(str(vol_w))
         vol_item.setFlags(vol_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
         self.weight_products_table.setItem(row, 5, vol_item)
         chk_widget = QWidget()
         chk_layout = QHBoxLayout(chk_widget)
         chk_layout.setContentsMargins(8, 2, 8, 2)
         chk = QCheckBox()
+        chk.setChecked(no_pkg)
         chk_layout.addWidget(chk)
         chk_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.weight_products_table.setCellWidget(row, 6, chk_widget)
+        return row
+
+    def _weight_add_product_row(self):
+        """Add a blank product row to the products table."""
+        self._weight_append_product_row()
+
+    def _weight_quick_add_product(self):
+        """Add one product from the Quick Add form and reset it for the next entry."""
+        sku = self.weight_quick_sku.text().strip()
+        if not sku:
+            self.weight_quick_sku.setFocus()
+            return
+
+        existing_skus = {
+            self.weight_products_table.item(r, 0).text().strip()
+            for r in range(self.weight_products_table.rowCount())
+            if self.weight_products_table.item(r, 0)
+        }
+        if sku in existing_skus:
+            QMessageBox.warning(
+                self, "Duplicate SKU",
+                f"SKU '{sku}' is already in the table. Edit it there instead."
+            )
+            return
+
+        self._weight_append_product_row(
+            sku=sku,
+            name=self.weight_quick_name.text().strip(),
+            l=self.weight_quick_l.value(),
+            w=self.weight_quick_w.value(),
+            h=self.weight_quick_h.value(),
+            no_pkg=self.weight_quick_no_pkg.isChecked(),
+        )
+
+        self.weight_quick_sku.clear()
+        self.weight_quick_name.clear()
+        self.weight_quick_l.setValue(0)
+        self.weight_quick_w.setValue(0)
+        self.weight_quick_h.setValue(0)
+        self.weight_quick_no_pkg.setChecked(False)
+        self.weight_quick_sku.setFocus()
 
     def _weight_add_box_row(self):
         """Add a blank box row to the boxes table."""

--- a/shopify_tool/undo_manager.py
+++ b/shopify_tool/undo_manager.py
@@ -21,7 +21,8 @@ class UndoManager:
     """Manages undo history for DataFrame operations.
 
     Only stores affected rows (not full DataFrame) for memory efficiency.
-    Supports single-level undo (can undo last operation only).
+    Supports multi-level undo (up to max_history operations back), not just
+    the last operation.
     """
 
     def __init__(self, main_window):
@@ -497,23 +498,30 @@ class UndoManager:
             True if successful
         """
         try:
-            params.get("affected_indexes", [])
-
             if affected_rows_before.empty:
                 self.log.warning("No affected rows to restore")
                 return False
 
-            # The affected_rows_before DataFrame has the original indexes as its index
-            # We need to restore Order_Fulfillment_Status from before state
-            for idx, row in affected_rows_before.iterrows():
-                original_status = row.get("Order_Fulfillment_Status")
-                # Find matching row in current DataFrame
-                # After reset_index, we need to find by other criteria or use iloc
-                if pd.notna(original_status) and idx in self.main_window.analysis_results_df.index:
-                    self.main_window.analysis_results_df.loc[idx, "Order_Fulfillment_Status"] = original_status
+            # affected_rows_before round-trips through JSON (to_dict('records') /
+            # pd.DataFrame(...)) between record and undo, which discards its original
+            # pandas index and replaces it with a fresh 0..n-1 range. That range does
+            # NOT correspond to positions in the live DataFrame, so restoring by index
+            # label silently writes into unrelated rows. Match by Order_Number instead
+            # (same approach as _undo_toggle_status), since status is order-level.
+            df = self.main_window.analysis_results_df
+            restored = 0
+            for order_number, group in affected_rows_before.groupby("Order_Number"):
+                original_status = group["Order_Fulfillment_Status"].iloc[0]
+                if pd.isna(original_status):
+                    continue
+                mask = df["Order_Number"].astype(str).str.strip() == str(order_number).strip()
+                if mask.any():
+                    df.loc[mask, "Order_Fulfillment_Status"] = original_status
+                    restored += 1
 
-            self.log.info(f"Undid bulk status change for {len(affected_rows_before)} rows")
-            return True
+            self.main_window.analysis_results_df = df
+            self.log.info(f"Undid bulk status change for {restored} orders")
+            return restored > 0
 
         except Exception:
             self.log.exception("Failed to undo bulk status change")
@@ -534,14 +542,22 @@ class UndoManager:
                 self.log.warning("No affected rows to restore")
                 return False
 
-            # Restore Internal_Tags from before state (representative rows only)
-            for idx, row in affected_rows_before.iterrows():
-                original_tags = row.get("Internal_Tags", "[]")
-                if idx in self.main_window.analysis_results_df.index:
-                    self.main_window.analysis_results_df.loc[idx, "Internal_Tags"] = original_tags
+            # See _undo_bulk_change_status: affected_rows_before's index is not
+            # meaningful after the record/undo JSON round-trip. Match by
+            # Order_Number and restore the order's first current row (mirrors
+            # which row the original bulk_add_tag/bulk_remove_tag wrote to).
+            df = self.main_window.analysis_results_df
+            restored = 0
+            for order_number, group in affected_rows_before.groupby("Order_Number"):
+                original_tags = group["Internal_Tags"].iloc[0] if "Internal_Tags" in group.columns else "[]"
+                order_rows = df.index[df["Order_Number"] == order_number]
+                if len(order_rows):
+                    df.loc[order_rows[0], "Internal_Tags"] = original_tags
+                    restored += 1
 
-            self.log.info(f"Undid bulk add tag for {len(affected_rows_before)} orders")
-            return True
+            self.main_window.analysis_results_df = df
+            self.log.info(f"Undid bulk add tag for {restored} orders")
+            return restored > 0
 
         except Exception:
             self.log.exception("Failed to undo bulk add tag")
@@ -562,14 +578,20 @@ class UndoManager:
                 self.log.warning("No affected rows to restore")
                 return False
 
-            # Restore Internal_Tags from before state (representative rows only)
-            for idx, row in affected_rows_before.iterrows():
-                original_tags = row.get("Internal_Tags", "[]")
-                if idx in self.main_window.analysis_results_df.index:
-                    self.main_window.analysis_results_df.loc[idx, "Internal_Tags"] = original_tags
+            # See _undo_bulk_change_status: match by Order_Number, not the
+            # (JSON-round-trip-reset) DataFrame index.
+            df = self.main_window.analysis_results_df
+            restored = 0
+            for order_number, group in affected_rows_before.groupby("Order_Number"):
+                original_tags = group["Internal_Tags"].iloc[0] if "Internal_Tags" in group.columns else "[]"
+                order_rows = df.index[df["Order_Number"] == order_number]
+                if len(order_rows):
+                    df.loc[order_rows[0], "Internal_Tags"] = original_tags
+                    restored += 1
 
-            self.log.info(f"Undid bulk remove tag for {len(affected_rows_before)} orders")
-            return True
+            self.main_window.analysis_results_df = df
+            self.log.info(f"Undid bulk remove tag for {restored} orders")
+            return restored > 0
 
         except Exception:
             self.log.exception("Failed to undo bulk remove tag")

--- a/shopify_tool/weight_calculator.py
+++ b/shopify_tool/weight_calculator.py
@@ -288,20 +288,19 @@ def enrich_dataframe_with_weights(df: pd.DataFrame, weight_config: dict) -> pd.D
     order_all_no_pkg = {}
     order_min_box = {}
 
-    boxes = weight_config.get("boxes", [])
-
     for order_num, order_group in df.groupby("Order_Number"):
         order_vol_weights[order_num] = calc_order_volumetric_weight(order_group, weight_config)
         order_all_no_pkg[order_num] = is_all_no_packaging(order_group, weight_config)
-        if boxes:
-            order_min_box[order_num] = find_min_box_for_order(order_group, weight_config)
+        # find_min_box_for_order already returns the correct sentinel (NO_BOX_NEEDED /
+        # NO_BOX_FITS / UNKNOWN_DIMS) when weight_config["boxes"] is empty -- skipping
+        # the call here used to force every order to UNKNOWN_DIMS even when it plainly
+        # needed no box at all, which is wrong (and misleads Rule Engine conditions on
+        # Order_Min_Box).
+        order_min_box[order_num] = find_min_box_for_order(order_group, weight_config)
 
     df["Order_Volumetric_Weight"] = df["Order_Number"].map(order_vol_weights).fillna(0.0)
     df["All_No_Packaging"] = df["Order_Number"].map(order_all_no_pkg).fillna(False)
-    if boxes:
-        df["Order_Min_Box"] = df["Order_Number"].map(order_min_box).fillna(UNKNOWN_DIMS)
-    else:
-        df["Order_Min_Box"] = UNKNOWN_DIMS
+    df["Order_Min_Box"] = df["Order_Number"].map(order_min_box).fillna(UNKNOWN_DIMS)
 
     logger.info(
         f"[WeightCalc] Enriched {len(df)} rows with volumetric weights. "

--- a/tests/test_settings_window_weight_quick_add.py
+++ b/tests/test_settings_window_weight_quick_add.py
@@ -1,0 +1,84 @@
+"""Regression/behavior test for the Weight tab's Quick Add panel
+(gui.settings_window_pyside.SettingsWindow._weight_quick_add_product).
+
+Exercises the bound methods directly against a bare QWidget standing in for
+SettingsWindow, rather than constructing the real SettingsWindow -- its full
+__init__ builds every settings tab and hangs under the offscreen QPA
+platform (no way to dismiss real dialogs headlessly), which this test has
+no need to go through just to check the Quick Add row-insertion logic.
+"""
+import pytest
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QDialog,
+    QDoubleSpinBox,
+    QLineEdit,
+    QTableWidget,
+)
+
+from gui.settings_window_pyside import SettingsWindow
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def sw(qapp):
+    """A real SettingsWindow instance with only QDialog.__init__ run (not
+    SettingsWindow.__init__, which builds every settings tab and hangs under
+    the offscreen QPA platform), carrying just the attributes the Quick Add
+    methods touch. Using the real class (not a bare QWidget) keeps `self.` calls
+    inside those methods resolving to the real bound methods."""
+    obj = SettingsWindow.__new__(SettingsWindow)
+    QDialog.__init__(obj)
+    obj.weight_products_table = QTableWidget(0, 7)
+    obj.weight_divisor_spin = QDoubleSpinBox()
+    obj.weight_divisor_spin.setValue(6000)
+    obj.weight_quick_sku = QLineEdit()
+    obj.weight_quick_name = QLineEdit()
+    obj.weight_quick_l = QDoubleSpinBox()
+    obj.weight_quick_w = QDoubleSpinBox()
+    obj.weight_quick_h = QDoubleSpinBox()
+    obj.weight_quick_no_pkg = QCheckBox()
+    return obj
+
+
+def test_quick_add_appends_a_row_and_resets_the_form(sw):
+    sw.weight_quick_sku.setText("NEWSKU")
+    sw.weight_quick_name.setText("Test product")
+    sw.weight_quick_l.setValue(5)
+    sw.weight_quick_w.setValue(6)
+    sw.weight_quick_h.setValue(7)
+    sw.weight_quick_no_pkg.setChecked(True)
+
+    SettingsWindow._weight_quick_add_product(sw)
+
+    assert sw.weight_products_table.rowCount() == 1
+    assert sw.weight_products_table.item(0, 0).text() == "NEWSKU"
+    assert sw.weight_products_table.item(0, 1).text() == "Test product"
+    assert sw.weight_products_table.item(0, 2).text() == "5.0"
+    assert sw.weight_products_table.cellWidget(0, 6).findChild(QCheckBox).isChecked()
+    # form resets for the next entry
+    assert sw.weight_quick_sku.text() == ""
+    assert sw.weight_quick_l.value() == 0
+
+
+def test_quick_add_rejects_blank_sku(sw):
+    SettingsWindow._weight_quick_add_product(sw)
+    assert sw.weight_products_table.rowCount() == 0
+
+
+def test_quick_add_rejects_duplicate_sku_without_adding_a_row(sw, monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+
+    sw.weight_quick_sku.setText("DUPE")
+    SettingsWindow._weight_quick_add_product(sw)
+    assert sw.weight_products_table.rowCount() == 1
+
+    sw.weight_quick_sku.setText("DUPE")
+    SettingsWindow._weight_quick_add_product(sw)
+    assert sw.weight_products_table.rowCount() == 1

--- a/tests/test_undo_manager.py
+++ b/tests/test_undo_manager.py
@@ -1,0 +1,77 @@
+"""Regression tests for shopify_tool.undo_manager.UndoManager bulk-op undo.
+
+Root cause: record_operation() serializes affected_rows_before via
+to_dict('records'), and undo() reconstructs it via pd.DataFrame(records) --
+this round-trip discards the DataFrame's original index labels and replaces
+them with a fresh 0..n-1 range. The bulk undo handlers used to key off that
+index directly (`if idx in df.index: df.loc[idx, ...] = ...`), so as soon as
+the bulk selection's real index labels weren't already 0..n-1, undo() wrote
+into the wrong rows (or no rows at all) while still reporting success. Fixed
+by matching on Order_Number instead, mirroring the pattern already used by
+the single-row undo handlers (_undo_toggle_status et al).
+"""
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from shopify_tool.undo_manager import UndoManager
+
+
+@pytest.fixture
+def mw():
+    df = pd.DataFrame(
+        {
+            "Order_Number": ["A", "B", "C", "D", "E"],
+            "Order_Fulfillment_Status": ["Fulfillable"] * 5,
+            "Internal_Tags": ["[]"] * 5,
+        }
+    )
+    return SimpleNamespace(
+        analysis_results_df=df,
+        analysis_stats=None,
+        current_client_id="1",
+        session_path=None,
+    )
+
+
+def test_undo_bulk_change_status_restores_the_selected_orders(mw):
+    """Selection lands on non-leading index labels [2, 3] -- the exact shape
+    that previously restored into rows [0, 1] (A, B) instead of [2, 3] (C, D)."""
+    um = UndoManager(mw)
+    selected = [2, 3]
+    affected_before = mw.analysis_results_df.loc[selected].copy()
+    mw.analysis_results_df.loc[selected, "Order_Fulfillment_Status"] = "Not Fulfillable"
+    um.record_operation(
+        "bulk_change_status", "Bulk status C,D", {"affected_indexes": selected}, affected_before
+    )
+
+    ok, _ = um.undo()
+
+    by_order = mw.analysis_results_df.set_index("Order_Number")["Order_Fulfillment_Status"]
+    assert ok is True
+    assert by_order.loc["C"] == "Fulfillable"
+    assert by_order.loc["D"] == "Fulfillable"
+    assert by_order.loc["A"] == "Fulfillable"  # untouched
+    assert by_order.loc["B"] == "Fulfillable"  # untouched
+
+
+def test_undo_bulk_add_tag_restores_the_selected_orders(mw):
+    um = UndoManager(mw)
+    representative = [2, 3]
+    affected_before = mw.analysis_results_df.loc[representative].copy()
+    mw.analysis_results_df.loc[representative, "Internal_Tags"] = '["fragile"]'
+    um.record_operation(
+        "bulk_add_tag",
+        "Bulk add tag",
+        {"affected_indexes": representative, "order_numbers": ["C", "D"]},
+        affected_before,
+    )
+
+    ok, _ = um.undo()
+
+    by_order = mw.analysis_results_df.set_index("Order_Number")["Internal_Tags"]
+    assert ok is True
+    assert by_order.loc["C"] == "[]"
+    assert by_order.loc["D"] == "[]"
+    assert by_order.loc["A"] == "[]"  # untouched

--- a/tests/test_weight_calculator.py
+++ b/tests/test_weight_calculator.py
@@ -5,6 +5,7 @@ import pandas as pd
 from shopify_tool.weight_calculator import (
     NO_BOX_NEEDED,
     calc_order_volumetric_weight,
+    enrich_dataframe_with_weights,
     find_min_box_for_order,
 )
 
@@ -27,3 +28,34 @@ class TestZeroQuantityIsNotCoercedToOne:
     def test_zero_quantity_needs_no_box(self):
         order_df = pd.DataFrame([{"SKU": "A1", "Quantity": 0}])
         assert find_min_box_for_order(order_df, _weight_config()) == NO_BOX_NEEDED
+
+
+class TestOrderMinBoxWithNoBoxesConfigured:
+    """Root cause: enrich_dataframe_with_weights() used to skip calling
+    find_min_box_for_order() entirely whenever weight_config["boxes"] was
+    empty, forcing every order to UNKNOWN_DIMS -- even orders whose items are
+    all no_packaging=True and plainly need no box at all. find_min_box_for_order()
+    already resolves this correctly on its own; the guard was redundant and wrong."""
+
+    def test_all_no_packaging_order_is_labeled_no_box_needed_not_unknown(self):
+        config = {
+            "volumetric_divisor": 6000,
+            "products": {"A1": {"no_packaging": True}},
+            "boxes": [],
+        }
+        df = pd.DataFrame([{"Order_Number": "1001", "SKU": "A1", "Quantity": 1}])
+
+        result = enrich_dataframe_with_weights(df, config)
+
+        assert result.loc[0, "Order_Min_Box"] == NO_BOX_NEEDED
+
+    def test_order_needing_packaging_with_no_boxes_configured_is_no_box_fits(self):
+        """Dimensions ARE known here, so this must be distinguishable from the
+        genuinely-unknown-dims case -- NO_BOX_FITS, not UNKNOWN_DIMS."""
+        from shopify_tool.weight_calculator import NO_BOX_FITS
+
+        df = pd.DataFrame([{"Order_Number": "1001", "SKU": "A1", "Quantity": 1}])
+
+        result = enrich_dataframe_with_weights(df, _weight_config())
+
+        assert result.loc[0, "Order_Min_Box"] == NO_BOX_FITS


### PR DESCRIPTION
## Summary

Three items from the Roadmap → Phase 2 investigation spikes (Green Delivery Development, Todoist):

**1. Undo: bulk-op restores silently touch the wrong rows (or none)**

`record_operation()` serializes `affected_rows_before` via `to_dict('records')`, and `undo()` reconstructs it via `pd.DataFrame(records)`. That round-trip discards the DataFrame's original index labels and replaces them with a fresh `0..n-1` range. `_undo_bulk_change_status` / `_undo_bulk_add_tag` / `_undo_bulk_remove_tag` keyed restoration off that stale index (`if idx in df.index: ...`), so as soon as the real selected rows weren't already at positions `0..n-1`, undo wrote into unrelated rows — or found nothing to restore — while still reporting `"Undone: ..."` success. Reproduced with a minimal, single-immediate-undo case (no chaining required).

Fixed by matching on `Order_Number` instead, the same approach already used successfully by the single-row handlers (`_undo_toggle_status`, `_undo_add_tag`). Also corrected the class docstring, which claimed single-level undo while `current_position` has always supported walking back through the full history.

**2. Weight calculator: `Order_Min_Box` forced to `UNKNOWN_DIMS` whenever no boxes are configured yet**

`enrich_dataframe_with_weights()` skipped calling `find_min_box_for_order()` entirely when `weight_config["boxes"]` was empty, so every order — including ones where all items are `no_packaging=True` and plainly need no box — got labeled `UNKNOWN_DIMS`. `find_min_box_for_order()` already resolves this correctly on its own (`NO_BOX_NEEDED` / `NO_BOX_FITS` / `UNKNOWN_DIMS`); the guard was redundant and wrong. This also affects Rule Engine conditions keyed on `Order_Min_Box`.

**3. Weight tab: Quick Add panel for one-off dimension entry**

Bulk entry was already covered by the existing CSV import; manual one-off entry meant Add Row → click into 3 separate table cells. Added a small form above the products table (SKU/name + L/W/H spin boxes + no-packaging checkbox + Add, Enter also works) that appends the row and clears/refocuses for the next SKU. Factored the row-insertion logic shared with the existing "Add Row" button into `_weight_append_product_row()` instead of duplicating it a fourth time.

## Test plan
- [x] `tests/test_undo_manager.py` — bulk status + bulk tag restore, non-leading index labels
- [x] `tests/test_weight_calculator.py::TestOrderMinBoxWithNoBoxesConfigured`
- [x] `tests/test_settings_window_weight_quick_add.py` — append/reset, blank-SKU rejection, duplicate-SKU rejection
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest` — 253 passed
- [x] `ruff check . --exclude shared` — clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-level undo reliability for bulk status and tag changes, restoring the correct orders without relying on row positions.
  * Weight tab packaging results now correctly distinguish “no packaging needed,” “no box fits,” and “unknown dimensions.”
* **New Features**
  * Added “Quick Add” to the Weight tab to enter a SKU and dimensions (including optional “No Packaging”) and insert it into the products table.
* **Tests**
  * Added regression tests for bulk undo and for Weight tab quick-add and packaging-resolution edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->