### PR TITLE
Fix Reference Labels barcode/ref layout: normalize rotation, center, add separator

### DIFF
--- a/shopify_tool/pdf_processor.py
+++ b/shopify_tool/pdf_processor.py
@@ -174,6 +174,14 @@ def process_reference_labels(
 
             if ref:
                 try:
+                    # Courier PDFs set wildly different page /Rotate values (some
+                    # ship pre-rotated 90/270 label stock instead of authoring
+                    # content upright). Bake rotation into content first so
+                    # mediabox always reflects the true visual page -- otherwise
+                    # the "bottom" strip below lands on a different physical edge
+                    # (top/left/right) depending on which courier produced the PDF.
+                    page.transfer_rotation_to_content()
+
                     page_width = float(page.mediabox.width)
                     page_height = float(page.mediabox.height)
 
@@ -506,8 +514,9 @@ def create_reference_overlay(
 ) -> BytesIO:
     """
     Create PDF overlay with the Reference Number and a horizontal Code-128
-    barcode encoding it, positioned in the bottom strip freed up by
-    process_reference_labels()'s content-shrink transform.
+    barcode encoding it, centered as one block in the bottom-middle of the
+    strip freed up by process_reference_labels()'s content-shrink transform,
+    with a separator line marking the strip off from the original content.
 
     Args:
         reference_number: Reference number to display and encode
@@ -523,15 +532,26 @@ def create_reference_overlay(
     strip_height = page_height * (1 - _CONTENT_SCALE)
     margin = 8
 
+    # Separator: marks the boundary between the shrunk courier content above
+    # and the added reference strip below, so the two are never mistaken for
+    # one continuous original label.
+    can.setLineWidth(0.75)
+    can.line(margin, strip_height, page_width - margin, strip_height)
+
     can.setFont("Helvetica-Bold", 10)
     text = f"REF: {reference_number}"
-    text_y = strip_height / 2 - 3
-    can.drawString(margin, text_y, text)
     text_width = can.stringWidth(text, "Helvetica-Bold", 10)
 
     bar_height = strip_height * 0.6
     barcode = code128.Code128(reference_number, barHeight=bar_height, barWidth=0.8)
-    barcode.drawOn(can, margin + text_width + 12, (strip_height - bar_height) / 2)
+
+    gap = 12
+    block_width = text_width + gap + barcode.width
+    block_x = (page_width - block_width) / 2
+
+    text_y = strip_height / 2 - 3
+    can.drawString(block_x, text_y, text)
+    barcode.drawOn(can, block_x + text_width + gap, (strip_height - bar_height) / 2)
 
     can.save()
     packet.seek(0)

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -64,6 +64,45 @@ class TestProcessReferenceLabelsShrink:
         assert "REF: REF-001" in page.extract_text()
 
 
+class TestProcessReferenceLabelsRotation:
+    def test_rotated_page_normalized_before_shrink(self, tmp_path):
+        """Courier PDFs vary in /Rotate (some ship pre-rotated label stock).
+        The strip must always land on the true visual bottom, not the raw
+        mediabox's unrotated bottom edge."""
+        pdf_path = tmp_path / "courier.pdf"
+        _make_courier_pdf(pdf_path, width_pt=288, height_pt=432)
+
+        reader = PdfReader(str(pdf_path))
+        writer_page = reader.pages[0]
+        writer_page.rotate(90)
+        from pypdf import PdfWriter
+        rotated_writer = PdfWriter()
+        rotated_writer.add_page(writer_page)
+        rotated_pdf_path = tmp_path / "courier_rotated.pdf"
+        with open(rotated_pdf_path, "wb") as f:
+            rotated_writer.write(f)
+
+        csv_path = tmp_path / "mapping.csv"
+        csv_path.write_text(
+            "PostOne,Tracking,Reference,Col3,Col4,Col5,Name\n"
+            ",,REF-001,,,,Acme Warehouse Co\n"
+        )
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+
+        result = pdf_processor.process_reference_labels(
+            str(rotated_pdf_path), str(csv_path), str(output_dir)
+        )
+        assert result["matched"] == 1
+
+        out_page = PdfReader(result["output_file"]).pages[0]
+        # Rotation baked into content and reset -- mediabox now reflects the
+        # true visual page (swapped from the original 288x432 mediabox).
+        assert out_page.rotation == 0
+        assert float(out_page.mediabox.width) == pytest.approx(432)
+        assert float(out_page.mediabox.height) == pytest.approx(288)
+
+
 class TestCreateReferenceOverlayBarcode:
     def test_draws_code128_barcode_with_reference_value(self, monkeypatch):
         from reportlab.graphics.barcode import code128
@@ -89,3 +128,66 @@ class TestCreateReferenceOverlayBarcode:
         overlay_pdf = pdf_processor.create_reference_overlay("REF-001", 288, 432)
         reader = PdfReader(overlay_pdf)
         assert len(reader.pages) == 1
+
+
+class TestCreateReferenceOverlayLayout:
+    def test_ref_and_barcode_block_is_horizontally_centered(self, monkeypatch):
+        from reportlab.graphics.barcode import code128
+        from reportlab.pdfgen import canvas as canvas_mod
+
+        page_width = 288
+        draw_string_calls = []
+        original_draw_string = canvas_mod.Canvas.drawString
+
+        def spy_draw_string(self, x, y, text, **kwargs):
+            draw_string_calls.append((x, y, text))
+            return original_draw_string(self, x, y, text, **kwargs)
+
+        monkeypatch.setattr(canvas_mod.Canvas, "drawString", spy_draw_string)
+
+        barcode_calls = []
+        original_draw_on = code128.Code128.drawOn
+
+        def spy_draw_on(self, canv, x, y, **kwargs):
+            barcode_calls.append((x, self.width))
+            return original_draw_on(self, canv, x, y, **kwargs)
+
+        monkeypatch.setattr(code128.Code128, "drawOn", spy_draw_on)
+
+        pdf_processor.create_reference_overlay("REF-001", page_width, 432)
+
+        text_x, _text_y, text = draw_string_calls[0]
+        barcode_x, barcode_width = barcode_calls[0]
+
+        block_start = text_x
+        block_end = barcode_x + barcode_width
+        block_center = (block_start + block_end) / 2
+
+        # The combined REF-text + barcode block sits centered on the page,
+        # not left-margin-anchored -- "bottom middle", not "bottom left".
+        assert block_center == pytest.approx(page_width / 2, abs=1.0)
+        assert text == "REF: REF-001"
+
+    def test_separator_line_drawn_at_strip_boundary(self, monkeypatch):
+        from reportlab.pdfgen import canvas as canvas_mod
+
+        page_height = 432
+        line_calls = []
+        original_line = canvas_mod.Canvas.line
+
+        def spy_line(self, x1, y1, x2, y2, **kwargs):
+            line_calls.append((x1, y1, x2, y2))
+            return original_line(self, x1, y1, x2, y2, **kwargs)
+
+        monkeypatch.setattr(canvas_mod.Canvas, "line", spy_line)
+
+        pdf_processor.create_reference_overlay("REF-001", 288, page_height)
+
+        assert len(line_calls) == 1
+        x1, y1, x2, y2 = line_calls[0]
+        strip_height = page_height * (1 - pdf_processor._CONTENT_SCALE)
+        # Horizontal line at the top of the reference strip -- the boundary
+        # between the shrunk courier content and the added strip.
+        assert y1 == pytest.approx(strip_height)
+        assert y1 == pytest.approx(y2)
+        assert x2 > x1


### PR DESCRIPTION
## Summary
- Reference Labels' ref-number + Code-128 barcode strip (added in #262) was computed from each page's raw, unrotated `mediabox`, ignoring the page's `/Rotate` attribute. Courier PDFs vary in `/Rotate` (some ship pre-rotated label stock), so the "reserve the bottom strip" logic landed on a different physical edge (top/left/right) depending on which courier produced the PDF — this is the "different layouts... different positions where is top or bottom" behavior reported.
- `process_reference_labels()` now calls `page.transfer_rotation_to_content()` (bakes rotation into content, resets `/Rotate` to 0) before computing the strip, so every matched page is processed in its true visual orientation regardless of source rotation.
- `create_reference_overlay()`: the REF text + barcode were left-margin-anchored; now centered as one block at bottom-middle. A separator line now marks the boundary between the shrunk courier content and the added strip.

Checked `worktree-phase4-blabel-patch` (mentioned as prior worktree work) before starting — it's a stale, unmerged branch diverged from before #259 landed, and its layout commits are for the *Barcode Generator*'s own Code-128/QR label templates (a different feature), not Reference Labels' courier-PDF overlay. Not applicable here.

## Test plan
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest` — 358 passed (4 new tests: rotation normalization, block centering, separator line)
- [x] `ruff check` clean
- [x] Manually rendered processed output for a normal-orientation and a pre-rotated simulated courier PDF (`pypdfium2`) — confirmed ref+barcode strip lands at the true bottom-middle with separator in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNH4EPEWgSZ9yxWESPRXmU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF handling for rotated pages to ensure content is correctly sized, scaled, and positioned.
  * Centered reference text and barcodes more consistently in the bottom content area.
  * Added a separator line to clearly distinguish the reference section.

* **Tests**
  * Added coverage for rotated-page dimensions, rotation normalization, and reference layout alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->