### PR TITLE
Fix analysis-run UI freeze: background the stats-recording network I/O

### DIFF
--- a/gui/actions_handler.py
+++ b/gui/actions_handler.py
@@ -48,6 +48,7 @@ class ActionsHandler(QObject):
         super().__init__()
         self.mw = main_window
         self.log = logging.getLogger(__name__)
+        self._stats_workers = set()  # keeps in-flight stats-recording Workers alive
 
     def create_new_session(self):
         """Creates a new session using SessionManager.
@@ -217,62 +218,35 @@ class ActionsHandler(QObject):
             # pre-depletion stock and over-promise fulfillment on the next run.
 
             # ========================================
-            # NEW: RECORD STATISTICS TO SERVER
+            # RECORD STATISTICS TO SERVER
             # ========================================
-            try:
-                from shared.session_id import derive_session_id
-                from shared.stats_manager import StatsManager
+            # StatsManager.record_analysis() performs blocking network I/O
+            # (file lock, read/write, fsync) over the UNC file share -- a
+            # fixed cost per call, independent of batch size. This method is
+            # a Qt result-signal slot, so it always runs on the GUI thread;
+            # doing that I/O inline here froze the UI on every analysis run.
+            # See docs/superpowers/specs/2026-08-09-packaging-unlock-and-perf-audit-design.md
+            # (Track A). The cheap in-memory counts below stay inline (not
+            # the freeze source); only the network write is backgrounded.
+            orders_count = (
+                len(df["Order_Number"].unique())
+                if "Order_Number" in df.columns
+                else 0
+            )
+            items_count = len(df)
 
-                self.log.info("Recording analysis statistics to server...")
-
-                stats_mgr = StatsManager(
-                    base_path=str(self.mw.profile_manager.base_path)
-                )
-
-                # Get session info
-                session_name = (
-                    derive_session_id(self.mw.session_path)
-                    if self.mw.session_path
-                    else "unknown"
-                )
-
-                # Count unique orders and items
-                orders_count = (
-                    len(df["Order_Number"].unique())
-                    if "Order_Number" in df.columns
+            fulfillable_orders = 0
+            if "Order_Fulfillment_Status" in df.columns:
+                fulfillable_df = df[df["Order_Fulfillment_Status"] == "Fulfillable"]
+                fulfillable_orders = (
+                    len(fulfillable_df["Order_Number"].unique())
+                    if not fulfillable_df.empty
                     else 0
                 )
-                items_count = len(df)
 
-                # Calculate fulfillable orders for metadata
-                fulfillable_orders = 0
-                if "Order_Fulfillment_Status" in df.columns:
-                    fulfillable_df = df[df["Order_Fulfillment_Status"] == "Fulfillable"]
-                    fulfillable_orders = (
-                        len(fulfillable_df["Order_Number"].unique())
-                        if not fulfillable_df.empty
-                        else 0
-                    )
-
-                # Record to stats
-                stats_mgr.record_analysis(
-                    client_id=self.mw.current_client_id,
-                    session_id=session_name,
-                    orders_count=orders_count,
-                    metadata={
-                        "items_count": items_count,
-                        "fulfillable_orders": fulfillable_orders,
-                    },
-                )
-
-                self.log.info(
-                    f"Statistics recorded: {orders_count} orders, {items_count} items, {fulfillable_orders} fulfillable"
-                )
-
-            except Exception:
-                # Don't fail the analysis if stats recording fails
-                self.log.exception("Failed to record statistics")
-                # Continue with normal flow
+            self._record_analysis_stats_async(
+                orders_count, items_count, fulfillable_orders
+            )
             # ========================================
             # END STATISTICS RECORDING
             # ========================================
@@ -298,6 +272,72 @@ class ActionsHandler(QObject):
                 "Analysis Error",
                 f"An error occurred during analysis:\n{result_msg}",
             )
+
+    def _record_analysis_stats_async(self, orders_count, items_count, fulfillable_orders):
+        """Fires off StatsManager.record_analysis() on a background thread.
+
+        StatsManager performs blocking network I/O over the UNC file share --
+        see on_analysis_complete for why this must never run inline on the Qt
+        main thread.
+        """
+        base_path = str(self.mw.profile_manager.base_path)
+        session_path = self.mw.session_path
+        client_id = self.mw.current_client_id
+
+        worker = Worker(
+            self._record_analysis_stats_job,
+            base_path,
+            session_path,
+            client_id,
+            orders_count,
+            items_count,
+            fulfillable_orders,
+        )
+        # Keep a strong reference until the worker finishes -- a bare local
+        # var would let the unparented WorkerSignals object get garbage
+        # collected before Qt dispatches its queued signals (same failure
+        # mode documented on _client_load_workers in main_window_pyside.py).
+        self._stats_workers.add(worker)
+        worker.signals.finished.connect(lambda: self._stats_workers.discard(worker))
+        self.mw.threadpool.start(worker)
+
+    def _record_analysis_stats_job(
+        self,
+        base_path,
+        session_path,
+        client_id,
+        orders_count,
+        items_count,
+        fulfillable_orders,
+    ):
+        """Background-thread body: writes analysis stats to the shared server file."""
+        try:
+            from shared.session_id import derive_session_id
+            from shared.stats_manager import StatsManager
+
+            self.log.info("Recording analysis statistics to server...")
+
+            stats_mgr = StatsManager(base_path=base_path)
+            session_name = (
+                derive_session_id(session_path) if session_path else "unknown"
+            )
+
+            stats_mgr.record_analysis(
+                client_id=client_id,
+                session_id=session_name,
+                orders_count=orders_count,
+                metadata={
+                    "items_count": items_count,
+                    "fulfillable_orders": fulfillable_orders,
+                },
+            )
+
+            self.log.info(
+                f"Statistics recorded: {orders_count} orders, {items_count} items, {fulfillable_orders} fulfillable"
+            )
+        except Exception:
+            # Don't fail the analysis if stats recording fails
+            self.log.exception("Failed to record statistics")
 
     def on_task_error(self, error):
         """Handles the 'error' signal from any worker thread.

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -1568,6 +1568,11 @@ class MainWindow(QMainWindow):
             logger.warning(f"Failed to save window geometry: {e}")
         # Session data is now managed by SessionManager on the server
         # No need to save local session files
+        # Give background workers (e.g. stats recording) a bounded window to
+        # finish their network I/O so closing right after an analysis run
+        # doesn't kill a write mid-flight -- bounded so a hung write can't
+        # hang shutdown.
+        self.threadpool.waitForDone(2000)
         event.accept()
 
 

--- a/tests/test_actions_handler.py
+++ b/tests/test_actions_handler.py
@@ -5,11 +5,13 @@ order with two lines sharing the same SKU would have both lines deleted when
 the user only meant to remove one. The fix threads the clicked row's position
 through from the context menu and removes exactly that row.
 """
+import time
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pandas as pd
 import pytest
+from PySide6.QtCore import QThreadPool
 from PySide6.QtWidgets import QInputDialog, QMessageBox
 
 from gui.actions_handler import ActionsHandler
@@ -133,3 +135,64 @@ def test_bulk_remove_tag_removes_from_every_row_of_a_multi_line_order(mw_with_ta
     assert tags.loc["A1"] == "[]"
     assert tags.loc["A2"] == "[]"  # order 1001's other line, not just the checked one
     assert tags.loc["B1"] == '["URGENT"]'  # different order, untouched
+
+
+def test_on_analysis_complete_does_not_block_ui_thread_on_stats_recording(
+    monkeypatch, tmp_path
+):
+    """Regression test for the analysis-run freeze (Todoist Track A).
+
+    Root cause: StatsManager.record_analysis() performs blocking network I/O
+    (file lock, read/write, fsync) over the UNC file share. on_analysis_complete
+    is a Qt result-signal slot, so it always executes on the GUI thread --
+    running that I/O inline froze the whole UI on every analysis run,
+    regardless of batch size (the network round-trips are a fixed cost, not
+    proportional to the data). The fix hands the stats write off to the
+    existing background QThreadPool instead of calling it inline.
+    """
+    df = pd.DataFrame(
+        [
+            {"Order_Number": "1001", "Order_Fulfillment_Status": "Fulfillable"},
+            {"Order_Number": "1002", "Order_Fulfillment_Status": "Fulfillable"},
+            {"Order_Number": "1003", "Order_Fulfillment_Status": "Unfulfillable"},
+        ]
+    )
+
+    calls = []
+
+    def slow_record_analysis(self, **kwargs):
+        time.sleep(0.3)  # stand-in for slow/contended UNC network I/O
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "shared.stats_manager.StatsManager.record_analysis", slow_record_analysis
+    )
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+
+    mw = SimpleNamespace(
+        session_path=str(tmp_path / "session_1"),
+        current_client_id="M",
+        profile_manager=SimpleNamespace(base_path=tmp_path),
+        threadpool=QThreadPool(),
+        log_activity=Mock(),
+        update_ui_state=Mock(),
+    )
+    handler = ActionsHandler(mw)
+
+    start = time.perf_counter()
+    handler.on_analysis_complete((True, "report.csv", df, {}))
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.2, (
+        f"on_analysis_complete blocked the calling thread for {elapsed:.3f}s -- "
+        "statistics recording must be handed off to a background thread, not "
+        "run inline in this Qt result-signal slot"
+    )
+
+    assert mw.threadpool.waitForDone(2000), "background stats worker never finished"
+    assert len(calls) == 1
+    assert calls[0]["client_id"] == "M"
+    assert calls[0]["session_id"] == "session_1"
+    assert calls[0]["orders_count"] == 3
+    assert calls[0]["metadata"]["items_count"] == 3
+    assert calls[0]["metadata"]["fulfillable_orders"] == 2


### PR DESCRIPTION
## Summary
- Root-causes the recurring "UI freezes a couple seconds on every analysis run, regardless of batch size" complaint: `ActionsHandler.on_analysis_complete` (a Qt result-signal slot, always on the GUI thread) was calling `StatsManager.record_analysis()` inline, which does blocking network I/O (file lock, read/write, fsync) over the UNC file share — a fixed per-call cost, not something that scales with data.
- Hands that write off to the app's existing `QThreadPool`/`Worker`, using the same worker-reference-retention pattern already proven for `_client_load_workers` in `main_window_pyside.py`.
- Follow-up from code review: `closeEvent` now waits up to 2s for background workers to finish before accepting the close, since backgrounding the write removed an accidental protection — the write used to block the event loop, so it couldn't be interrupted by a close mid-write; now it can. Bounded so a hung write can't hang shutdown.

Track A of `docs/superpowers/specs/2026-08-09-packaging-unlock-and-perf-audit-design.md`. Todoist task: "Analysis-run freeze: root-cause the fixed-cost UI freeze" (p2, ahead of Phase 5).

## Test plan
- [x] `QT_QPA_PLATFORM=offscreen python -m pytest` — 366 passed
- [x] `ruff check . --exclude shared` — clean
- [x] New regression test (`tests/test_actions_handler.py::test_on_analysis_complete_does_not_block_ui_thread_on_stats_recording`) verified to fail against the pre-fix code and pass against the fix (confirmed independently during code review by checking out the pre-fix commit)
- [x] Code review completed (general-purpose subagent) — Ready to merge, one Important issue (close-during-write data-loss window) addressed in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Analysis completion remains responsive while statistics are recorded in the background.

* **Reliability**
  * The application now waits briefly for background tasks to finish when closing, helping preserve pending statistics.
  * Statistics-recording failures are logged without interrupting analysis completion.

* **Bug Fixes**
  * Improved handling of slow statistics recording to prevent delays in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->