### PR TITLE
Fix frozen build crash on Reference Labels (missing reportlab barcode submodules)

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -86,10 +86,15 @@ jobs:
         run: |
           C:\msys64\usr\bin\pacman.exe -S --noconfirm --needed mingw-w64-x86_64-pango
       - name: Build with PyInstaller
+        # reportlab.graphics.barcode registers each barcode type (code93,
+        # code39, ...) via exec()'d import strings, invisible to PyInstaller's
+        # static analysis -- omitting this crashes any frozen build on first
+        # barcode import with "ModuleNotFoundError: reportlab.graphics.barcode.code93".
         run: >
           pyinstaller --name ShopifyFulfillmentTool --onedir --windowed --noconfirm
           --add-data "shopify_tool/templates;shopify_tool/templates"
           --collect-data blabel
+          --collect-submodules reportlab.graphics.barcode
           gui_main.py
       - name: Bundle GTK DLLs
         shell: pwsh


### PR DESCRIPTION
## Summary
- PR #262 added `from reportlab.graphics.barcode import code128` to `shopify_tool/pdf_processor.py` for the new Reference Labels barcode overlay.
- That import triggers reportlab's barcode-widget registry, which registers every barcode type (`code93`, `code39`, `msi`, `eanbc`, `qr`, ...) via `exec()`'d import strings — invisible to PyInstaller's static analysis.
- Confirmed in production: real build crashed on first Reference Labels PDF with `ModuleNotFoundError: No module named 'reportlab.graphics.barcode.code93'` (see execution log traceback through `gui/reference_labels_widget.py` → `shopify_tool/pdf_processor.py` → `reportlab/graphics/barcode/widgets.py`).
- Fix: add `--collect-submodules reportlab.graphics.barcode` to the PyInstaller build command in `.github/workflows/build_release.yml`, so PyInstaller bundles every barcode submodule instead of only the statically-visible ones.

## Verification
- Reproduced the exact crash locally: froze a minimal repro script with PyInstaller (pure-Python issue, platform-independent) — got the identical `ModuleNotFoundError: reportlab.graphics.barcode.code93` traceback.
- Rebuilt the same repro with `--collect-submodules reportlab.graphics.barcode` added — clean run, no crash.
- No Python source changes; this is a build-config-only fix, so the existing test suite / lint are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNH4EPEWgSZ9yxWESPRXmU