### PR TITLE
Fix raw-ZPL label fit and widen reference-number barcode bars

### DIFF
--- a/gui/barcode_generator_widget.py
+++ b/gui/barcode_generator_widget.py
@@ -20,6 +20,7 @@ from PySide6.QtPrintSupport import QPrinterInfo
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QDoubleSpinBox,
     QGroupBox,
     QHBoxLayout,
     QLabel,
@@ -177,6 +178,34 @@ class BarcodeGeneratorWidget(QWidget):
         self.raw_zpl_rotate_check.setChecked(print_settings["raw_zpl_rotate"])
         layout.addWidget(self.raw_zpl_rotate_check)
 
+        # This flow's own template is always authored at 68x38mm, so fitting
+        # is mostly a safety net here (unlike Reference Labels, where the
+        # source PDF's page size is a courier's and can't be trusted) -- set
+        # it to match whatever label stock is actually loaded if it ever
+        # changes. 0 (default) keeps using the template's own page size.
+        label_size_row = QHBoxLayout()
+        label_size_row.addWidget(QLabel("Fit to label size (mm):"))
+        self.raw_zpl_label_width_spin = QDoubleSpinBox()
+        self.raw_zpl_label_width_spin.setRange(0.0, 500.0)
+        self.raw_zpl_label_width_spin.setDecimals(1)
+        self.raw_zpl_label_width_spin.setSpecialValueText("(use PDF page size)")
+        self.raw_zpl_label_width_spin.setValue(print_settings["raw_zpl_label_width_mm"])
+        self.raw_zpl_label_width_spin.setToolTip(
+            "Physical label width as loaded in the printer, e.g. 68 for this "
+            "flow's default label stock. 0 disables fitting and uses the "
+            "generated PDF's own page size."
+        )
+        label_size_row.addWidget(self.raw_zpl_label_width_spin)
+        label_size_row.addWidget(QLabel("x"))
+        self.raw_zpl_label_height_spin = QDoubleSpinBox()
+        self.raw_zpl_label_height_spin.setRange(0.0, 500.0)
+        self.raw_zpl_label_height_spin.setDecimals(1)
+        self.raw_zpl_label_height_spin.setSpecialValueText("(use PDF page size)")
+        self.raw_zpl_label_height_spin.setValue(print_settings["raw_zpl_label_height_mm"])
+        self.raw_zpl_label_height_spin.setToolTip(self.raw_zpl_label_width_spin.toolTip())
+        label_size_row.addWidget(self.raw_zpl_label_height_spin)
+        layout.addLayout(label_size_row)
+
         printer_row = QHBoxLayout()
         printer_row.addWidget(QLabel("Default printer (driver mode):"))
         self.driver_printer_combo = QComboBox()
@@ -193,6 +222,8 @@ class BarcodeGeneratorWidget(QWidget):
             is_zpl = self.print_mode_combo.currentData() == "raw_zpl"
             self.raw_zpl_target_edit.setEnabled(is_zpl)
             self.raw_zpl_rotate_check.setEnabled(is_zpl)
+            self.raw_zpl_label_width_spin.setEnabled(is_zpl)
+            self.raw_zpl_label_height_spin.setEnabled(is_zpl)
             self.driver_printer_combo.setEnabled(not is_zpl)
 
         _update_zpl_controls_enabled()
@@ -200,6 +231,8 @@ class BarcodeGeneratorWidget(QWidget):
         self.print_mode_combo.currentIndexChanged.connect(self._save_print_settings)
         self.raw_zpl_target_edit.editingFinished.connect(self._save_print_settings)
         self.raw_zpl_rotate_check.toggled.connect(self._save_print_settings)
+        self.raw_zpl_label_width_spin.editingFinished.connect(self._save_print_settings)
+        self.raw_zpl_label_height_spin.editingFinished.connect(self._save_print_settings)
         self.driver_printer_combo.currentIndexChanged.connect(self._save_print_settings)
 
         return group
@@ -617,6 +650,8 @@ class BarcodeGeneratorWidget(QWidget):
             "print_mode": self.print_mode_combo.currentData(),
             "raw_zpl_target": self.raw_zpl_target_edit.text(),
             "raw_zpl_rotate": self.raw_zpl_rotate_check.isChecked(),
+            "raw_zpl_label_width_mm": self.raw_zpl_label_width_spin.value(),
+            "raw_zpl_label_height_mm": self.raw_zpl_label_height_spin.value(),
             "driver_printer_name": self.driver_printer_combo.currentData(),
         })
 

--- a/gui/pdf_printing.py
+++ b/gui/pdf_printing.py
@@ -31,6 +31,8 @@ def load_print_settings(scope: str) -> dict:
         "print_mode": qs.value(f"{scope}/print_mode", "driver"),
         "raw_zpl_target": qs.value(f"{scope}/raw_zpl_target", ""),
         "raw_zpl_rotate": qs.value(f"{scope}/raw_zpl_rotate", False, type=bool),
+        "raw_zpl_label_width_mm": qs.value(f"{scope}/raw_zpl_label_width_mm", 0.0, type=float),
+        "raw_zpl_label_height_mm": qs.value(f"{scope}/raw_zpl_label_height_mm", 0.0, type=float),
         "driver_printer_name": qs.value(f"{scope}/driver_printer_name", ""),
     }
 
@@ -40,6 +42,8 @@ def save_print_settings(scope: str, settings: dict) -> None:
     qs.setValue(f"{scope}/print_mode", settings["print_mode"])
     qs.setValue(f"{scope}/raw_zpl_target", settings["raw_zpl_target"])
     qs.setValue(f"{scope}/raw_zpl_rotate", settings["raw_zpl_rotate"])
+    qs.setValue(f"{scope}/raw_zpl_label_width_mm", settings["raw_zpl_label_width_mm"])
+    qs.setValue(f"{scope}/raw_zpl_label_height_mm", settings["raw_zpl_label_height_mm"])
     qs.setValue(f"{scope}/driver_printer_name", settings["driver_printer_name"])
 
 
@@ -64,8 +68,16 @@ def _print_pdf_raw_zpl_mode(parent, pdf_path: Path, settings: dict) -> bool:
             "Set the raw ZPL printer target in this window's Output/Options section first."
         )
         return False
+    width_mm = settings.get("raw_zpl_label_width_mm", 0.0)
+    height_mm = settings.get("raw_zpl_label_height_mm", 0.0)
+    target_size_mm = (width_mm, height_mm) if width_mm > 0 and height_mm > 0 else None
     try:
-        label_printing.print_pdf_raw_zpl(pdf_path, target, rotate=settings.get("raw_zpl_rotate", False))
+        label_printing.print_pdf_raw_zpl(
+            pdf_path,
+            target,
+            rotate=settings.get("raw_zpl_rotate", False),
+            target_size_mm=target_size_mm,
+        )
         return True
     except (OSError, *label_printing.windows_print_errors()) as error:
         logger.exception("Raw ZPL print failed")

--- a/gui/reference_labels_widget.py
+++ b/gui/reference_labels_widget.py
@@ -16,6 +16,7 @@ from PySide6.QtPrintSupport import QPrinterInfo
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QDoubleSpinBox,
     QFileDialog,
     QGroupBox,
     QHBoxLayout,
@@ -174,6 +175,34 @@ class ReferenceLabelsWidget(QWidget):
         self.raw_zpl_rotate_check.setChecked(print_settings["raw_zpl_rotate"])
         layout.addWidget(self.raw_zpl_rotate_check)
 
+        # Courier PDFs' own page size can't be trusted (the same batch mixes
+        # pages from ~98x147mm up to 152x102mm depending on courier) -- raw
+        # ZPL has no driver to fit that to the physical label, so it prints
+        # shrunk with blank margin instead of filling it. Set both to the
+        # loaded label's real size to fit every page to it; 0 (default)
+        # keeps the old behavior of using each page's own size as-is.
+        label_size_row = QHBoxLayout()
+        label_size_row.addWidget(QLabel("Fit to label size (mm):"))
+        self.raw_zpl_label_width_spin = QDoubleSpinBox()
+        self.raw_zpl_label_width_spin.setRange(0.0, 500.0)
+        self.raw_zpl_label_width_spin.setDecimals(1)
+        self.raw_zpl_label_width_spin.setSpecialValueText("(use PDF page size)")
+        self.raw_zpl_label_width_spin.setValue(print_settings["raw_zpl_label_width_mm"])
+        self.raw_zpl_label_width_spin.setToolTip(
+            "Physical label width as loaded in the printer, e.g. 152.4 for 6x4in "
+            "shipping labels. 0 disables fitting and uses each page's own PDF size."
+        )
+        label_size_row.addWidget(self.raw_zpl_label_width_spin)
+        label_size_row.addWidget(QLabel("x"))
+        self.raw_zpl_label_height_spin = QDoubleSpinBox()
+        self.raw_zpl_label_height_spin.setRange(0.0, 500.0)
+        self.raw_zpl_label_height_spin.setDecimals(1)
+        self.raw_zpl_label_height_spin.setSpecialValueText("(use PDF page size)")
+        self.raw_zpl_label_height_spin.setValue(print_settings["raw_zpl_label_height_mm"])
+        self.raw_zpl_label_height_spin.setToolTip(self.raw_zpl_label_width_spin.toolTip())
+        label_size_row.addWidget(self.raw_zpl_label_height_spin)
+        layout.addLayout(label_size_row)
+
         printer_row = QHBoxLayout()
         printer_row.addWidget(QLabel("Default printer (driver mode):"))
         self.driver_printer_combo = QComboBox()
@@ -190,6 +219,8 @@ class ReferenceLabelsWidget(QWidget):
             is_zpl = self.print_mode_combo.currentData() == "raw_zpl"
             self.raw_zpl_target_edit.setEnabled(is_zpl)
             self.raw_zpl_rotate_check.setEnabled(is_zpl)
+            self.raw_zpl_label_width_spin.setEnabled(is_zpl)
+            self.raw_zpl_label_height_spin.setEnabled(is_zpl)
             self.driver_printer_combo.setEnabled(not is_zpl)
 
         _update_zpl_controls_enabled()
@@ -197,6 +228,8 @@ class ReferenceLabelsWidget(QWidget):
         self.print_mode_combo.currentIndexChanged.connect(self._save_print_settings)
         self.raw_zpl_target_edit.editingFinished.connect(self._save_print_settings)
         self.raw_zpl_rotate_check.toggled.connect(self._save_print_settings)
+        self.raw_zpl_label_width_spin.editingFinished.connect(self._save_print_settings)
+        self.raw_zpl_label_height_spin.editingFinished.connect(self._save_print_settings)
         self.driver_printer_combo.currentIndexChanged.connect(self._save_print_settings)
 
         return group
@@ -582,6 +615,8 @@ class ReferenceLabelsWidget(QWidget):
             "print_mode": self.print_mode_combo.currentData(),
             "raw_zpl_target": self.raw_zpl_target_edit.text(),
             "raw_zpl_rotate": self.raw_zpl_rotate_check.isChecked(),
+            "raw_zpl_label_width_mm": self.raw_zpl_label_width_spin.value(),
+            "raw_zpl_label_height_mm": self.raw_zpl_label_height_spin.value(),
             "driver_printer_name": self.driver_printer_combo.currentData(),
         })
 

--- a/shopify_tool/label_printing.py
+++ b/shopify_tool/label_printing.py
@@ -23,13 +23,37 @@ from zebrafy import ZebrafyImage
 PRINT_DPI = 203
 
 
-def rasterize_pdf(pdf_path: Path, dpi: int = PRINT_DPI) -> list[Image.Image]:
-    """Rasterize every page of pdf_path into a 1-bit PIL Image, one per label."""
+def rasterize_pdf(
+    pdf_path: Path, dpi: int = PRINT_DPI, target_size_mm: tuple[float, float] | None = None
+) -> list[Image.Image]:
+    """Rasterize every page of pdf_path into a 1-bit PIL Image, one per label.
+
+    Raw ZPL has no driver in the loop to reconcile a source page's own size
+    against the physical label loaded in the printer -- ^PW/^LL just mirror
+    whatever pixel dimensions we hand it (see image_to_zpl). Reference
+    Labels source PDFs come from couriers and their page size is not
+    trustworthy: the same batch PDF can mix pages from 98x147mm up to
+    152x102mm. Left alone, a page smaller than the loaded media prints
+    shrunk with blank margin instead of filling the label -- pass
+    target_size_mm (the operator-configured physical label size) to resize
+    every page to it, matching what OS print drivers already do implicitly
+    when scaling a page to the selected paper size.
+    """
     pdf = pdfium.PdfDocument(str(pdf_path))
     images = []
     for page in pdf:
         bitmap = page.render(scale=dpi / 72, grayscale=True)
-        images.append(bitmap.to_pil().convert("1", dither=Image.Dither.NONE))
+        image = bitmap.to_pil()
+        if target_size_mm is not None:
+            width_mm, height_mm = target_size_mm
+            target_px = (round(width_mm / 25.4 * dpi), round(height_mm / 25.4 * dpi))
+            # Resize while still greyscale (LANCZOS) rather than after the
+            # bilevel threshold below -- resizing a already-bilevel image
+            # can only pick whole existing pixels (aliased jagged edges on
+            # thin barcode bars), while resizing greyscale first blends
+            # edges smoothly and *then* thresholds them to clean dots.
+            image = image.resize(target_px, Image.Resampling.LANCZOS)
+        images.append(image.convert("1", dither=Image.Dither.NONE))
     return images
 
 
@@ -67,10 +91,17 @@ def send_raw_linux(device_path: str, data: bytes) -> None:
     Path(device_path).write_bytes(data)
 
 
-def print_pdf_raw_zpl(pdf_path: Path, target: str, rotate: bool = False) -> None:
+def print_pdf_raw_zpl(
+    pdf_path: Path,
+    target: str,
+    rotate: bool = False,
+    target_size_mm: tuple[float, float] | None = None,
+) -> None:
     """Rasterize pdf_path and send each page as its own raw ZPL job to target
-    (a Windows print-queue name, or a device path on Linux dev machines)."""
-    for image in rasterize_pdf(pdf_path):
+    (a Windows print-queue name, or a device path on Linux dev machines).
+    target_size_mm, if given, fits every page to that physical label size
+    (see rasterize_pdf) before rotate is applied."""
+    for image in rasterize_pdf(pdf_path, target_size_mm=target_size_mm):
         data = image_to_zpl(image, rotate=rotate).encode("ascii")
         if sys.platform == "win32":
             send_raw_windows(target, data)

--- a/shopify_tool/pdf_processor.py
+++ b/shopify_tool/pdf_processor.py
@@ -22,9 +22,20 @@ from pypdf import PdfReader, PdfWriter, Transformation
 from reportlab.graphics.barcode import code128
 from reportlab.pdfgen import canvas
 
+from shopify_tool.label_printing import PRINT_DPI
+
 logger = logging.getLogger(__name__)
 
 _CONTENT_SCALE = 0.88
+
+# Code-128 module (narrowest bar) width, sized in whole dots at the raw-ZPL
+# print resolution rather than a bare point value. The previous 0.8pt
+# landed at 0.8 * 203/72 = 2.26 dots -- a fractional dot count where
+# adjacent bars round inconsistently during rasterization and thermal dot
+# gain, blurring the barcode into a near-solid block. 4 whole dots gives
+# each bar a clean, consistent edge.
+_BARCODE_MODULE_DOTS = 4
+_BARCODE_BAR_WIDTH = _BARCODE_MODULE_DOTS * 72 / PRINT_DPI
 
 
 # Custom Exceptions
@@ -543,7 +554,7 @@ def create_reference_overlay(
     text_width = can.stringWidth(text, "Helvetica-Bold", 10)
 
     bar_height = strip_height * 0.6
-    barcode = code128.Code128(reference_number, barHeight=bar_height, barWidth=0.8)
+    barcode = code128.Code128(reference_number, barHeight=bar_height, barWidth=_BARCODE_BAR_WIDTH)
 
     gap = 12
     block_width = text_width + gap + barcode.width

--- a/tests/test_label_printing.py
+++ b/tests/test_label_printing.py
@@ -42,6 +42,40 @@ class TestRasterizePdf:
         assert high.width > low.width
         assert high.height > low.height
 
+    def test_target_size_mm_overrides_source_page_size(self, tmp_path):
+        # The source PDF here is authored at 68x38mm; a courier PDF's own
+        # page size can't be trusted (varies page to page in the same
+        # batch), so target_size_mm must win regardless of the source.
+        pdf_path = _make_pdf(tmp_path, pages=1)
+        image = label_printing.rasterize_pdf(pdf_path, dpi=203, target_size_mm=(100.0, 150.0))[0]
+        assert image.size == (round(100.0 / 25.4 * 203), round(150.0 / 25.4 * 203))
+
+    def test_target_size_mm_normalizes_pages_of_differing_source_size(self, tmp_path):
+        # Reproduces the real bug: a batch PDF where pages have different
+        # native sizes (mixed couriers) must all come out identical once a
+        # target size is given, instead of mirroring their own varying size.
+        from reportlab.lib.units import mm
+        from reportlab.pdfgen import canvas
+
+        pdf_path = tmp_path / "mixed.pdf"
+        c = canvas.Canvas(str(pdf_path))
+        c.setPageSize((98 * mm, 147 * mm))
+        c.showPage()
+        c.setPageSize((114 * mm, 100 * mm))
+        c.showPage()
+        c.save()
+
+        images = label_printing.rasterize_pdf(pdf_path, target_size_mm=(152.4, 101.6))
+        assert images[0].size == images[1].size == (
+            round(152.4 / 25.4 * 203), round(101.6 / 25.4 * 203)
+        )
+
+    def test_no_target_size_mm_keeps_source_page_size(self, tmp_path):
+        pdf_path = _make_pdf(tmp_path, pages=1)
+        default = label_printing.rasterize_pdf(pdf_path)[0]
+        explicit_none = label_printing.rasterize_pdf(pdf_path, target_size_mm=None)[0]
+        assert default.size == explicit_none.size
+
 
 class TestImageToZpl:
     def test_wraps_field_in_xa_xz(self):
@@ -103,6 +137,23 @@ class TestPrintPdfRawZpl:
         label_printing.print_pdf_raw_zpl(pdf_path, "/dev/usb/lp0")
         assert len(sent) == 2
         assert all(target == "/dev/usb/lp0" for target, _ in sent)
+
+    def test_target_size_mm_passed_through_to_rasterize(self, tmp_path, monkeypatch):
+        pdf_path = _make_pdf(tmp_path, pages=1)
+        seen = []
+        original_rasterize = label_printing.rasterize_pdf
+
+        def spy_rasterize(path, dpi=label_printing.PRINT_DPI, target_size_mm=None):
+            seen.append(target_size_mm)
+            return original_rasterize(path, dpi=dpi, target_size_mm=target_size_mm)
+
+        monkeypatch.setattr(label_printing, "rasterize_pdf", spy_rasterize)
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(label_printing, "send_raw_linux", lambda target, data: None)
+
+        label_printing.print_pdf_raw_zpl(pdf_path, "/dev/usb/lp0", target_size_mm=(152.4, 101.6))
+
+        assert seen == [(152.4, 101.6)]
 
 
 class TestWindowsPrintErrors:

--- a/tests/test_pdf_printing.py
+++ b/tests/test_pdf_printing.py
@@ -36,6 +36,7 @@ class TestPrintSettingsRoundTrip:
         settings = pdf_printing.load_print_settings("reference_labels")
         assert settings == {
             "print_mode": "driver", "raw_zpl_target": "", "raw_zpl_rotate": False,
+            "raw_zpl_label_width_mm": 0.0, "raw_zpl_label_height_mm": 0.0,
             "driver_printer_name": "",
         }
 
@@ -44,13 +45,17 @@ class TestPrintSettingsRoundTrip:
             "reference_labels",
             {
                 "print_mode": "raw_zpl", "raw_zpl_target": "ZPL-RAW-Printer",
-                "raw_zpl_rotate": True, "driver_printer_name": "Labels 6x4",
+                "raw_zpl_rotate": True,
+                "raw_zpl_label_width_mm": 152.4, "raw_zpl_label_height_mm": 101.6,
+                "driver_printer_name": "Labels 6x4",
             },
         )
         assert pdf_printing.load_print_settings("reference_labels") == {
             "print_mode": "raw_zpl",
             "raw_zpl_target": "ZPL-RAW-Printer",
             "raw_zpl_rotate": True,
+            "raw_zpl_label_width_mm": 152.4,
+            "raw_zpl_label_height_mm": 101.6,
             "driver_printer_name": "Labels 6x4",
         }
 
@@ -59,14 +64,18 @@ class TestPrintSettingsRoundTrip:
             "reference_labels",
             {
                 "print_mode": "raw_zpl", "raw_zpl_target": "Labels 6x4",
-                "raw_zpl_rotate": False, "driver_printer_name": "Labels 6x4",
+                "raw_zpl_rotate": False,
+                "raw_zpl_label_width_mm": 152.4, "raw_zpl_label_height_mm": 101.6,
+                "driver_printer_name": "Labels 6x4",
             },
         )
         pdf_printing.save_print_settings(
             "barcode_generator",
             {
                 "print_mode": "driver", "raw_zpl_target": "Barcodes",
-                "raw_zpl_rotate": True, "driver_printer_name": "Barcodes",
+                "raw_zpl_rotate": True,
+                "raw_zpl_label_width_mm": 68.0, "raw_zpl_label_height_mm": 38.0,
+                "driver_printer_name": "Barcodes",
             },
         )
 
@@ -102,7 +111,39 @@ class TestPrintPdfRawZplMode:
         )
 
         assert result is True
-        called.assert_called_once_with(pdf_path, "ZPL-RAW-Printer", rotate=True)
+        called.assert_called_once_with(pdf_path, "ZPL-RAW-Printer", rotate=True, target_size_mm=None)
+
+    def test_omits_target_size_when_width_or_height_is_zero(self, monkeypatch, tmp_path):
+        called = Mock()
+        monkeypatch.setattr(pdf_printing.label_printing, "print_pdf_raw_zpl", called)
+        pdf_path = tmp_path / "x.pdf"
+
+        pdf_printing.print_pdf(
+            None, pdf_path,
+            {
+                "print_mode": "raw_zpl", "raw_zpl_target": "ZPL-RAW-Printer", "raw_zpl_rotate": False,
+                "raw_zpl_label_width_mm": 152.4, "raw_zpl_label_height_mm": 0.0,
+            },
+        )
+
+        called.assert_called_once_with(pdf_path, "ZPL-RAW-Printer", rotate=False, target_size_mm=None)
+
+    def test_passes_target_size_when_both_dimensions_configured(self, monkeypatch, tmp_path):
+        called = Mock()
+        monkeypatch.setattr(pdf_printing.label_printing, "print_pdf_raw_zpl", called)
+        pdf_path = tmp_path / "x.pdf"
+
+        pdf_printing.print_pdf(
+            None, pdf_path,
+            {
+                "print_mode": "raw_zpl", "raw_zpl_target": "ZPL-RAW-Printer", "raw_zpl_rotate": False,
+                "raw_zpl_label_width_mm": 152.4, "raw_zpl_label_height_mm": 101.6,
+            },
+        )
+
+        called.assert_called_once_with(
+            pdf_path, "ZPL-RAW-Printer", rotate=False, target_size_mm=(152.4, 101.6)
+        )
 
     def test_exception_shows_critical_and_returns_false(self, monkeypatch, tmp_path):
         critical = Mock()

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -129,6 +129,31 @@ class TestCreateReferenceOverlayBarcode:
         reader = PdfReader(overlay_pdf)
         assert len(reader.pages) == 1
 
+    def test_barcode_module_width_is_whole_dots_at_print_dpi(self, monkeypatch):
+        # 0.8pt (the old value) is 2.26 dots at 203 DPI -- a fractional dot
+        # count where rasterization rounds bars inconsistently, blurring
+        # the barcode into a near-solid block. barWidth must land on a
+        # clean whole-dot count.
+        from reportlab.graphics.barcode import code128
+
+        from shopify_tool.label_printing import PRINT_DPI
+
+        calls = []
+        original_init = code128.Code128.__init__
+
+        def spy_init(self, value, **kwargs):
+            calls.append(kwargs.get("barWidth"))
+            return original_init(self, value, **kwargs)
+
+        monkeypatch.setattr(code128.Code128, "__init__", spy_init)
+
+        pdf_processor.create_reference_overlay("REF-001", 288, 432)
+
+        assert len(calls) == 1
+        module_dots = calls[0] * PRINT_DPI / 72
+        assert module_dots == pytest.approx(round(module_dots))
+        assert module_dots >= 3
+
 
 class TestCreateReferenceOverlayLayout:
     def test_ref_and_barcode_block_is_horizontally_centered(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Raw ZPL printing rendered each page 1:1 from the source PDF's own size with no fit-to-media step. Root-caused against `testbarcodes/1.pdf` (real 18-page multi-courier batch): the same PDF mixes 7 distinct physical page sizes (98x147mm to 152x102mm). Any page smaller than the loaded label stock printed shrunk with blank margin — the OS-driver path (and Adobe) doesn't have this problem because it already scales to the selected paper size. `rasterize_pdf()`/`print_pdf_raw_zpl()` now accept an operator-set `target_size_mm`, resizing every page to it before ZPL encoding. New "Fit to label size (mm)" fields added to both Reference Labels and Barcode Generator print settings; defaults to 0/off so nothing changes until an operator configures it.
- The reference-number Code-128 barcode's `barWidth` (0.8pt) was 2.26 dots at the 203 DPI raw-ZPL print resolution — a fractional dot count where adjacent bars round inconsistently during rasterization/dot-gain, blurring into a near-solid block ("still readable but uncomfortable"). Resized to a clean 4 whole dots.

## Test plan
- [x] `pytest` — 365 passed, no regressions
- [x] `ruff check` — clean
- [x] Ran `process_reference_labels()` end-to-end against real production data (`~/Desktop/testbarcodes/1.pdf` + `2.csv`, 18 rows): 18/18 matched, 0 unmatched
- [x] Verified without the fix, the processed output still rasterizes to 7 distinct physical sizes across 18 pages; with `target_size_mm` set, all 18 normalize to one
- [x] Visually confirmed the barcode-width fix at true 203 DPI rasterization (before/after bar-width render + real REF strip crop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmnsrpigV1AedxZsTsADL9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable raw-ZPL label width and height in millimeters for barcode and reference label printing.
  * Label dimensions are saved with print settings and applied when both values are configured.
  * When dimensions are unset, printing retains the PDF’s original page size.
* **Bug Fixes**
  * Improved barcode sizing for consistent, printer-resolution-aligned output.
  * Preserved existing rotation, validation, and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->