### PR TITLE
Phase 5 — Table & stats UX: grouped column config, statistics sort/filter, simplified Add Product dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,15 @@ than on Max/API plans. Before starting multi-step work (a `brainstorming`/`writi
 pass, a large implementation, anything spanning many tool calls), check current usage:
 
 ```bash
-claude-monitor --once --output json --plan pro
+claude-monitor --once --output json
 ```
+
+**Don't add `--plan pro`** — it forces a hardcoded, badly-miscalibrated generic ceiling
+(verified ~15-30x too conservative against Claude Code's own official in-app usage panel).
+Omitting `--plan` lets `claude-monitor` auto-calibrate a `custom` limit from this account's
+real historical usage instead, which tracks much closer to reality. It's still a local
+estimate, not an official number — there's no offline source for Anthropic's true usage
+percentage on this machine.
 
 Key fields: `limits.five_hour.used_percentage` / `.resets_at` (rolling 5-hour window — the
 binding day-to-day constraint), `status.label` (`"limit_hit"` means stop and wait for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,28 @@ CI runs lint + this suite + a headless smoke test (see `.github/workflows/build_
 
 ---
 
+## Session Resource Check
+
+Roadmap work on this repo runs on a Claude Pro subscription — token budget is scarcer
+than on Max/API plans. Before starting multi-step work (a `brainstorming`/`writing-plans`
+pass, a large implementation, anything spanning many tool calls), check current usage:
+
+```bash
+claude-monitor --once --output json --plan pro
+```
+
+Key fields: `limits.five_hour.used_percentage` / `.resets_at` (rolling 5-hour window — the
+binding day-to-day constraint), `status.label` (`"limit_hit"` means stop and wait for
+`resets_at`). If usage is already high, prefer smaller/shorter-scoped work this session.
+
+An unattended runner using this same check lives outside this repo at
+`~/automation/claude-roadmap-runner/` (usage-gated cron dispatcher + a fixed orienting
+prompt for overnight roadmap work across this repo and `packing-tool`) — see its
+`prompt.md` for the stage-detection convention it uses when resuming work it left
+mid-flight.
+
+---
+
 ## Shared Module (`shared/`)
 
 `shared/` (theme, logger, stats, file locking, atomic writes, session IDs) is **not owned by this repo**.

--- a/docs/superpowers/plans/2026-08-11-phase5-table-stats-ux-plan.md
+++ b/docs/superpowers/plans/2026-08-11-phase5-table-stats-ux-plan.md
@@ -1,0 +1,1157 @@
+# Phase 5 — Table & Stats UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the three independent Phase 5 UI cleanups (Todoist `6h8v49wj4M3cFxJV`) scoped in `docs/superpowers/specs/2026-08-11-phase5-table-stats-ux-design.md`: a grouped Manage Table Columns list, two small Statistics-tab fixes, and a simplified Add Product to Order dialog.
+
+**Architecture:** No new subsystems — each item is a targeted edit to an existing widget file, following the design doc's code-verified findings. Items are independent; tasks can be done and PR'd in any order, but this plan sequences them Item 1 → Item 2 → Item 3 to match the design doc.
+
+**Tech Stack:** PySide6 (`QListWidget`, `QTableWidget`, `QFormLayout`), pytest with `QT_QPA_PLATFORM=offscreen`.
+
+## Global Constraints
+
+- No hardcoded colors — use `get_theme_manager().get_current_theme()` tokens (per this repo's `CLAUDE.md`). The two `# ponytail:`-marked literal-color blocks already in `add_product_dialog.py` (warning/info tint backgrounds) are pre-existing and out of scope for this plan — leave them as-is except where a task explicitly touches that code.
+- No UI calls from background threads — not applicable here, none of these three items touch threading.
+- Run `QT_QPA_PLATFORM=offscreen python -m pytest` and `ruff check . --exclude shared` before each commit that touches code (per `AGENTS.md` / this repo's `CLAUDE.md`).
+- Run `graphify update .` after the final commit of this plan (per this repo's `CLAUDE.md` — a stale graph gives wrong answers about file relationships).
+
+---
+
+## Task 1: Manage Table Columns — group the column list by category with display names
+
+**Files:**
+- Modify: `gui/column_config_dialog.py` (module-level constants + `ColumnConfigPanel._load_columns`, `_on_search_changed`, `_on_item_changed`, `_on_move_up`, `_on_move_down`, `_on_show_all`, `_on_hide_all`, `_get_config_from_ui`)
+- Test: `tests/test_column_config_dialog.py` (new)
+
+**Interfaces:**
+- Consumes: `gui.table_config_manager.TableConfig` (existing — `visible_columns: dict[str, bool]`, `column_order: list[str]`, `locked_columns: list[str]`).
+- Produces: module-level `COLUMN_CATEGORIES: dict[str, str]`, `COLUMN_DISPLAY_NAMES: dict[str, str]`, `CATEGORY_ORDER: list[str]`, `_CATEGORY_HEADER_MARKER: str` in `gui/column_config_dialog.py`, consumed only within that file. Every `QListWidgetItem` in `self.column_list` now carries the **raw** column name (or `_CATEGORY_HEADER_MARKER` for header rows) in `item.data(Qt.UserRole)` — `item.text()` is now a **display** string only. Any future code touching `self.column_list` must read `item.data(Qt.UserRole)`, not `item.text()`.
+
+Currently `ColumnConfigPanel._load_columns` (`gui/column_config_dialog.py:255-292`) builds a flat, ungrouped `QListWidget` where each item's `text()` *is* the raw DataFrame column name (e.g. `Order_Fulfillment_Status`), and every other method in the class (`_on_item_changed`, `_on_move_up`, `_on_move_down`, `_get_config_from_ui`) reads that same `item.text()` back out as the column name. This task inserts non-checkable, bold category header rows between groups and swaps the checkable items' visible text for a friendlier display name — which means `item.text()` can no longer double as the raw column name. Every one of those call sites must switch to `item.data(Qt.UserRole)` in the same change, or they'll silently start writing display-name strings into `TableConfig.column_order`/`visible_columns` instead of real column names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_column_config_dialog.py`:
+
+```python
+"""Regression test: Manage Table Columns list must group columns under
+category header rows (grouped-list redesign, Phase 5 Item 1) without
+breaking the underlying visible/order round-trip. Root cause risk: switching
+list items to show display names instead of raw column names would break
+every call site that read item.text() as the column name -- this locks in
+item.data(Qt.UserRole) as the source of truth instead.
+"""
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from gui.column_config_dialog import ColumnConfigPanel, _CATEGORY_HEADER_MARKER
+from gui.table_config_manager import TableConfig
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def _make_panel(columns, locked_columns=None):
+    config = TableConfig(
+        visible_columns={col: True for col in columns},
+        column_order=columns,
+        locked_columns=locked_columns if locked_columns is not None else ["Order_Number"],
+    )
+    tcm = Mock()
+    tcm.get_current_config.return_value = config
+    tcm.get_current_view_name.return_value = "Default"
+    tcm.list_views.return_value = ["Default"]
+    tcm.pm.load_client_config.return_value = {}
+    main_window = Mock()
+    main_window.current_client_id = "TESTCLIENT"
+    main_window.analysis_results_df = None
+    return ColumnConfigPanel(tcm, main_window=main_window)
+
+
+def test_columns_are_grouped_under_category_headers():
+    panel = _make_panel(["Order_Number", "SKU", "Fulfillable", "Tags"])
+
+    categories_seen = [
+        panel.column_list.item(i).text()
+        for i in range(panel.column_list.count())
+        if panel.column_list.item(i).data(Qt.UserRole) == _CATEGORY_HEADER_MARKER
+    ]
+
+    assert categories_seen == ["Order Info", "Product Info", "Fulfillment", "Tags & Lot"]
+
+
+def test_get_config_from_ui_skips_header_rows():
+    panel = _make_panel(["Order_Number", "SKU", "Fulfillable"])
+
+    config = panel._get_config_from_ui()
+
+    assert set(config.column_order) == {"Order_Number", "SKU", "Fulfillable"}
+    assert _CATEGORY_HEADER_MARKER not in config.column_order
+
+
+def test_move_up_is_blocked_at_the_top_of_a_category_group():
+    panel = _make_panel(["SKU", "Product_Name"])  # both "Product Info"
+
+    # row 0 = "Product Info" header, row 1 = SKU, row 2 = Product_Name.
+    # Product_Name moving up swaps with SKU -- allowed.
+    panel.column_list.setCurrentRow(2)
+    panel._on_move_up()
+    assert panel.column_list.item(1).data(Qt.UserRole) == "Product_Name"
+
+    # Now at row 1, directly under the header -- moving up again must no-op
+    # instead of swapping with the header row.
+    panel._on_move_up()
+    assert panel.column_list.item(1).data(Qt.UserRole) == "Product_Name"
+
+
+def test_move_up_is_blocked_above_a_locked_column(monkeypatch):
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+    panel = _make_panel(["Order_Number", "Name"])  # both "Order Info"
+
+    # row 0 = header, row 1 = Order_Number (locked), row 2 = Name.
+    panel.column_list.setCurrentRow(2)
+    panel._on_move_up()
+
+    assert panel.column_list.item(1).data(Qt.UserRole) == "Order_Number"
+    assert panel.column_list.item(2).data(Qt.UserRole) == "Name"
+
+
+def test_locked_column_tooltip_still_shows_raw_name():
+    panel = _make_panel(["Order_Number"])
+
+    item = panel.column_list.item(1)  # row 0 = "Order Info" header
+    assert item.data(Qt.UserRole) == "Order_Number"
+    assert "Order_Number" in item.toolTip()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_column_config_dialog.py -v`
+Expected: FAIL — `ImportError: cannot import name '_CATEGORY_HEADER_MARKER'` (module constant doesn't exist yet).
+
+- [ ] **Step 3: Add the category/display-name lookup and import**
+
+In `gui/column_config_dialog.py`, add the import and module-level constants right after `logger = logging.getLogger(__name__)` (line 31):
+
+```python
+from PySide6.QtGui import QColor
+```
+(add to the existing `from PySide6.QtCore import Qt, Signal` block's neighboring imports, i.e. a new top-level import line)
+
+```python
+_CATEGORY_HEADER_MARKER = "__category_header__"
+
+# Category assignment for known analysis-output columns (see
+# shopify_tool/core.py and shopify_tool/analysis.py for the full
+# output-column list). Columns not listed here fall into "Other" rather
+# than being dropped from the list.
+COLUMN_CATEGORIES: dict[str, str] = {
+    "Order_Number": "Order Info",
+    "Name": "Order Info",
+    "Order_Type": "Order Info",
+    "Destination_Country": "Order Info",
+    "Shipping_Method": "Order Info",
+    "Shipping_Provider": "Order Info",
+    "Priority": "Order Info",
+    "Order_Min_Box": "Order Info",
+    "Execution_Date": "Order Info",
+    "Repeat": "Order Info",
+    "SKU": "Product Info",
+    "Product_Name": "Product Info",
+    "Warehouse_Name": "Product Info",
+    "Quantity": "Product Info",
+    "Has_SKU": "Product Info",
+    "Order_Fulfillment_Status": "Fulfillment",
+    "Fulfillable": "Fulfillment",
+    "Stock": "Fulfillment",
+    "Final_Stock": "Fulfillment",
+    "Stock_Alert": "Fulfillment",
+    "Summary_Missing": "Fulfillment",
+    "Summary_Present": "Fulfillment",
+    "Status_Note": "Fulfillment",
+    "Error": "Fulfillment",
+    "System_note": "Fulfillment",
+    "Notes": "Fulfillment",
+    "Tags": "Tags & Lot",
+    "Internal_Tags": "Tags & Lot",
+    "Lot_Details": "Tags & Lot",
+    "Lot_Batch": "Tags & Lot",
+    "Lot_Expiry": "Tags & Lot",
+    "Expiry_Date": "Tags & Lot",
+}
+
+CATEGORY_ORDER: list[str] = ["Order Info", "Product Info", "Fulfillment", "Tags & Lot", "Other"]
+
+COLUMN_DISPLAY_NAMES: dict[str, str] = {
+    "Order_Number": "Order Number",
+    "Name": "Order Name",
+    "Order_Type": "Order Type",
+    "Destination_Country": "Destination Country",
+    "Shipping_Method": "Shipping Method",
+    "Shipping_Provider": "Shipping Provider",
+    "Priority": "Priority",
+    "Order_Min_Box": "Min Box",
+    "Execution_Date": "Execution Date",
+    "Repeat": "Repeat Order",
+    "SKU": "SKU",
+    "Product_Name": "Product Name",
+    "Warehouse_Name": "Warehouse Name",
+    "Quantity": "Quantity",
+    "Has_SKU": "Has SKU",
+    "Order_Fulfillment_Status": "Fulfillment Status",
+    "Fulfillable": "Fulfillable",
+    "Stock": "Stock",
+    "Final_Stock": "Final Stock",
+    "Stock_Alert": "Stock Alert",
+    "Summary_Missing": "Missing Summary",
+    "Summary_Present": "Present Summary",
+    "Status_Note": "Status Note",
+    "Error": "Error",
+    "System_note": "System Note",
+    "Notes": "Notes",
+    "Tags": "Tags",
+    "Internal_Tags": "Internal Tags",
+    "Lot_Details": "Lot Details",
+    "Lot_Batch": "Lot Batch",
+    "Lot_Expiry": "Lot Expiry",
+    "Expiry_Date": "Expiry Date",
+}
+
+
+def _column_display_name(col_name: str) -> str:
+    return COLUMN_DISPLAY_NAMES.get(col_name, col_name)
+
+
+def _column_category(col_name: str) -> str:
+    return COLUMN_CATEGORIES.get(col_name, "Other")
+```
+
+- [ ] **Step 4: Rewrite `_load_columns` to group by category**
+
+Replace `ColumnConfigPanel._load_columns` (`gui/column_config_dialog.py:255-292`) with:
+
+```python
+    def _load_columns(self, config):
+        """Load columns into the list widget, grouped under category headers."""
+        self.column_list.clear()
+        self._current_columns = []
+
+        if hasattr(self.parent_window, 'analysis_results_df') and \
+           self.parent_window.analysis_results_df is not None:
+            df = self.parent_window.analysis_results_df
+            all_columns = df.columns.tolist()
+        else:
+            all_columns = config.column_order if config.column_order else list(config.visible_columns.keys())
+
+        if config.column_order:
+            ordered_columns = [col for col in config.column_order if col in all_columns]
+            for col in all_columns:
+                if col not in ordered_columns:
+                    ordered_columns.append(col)
+            columns = ordered_columns
+        else:
+            columns = all_columns
+
+        grouped: dict[str, list[str]] = {category: [] for category in CATEGORY_ORDER}
+        for col_name in columns:
+            grouped[_column_category(col_name)].append(col_name)
+
+        theme = get_theme_manager().get_current_theme()
+
+        for category in CATEGORY_ORDER:
+            cols_in_category = grouped[category]
+            if not cols_in_category:
+                continue
+
+            header_item = QListWidgetItem(category)
+            header_item.setFlags(Qt.NoItemFlags)
+            header_item.setData(Qt.UserRole, _CATEGORY_HEADER_MARKER)
+            header_font = header_item.font()
+            header_font.setBold(True)
+            header_item.setFont(header_font)
+            header_item.setForeground(QColor(theme.text_secondary))
+            self.column_list.addItem(header_item)
+
+            for col_name in cols_in_category:
+                item = QListWidgetItem(_column_display_name(col_name))
+                item.setData(Qt.UserRole, col_name)
+                item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+
+                is_visible = config.visible_columns.get(col_name, True)
+                item.setCheckState(Qt.Checked if is_visible else Qt.Unchecked)
+
+                if col_name in config.locked_columns:
+                    item.setToolTip(f"{col_name} (locked column, always visible and first)")
+                    font = item.font()
+                    font.setBold(True)
+                    item.setFont(font)
+                else:
+                    item.setToolTip(col_name)
+
+                self.column_list.addItem(item)
+                self._current_columns.append(col_name)
+
+        self._update_button_states()
+```
+
+- [ ] **Step 5: Update `_on_search_changed` to read raw names and hide headers while filtering**
+
+Replace `_on_search_changed` (`gui/column_config_dialog.py:294-305`) with:
+
+```python
+    def _on_search_changed(self, text: str):
+        """Handle search text change."""
+        text = text.lower()
+
+        for i in range(self.column_list.count()):
+            item = self.column_list.item(i)
+
+            if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+                # ponytail: headers just hide/show with any active filter
+                # rather than tracking per-group match counts -- upgrade to
+                # "hide only if the whole group is filtered out" if a user
+                # reports it's confusing to lose the grouping while typing.
+                item.setHidden(bool(text))
+                continue
+
+            column_name = item.data(Qt.UserRole)
+            item.setHidden(text not in column_name.lower())
+```
+
+- [ ] **Step 6: Update `_on_item_changed` to skip headers and read raw names**
+
+Replace the body of `_on_item_changed` (`gui/column_config_dialog.py:307-324`) — add a header guard right after the `_is_loading` check, and switch `item.text()` to `item.data(Qt.UserRole)`:
+
+```python
+    def _on_item_changed(self, item: QListWidgetItem):
+        """Handle item check state change."""
+        if self._is_loading:
+            return
+
+        if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return
+
+        column_name = item.data(Qt.UserRole)
+        config = self.table_config_manager.get_current_config()
+
+        if column_name in config.locked_columns and item.checkState() == Qt.Unchecked:
+            self._is_loading = True
+            item.setCheckState(Qt.Checked)
+            self._is_loading = False
+
+            QMessageBox.warning(
+                self,
+                "Cannot Hide Column",
+                f"Column '{column_name}' is locked and cannot be hidden."
+            )
+```
+
+- [ ] **Step 7: Rewrite `_on_move_up`/`_on_move_down` to respect group boundaries and read raw names**
+
+Replace `_on_move_up` (`gui/column_config_dialog.py:326-358`) with:
+
+```python
+    def _on_move_up(self):
+        """Move selected column up in the order (within its category group)."""
+        current_row = self.column_list.currentRow()
+        if current_row <= 0:
+            return
+
+        item = self.column_list.currentItem()
+        if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return
+
+        above_item = self.column_list.item(current_row - 1)
+        if above_item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return  # already first in its category group
+
+        config = self.table_config_manager.get_current_config()
+        column_name = item.data(Qt.UserRole)
+
+        if column_name in config.locked_columns:
+            QMessageBox.warning(
+                self,
+                "Cannot Move Column",
+                f"Column '{column_name}' is locked and cannot be moved."
+            )
+            return
+
+        above_column_name = above_item.data(Qt.UserRole)
+        if above_column_name in config.locked_columns:
+            QMessageBox.warning(
+                self,
+                "Cannot Move Column",
+                f"Cannot move above locked column '{above_column_name}'."
+            )
+            return
+
+        item = self.column_list.takeItem(current_row)
+        self.column_list.insertItem(current_row - 1, item)
+        self.column_list.setCurrentRow(current_row - 1)
+
+        self._current_columns.insert(current_row - 1, self._current_columns.pop(current_row))
+```
+
+Replace `_on_move_down` (`gui/column_config_dialog.py:360-390`) with:
+
+```python
+    def _on_move_down(self):
+        """Move selected column down in the order (within its category group)."""
+        current_row = self.column_list.currentRow()
+        if current_row < 0 or current_row >= self.column_list.count() - 1:
+            return
+
+        item = self.column_list.currentItem()
+        if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return
+
+        below_item = self.column_list.item(current_row + 1)
+        if below_item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return  # already last in its category group
+
+        config = self.table_config_manager.get_current_config()
+        column_name = item.data(Qt.UserRole)
+
+        if column_name in config.locked_columns:
+            QMessageBox.warning(
+                self,
+                "Cannot Move Column",
+                f"Column '{column_name}' is locked and cannot be moved."
+            )
+            return
+
+        below_column_name = below_item.data(Qt.UserRole)
+        if below_column_name in config.locked_columns:
+            QMessageBox.warning(
+                self,
+                "Cannot Move Column",
+                f"Cannot move below locked column '{below_column_name}'."
+            )
+            return
+
+        item = self.column_list.takeItem(current_row)
+        self.column_list.insertItem(current_row + 1, item)
+        self.column_list.setCurrentRow(current_row + 1)
+
+        self._current_columns.insert(current_row + 1, self._current_columns.pop(current_row))
+```
+
+This drops the old hardcoded `current_row == 1`/`current_row == 0` special cases (which assumed `Order_Number` always sat at literal row 0 — no longer true once a header row precedes it) in favor of a general "can't swap across a locked column" rule that works regardless of row offsets.
+
+- [ ] **Step 8: Update `_on_show_all`/`_on_hide_all` to skip headers and read raw names**
+
+Replace `_on_show_all` (`gui/column_config_dialog.py:392-402`) with:
+
+```python
+    def _on_show_all(self):
+        """Show all columns and disable auto-hide."""
+        self._is_loading = True
+        try:
+            for i in range(self.column_list.count()):
+                item = self.column_list.item(i)
+                if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+                    continue
+                item.setCheckState(Qt.Checked)
+        finally:
+            self._is_loading = False
+
+        self.auto_hide_checkbox.setChecked(False)
+```
+
+Replace `_on_hide_all` (`gui/column_config_dialog.py:404-419`) with:
+
+```python
+    def _on_hide_all(self):
+        """Hide all columns (except locked ones)."""
+        config = self.table_config_manager.get_current_config()
+
+        self._is_loading = True
+        try:
+            for i in range(self.column_list.count()):
+                item = self.column_list.item(i)
+                if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+                    continue
+                column_name = item.data(Qt.UserRole)
+
+                if column_name in config.locked_columns:
+                    continue
+
+                item.setCheckState(Qt.Unchecked)
+        finally:
+            self._is_loading = False
+```
+
+- [ ] **Step 9: Update `_get_config_from_ui` to skip headers and read raw names**
+
+Replace the item-iteration loop in `_get_config_from_ui` (`gui/column_config_dialog.py:637-665`, the `for i in range(self.column_list.count()):` block) with:
+
+```python
+        for i in range(self.column_list.count()):
+            item = self.column_list.item(i)
+            if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+                continue
+            column_name = item.data(Qt.UserRole)
+            is_visible = item.checkState() == Qt.Checked
+
+            visible_columns[column_name] = is_visible
+            column_order.append(column_name)
+```
+
+(the rest of the method — building and returning the `TableConfig` — is unchanged)
+
+- [ ] **Step 10: Run the test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_column_config_dialog.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 11: Run the full suite and lint, then commit**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest` — expect all pre-existing tests still pass (no other file reads `column_list` internals — confirmed via `grep -rn "\.column_list\b" gui/ --include="*.py"` returning only `column_config_dialog.py` itself).
+Run: `ruff check gui/column_config_dialog.py tests/test_column_config_dialog.py`
+
+```bash
+git add gui/column_config_dialog.py tests/test_column_config_dialog.py
+git commit -m "Group Manage Table Columns list by category with display names"
+```
+
+---
+
+## Task 2: Manage Table Columns — fold the two `client_config.json` writes into one
+
+**Files:**
+- Modify: `gui/table_config_manager.py:161-210` (`TableConfigManager.save_config`)
+- Modify: `gui/column_config_dialog.py:567-635` (`ColumnConfigPanel.apply_config`)
+- Test: `tests/test_table_config_manager.py` (new)
+
+**Interfaces:**
+- Consumes: `shopify_tool.profile_manager.ProfileManager.load_client_config`/`save_client_config` (existing, unchanged signatures).
+- Produces: `TableConfigManager.save_config(client_id, config, view_name="Default", additional_columns=None)` — new optional 4th parameter. When provided (not `None`), the additional-columns list is written into the same `client_config.json` read-modify-write as the view, instead of a second one.
+
+Today, `ColumnConfigPanel.apply_config()` (`gui/column_config_dialog.py:567-635`) calls `table_config_manager.save_config()` (one read-modify-write of `client_config.json`), then — if there's any additional-columns state — does a **second**, independent `self.table_config_manager.pm.load_client_config(...)` / `.save_client_config(...)` pair for the `additional_columns` key. Over a UNC file share that's two network round trips on every "Apply" click instead of one. This task moves the `additional_columns` write inside `TableConfigManager.save_config`'s existing read-modify-write.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_table_config_manager.py`:
+
+```python
+"""Regression test: applying column config must persist to client_config.json
+in a single write, not two separate read-modify-write round trips (one for
+the view, one for additional_columns) -- each was its own UNC-share round
+trip on every Apply click.
+"""
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from gui.table_config_manager import TableConfig, TableConfigManager
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def test_save_config_writes_view_and_additional_columns_in_one_call(profile_manager):
+    profile_manager.create_client_profile("TESTCLIENT", "Test Client")
+    tcm = TableConfigManager(main_window=Mock(), profile_manager=profile_manager)
+
+    save_spy = Mock(wraps=profile_manager.save_client_config)
+    profile_manager.save_client_config = save_spy
+
+    config = TableConfig(visible_columns={"SKU": True}, column_order=["SKU"])
+    additional_columns = [{"csv_name": "Extra", "internal_name": "extra", "enabled": True}]
+
+    tcm.save_config("TESTCLIENT", config, "Default", additional_columns=additional_columns)
+
+    assert save_spy.call_count == 1
+
+    saved = profile_manager.load_client_config("TESTCLIENT")
+    table_view = saved["ui_settings"]["table_view"]
+    assert table_view["views"]["Default"]["column_order"] == ["SKU"]
+    assert table_view["additional_columns"] == additional_columns
+
+
+def test_save_config_without_additional_columns_leaves_existing_value_untouched(profile_manager):
+    profile_manager.create_client_profile("TESTCLIENT", "Test Client")
+    tcm = TableConfigManager(main_window=Mock(), profile_manager=profile_manager)
+
+    seed = [{"csv_name": "Extra", "internal_name": "extra", "enabled": True}]
+    tcm.save_config("TESTCLIENT", TableConfig(), "Default", additional_columns=seed)
+
+    tcm.save_config("TESTCLIENT", TableConfig(visible_columns={"SKU": True}), "Default")
+
+    saved = profile_manager.load_client_config("TESTCLIENT")
+    assert saved["ui_settings"]["table_view"]["additional_columns"] == seed
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_table_config_manager.py -v`
+Expected: FAIL — `TypeError: save_config() got an unexpected keyword argument 'additional_columns'`
+
+- [ ] **Step 3: Add the `additional_columns` parameter to `save_config`**
+
+Replace `TableConfigManager.save_config` (`gui/table_config_manager.py:161-210`) with:
+
+```python
+    def save_config(
+        self,
+        client_id: str,
+        config: TableConfig,
+        view_name: str = "Default",
+        additional_columns: list[dict] | None = None,
+    ):
+        """Save table configuration for a client.
+
+        Args:
+            client_id: Client ID to save config for
+            config: TableConfig to save
+            view_name: Name of the view to save (default: "Default")
+            additional_columns: Optional "Additional CSV Columns" config to
+                persist in the same write. Pass None to leave whatever's
+                already stored untouched.
+
+        Raises:
+            Exception: If config saving fails (logs error)
+        """
+        try:
+            # Load full client config
+            client_config = self.pm.load_client_config(client_id)
+
+            # Ensure ui_settings.table_view structure exists
+            if "ui_settings" not in client_config:
+                client_config["ui_settings"] = {}
+            if "table_view" not in client_config["ui_settings"]:
+                client_config["ui_settings"]["table_view"] = {
+                    "version": 1,
+                    "active_view": view_name,
+                    "views": {}
+                }
+
+            table_view_settings = client_config["ui_settings"]["table_view"]
+
+            # Ensure views dict exists
+            if "views" not in table_view_settings:
+                table_view_settings["views"] = {}
+
+            # Save view data
+            table_view_settings["views"][view_name] = config.to_dict()
+
+            # Update active view
+            table_view_settings["active_view"] = view_name
+
+            if additional_columns is not None:
+                table_view_settings["additional_columns"] = additional_columns
+
+            # Persist to file (single read-modify-write for both view and
+            # additional_columns, instead of a second round trip)
+            self.pm.save_client_config(client_id, client_config)
+
+            # Update cached config if this is the current client
+            if client_id == self._current_client_id:
+                self._current_config = config
+                self._current_view_name = view_name
+
+            logger.debug(f"Saved table view '{view_name}' for CLIENT_{client_id}")
+
+        except Exception:
+            logger.exception(f"Failed to save table config for CLIENT_{client_id}")
+            raise
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_table_config_manager.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Update `apply_config` to use the single-write call and drop the second read-modify-write**
+
+Replace `ColumnConfigPanel.apply_config` (`gui/column_config_dialog.py:567-635`) with:
+
+```python
+    def apply_config(self):
+        """Apply the current configuration (save + update table view)."""
+        try:
+            config = self._get_config_from_ui()
+
+            if hasattr(self.parent_window, 'current_client_id') and self.parent_window.current_client_id:
+                client_id = self.parent_window.current_client_id
+                view_name = self.view_combo.currentText() or "Default"
+
+                additional_columns = None
+                if hasattr(self, 'additional_columns_config') and self.additional_columns_config:
+                    logger.debug("Syncing UI checkbox states to config before saving...")
+                    self._sync_ui_to_config()
+                    additional_columns = self.additional_columns_config
+
+                self.table_config_manager.save_config(
+                    client_id, config, view_name, additional_columns=additional_columns
+                )
+
+                if additional_columns is not None:
+                    enabled_cols = [col for col in additional_columns if col.get('enabled', False)]
+                    disabled_cols = [col for col in additional_columns if not col.get('enabled', False)]
+                    logger.debug(f"Saved additional columns config: {len(additional_columns)} columns")
+                    logger.debug(f"  Enabled: {len(enabled_cols)} - {[col['csv_name'] for col in enabled_cols]}")
+                    logger.debug(f"  Disabled: {len(disabled_cols)}")
+                    logger.info(
+                        f"Saved additional columns: {len(enabled_cols)} enabled "
+                        f"({', '.join([col['csv_name'] for col in enabled_cols])})"
+                    )
+
+                if hasattr(self.parent_window, 'tableView') and \
+                   hasattr(self.parent_window, 'analysis_results_df') and \
+                   self.parent_window.analysis_results_df is not None:
+                    self.table_config_manager.apply_config_to_view(
+                        self.parent_window.tableView,
+                        self.parent_window.analysis_results_df
+                    )
+
+                logger.info("Column configuration applied successfully")
+
+                if additional_columns and any(col.get('enabled', False) for col in additional_columns):
+                    QMessageBox.information(
+                        self,
+                        "Configuration Saved",
+                        "Table configuration has been saved.\n\n"
+                        "Note: If you changed additional columns, you must re-run the analysis "
+                        "to see the changes in the results table."
+                    )
+
+                self.config_applied.emit()
+
+            else:
+                QMessageBox.warning(
+                    self,
+                    "No Client Selected",
+                    "Please select a client before applying configuration."
+                )
+
+        except Exception as e:
+            logger.exception("Failed to apply configuration")
+            QMessageBox.critical(
+                self,
+                "Apply Failed",
+                f"Failed to apply configuration: {e!s}"
+            )
+```
+
+- [ ] **Step 6: Run the full suite and lint, then commit**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest`
+Run: `ruff check gui/table_config_manager.py gui/column_config_dialog.py tests/test_table_config_manager.py`
+
+```bash
+git add gui/table_config_manager.py gui/column_config_dialog.py tests/test_table_config_manager.py
+git commit -m "Fold column-config Apply into a single client_config.json write"
+```
+
+---
+
+## Task 3: Statistics tab — delete dead `create_statistics_tab` method
+
+**Files:**
+- Modify: `gui/ui_manager.py:825-856` (delete `UIManager.create_statistics_tab`)
+
+**Interfaces:**
+- Consumes: none.
+- Produces: none — pure deletion, `_create_statistics_subtab` (the method actually wired to the Statistics tab, `gui/ui_manager.py:1705`) is untouched.
+
+`UIManager.create_statistics_tab` (`gui/ui_manager.py:825-856`) is a superseded, older `QGridLayout`-based statistics-tab builder with zero call sites anywhere in the codebase — confirmed by `grep -rn "create_statistics_tab\b" --include="*.py" .` matching only its own `def` line. It was replaced by `_create_statistics_subtab` back in PR #221 and never deleted. No test is needed for a pure dead-code deletion (nothing calls it, so nothing can regress) — the full suite passing is the verification.
+
+- [ ] **Step 1: Confirm zero call sites**
+
+Run: `grep -rn "create_statistics_tab\b" --include="*.py" .`
+Expected: exactly one match — `gui/ui_manager.py:825:    def create_statistics_tab(self, tab_widget):` (the definition itself, no callers).
+
+- [ ] **Step 2: Delete the method**
+
+Delete lines 825-856 of `gui/ui_manager.py` (the entire `def create_statistics_tab(self, tab_widget):` method, from its `def` line up to and including the blank line right before `def set_ui_busy(self, is_busy):`).
+
+- [ ] **Step 3: Confirm it's gone and the suite still passes**
+
+Run: `grep -rn "create_statistics_tab\b" --include="*.py" .`
+Expected: no matches.
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest`
+Expected: same pass count as before this task (no test referenced the deleted method).
+
+Run: `ruff check gui/ui_manager.py`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gui/ui_manager.py
+git commit -m "Delete dead create_statistics_tab (superseded by _create_statistics_subtab since #221)"
+```
+
+---
+
+## Task 4: Statistics tab — sort + filter the SKU Summary table
+
+**Files:**
+- Modify: `gui/ui_manager.py:1817-1837` (`UIManager._create_statistics_subtab`, the "SKU Summary" section)
+- Modify: `gui/main_window_pyside.py:1304-1333` (`MainWindow.update_statistics_tab`, the "SKU table" section) — add a new `_on_sku_search_changed` method
+- Test: `tests/test_main_window_statistics.py` (new)
+
+**Interfaces:**
+- Consumes: `self.mw.sku_table` (existing `QTableWidget`, 6 columns: `#, SKU, Product, Total Qty, Fulfillable, Not Fulfillable`).
+- Produces: `self.mw.sku_search_input` (new `QLineEdit`), `MainWindow._on_sku_search_changed(self, text: str) -> None` (new method, filters `self.sku_table` rows by substring match against columns 1 (SKU) and 2 (Product)).
+
+The SKU Summary `QTableWidget` (`gui/ui_manager.py:1817-1837`) has no sorting and no filter — for a client with a large catalog this is the one real gap the design doc found in an otherwise-already-redesigned Statistics tab (the courier/session-totals/tag-breakdown cards shipped in PR #221). `QTableWidget.setSortingEnabled(True)` gets click-to-sort for free. A filter box needs one new `QLineEdit` above the table and a handler that hides non-matching rows.
+
+**Gotcha this task must handle:** once `setSortingEnabled(True)` is set, Qt re-sorts the table after every `insertRow`/`setItem` call, so `update_statistics_tab`'s populate loop (which uses a running `row_idx` counter to address rows) would silently write values into the wrong (just-resorted) row. Sorting must be disabled for the duration of the populate loop and re-enabled after.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_main_window_statistics.py`:
+
+```python
+"""Regression test: SKU Summary table search box filters by SKU or product
+substring (Phase 5 Item 2's "add sort/filter to the SKU table" gap).
+"""
+import pytest
+from PySide6.QtWidgets import QApplication, QTableWidget, QTableWidgetItem
+
+from gui.main_window_pyside import MainWindow
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def _make_sku_table(rows):
+    table = QTableWidget()
+    table.setColumnCount(3)
+    for row_idx, (sku, product) in enumerate(rows):
+        table.insertRow(row_idx)
+        table.setItem(row_idx, 1, QTableWidgetItem(sku))
+        table.setItem(row_idx, 2, QTableWidgetItem(product))
+    return table
+
+
+class _FakeMainWindow:
+    def __init__(self, table):
+        self.sku_table = table
+
+
+def test_sku_search_hides_non_matching_rows():
+    table = _make_sku_table([("SKU-A", "Widget A"), ("SKU-B", "Gadget B")])
+    mw = _FakeMainWindow(table)
+
+    MainWindow._on_sku_search_changed(mw, "gadget")
+
+    assert table.isRowHidden(0) is True
+    assert table.isRowHidden(1) is False
+
+
+def test_sku_search_matches_by_sku_too():
+    table = _make_sku_table([("SKU-A", "Widget A"), ("SKU-B", "Gadget B")])
+    mw = _FakeMainWindow(table)
+
+    MainWindow._on_sku_search_changed(mw, "sku-a")
+
+    assert table.isRowHidden(0) is False
+    assert table.isRowHidden(1) is True
+
+
+def test_empty_search_shows_all_rows():
+    table = _make_sku_table([("SKU-A", "Widget A"), ("SKU-B", "Gadget B")])
+    mw = _FakeMainWindow(table)
+
+    MainWindow._on_sku_search_changed(mw, "")
+
+    assert table.isRowHidden(0) is False
+    assert table.isRowHidden(1) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_main_window_statistics.py -v`
+Expected: FAIL — `AttributeError: type object 'MainWindow' has no attribute '_on_sku_search_changed'`
+
+- [ ] **Step 3: Add the search box and enable sorting in `_create_statistics_subtab`**
+
+In `gui/ui_manager.py`, replace the "SKU Summary" block (`gui/ui_manager.py:1817-1837`) with:
+
+```python
+        # ── 5. SKU Summary ─────────────────────────────────────────────────
+        sku_group = QGroupBox("SKU Summary")
+        sku_layout = QVBoxLayout(sku_group)
+        sku_layout.setContentsMargins(8, 8, 8, 8)
+
+        self.mw.sku_search_input = QLineEdit()
+        self.mw.sku_search_input.setPlaceholderText("Filter by SKU or product...")
+        self.mw.sku_search_input.textChanged.connect(self.mw._on_sku_search_changed)
+        sku_layout.addWidget(self.mw.sku_search_input)
+
+        self.mw.sku_table = QTableWidget()
+        self.mw.sku_table.setColumnCount(6)
+        self.mw.sku_table.setHorizontalHeaderLabels(
+            ["#", "SKU", "Product", "Total Qty", "Fulfillable", "Not Fulfillable"]
+        )
+        self.mw.sku_table.horizontalHeader().setStretchLastSection(False)
+        self.mw.sku_table.horizontalHeader().setSectionResizeMode(
+            2, QHeaderView.Stretch
+        )
+        self.mw.sku_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.mw.sku_table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.mw.sku_table.setAlternatingRowColors(True)
+        self.mw.sku_table.verticalHeader().setVisible(False)
+        self.mw.sku_table.setSortingEnabled(True)
+        self.mw.sku_table.setMinimumHeight(200)
+        sku_layout.addWidget(self.mw.sku_table)
+        layout.addWidget(sku_group, 1)
+```
+
+(`QLineEdit` and `QHeaderView` are already imported at the top of `gui/ui_manager.py` — no import changes needed there.)
+
+- [ ] **Step 4: Guard the populate loop against sorting, and add the filter handler**
+
+In `gui/main_window_pyside.py`, replace the "SKU table" block inside `update_statistics_tab` (`gui/main_window_pyside.py:1304-1333`) with:
+
+```python
+        # === 4. SKU table ===
+        if hasattr(self, "sku_table"):
+            self.sku_table.setSortingEnabled(False)
+            self.sku_table.setRowCount(0)
+            sku_summary = self.analysis_stats.get("sku_summary") or []
+            for row_idx, sku_data in enumerate(sku_summary):
+                self.sku_table.insertRow(row_idx)
+
+                num_item = QTableWidgetItem(str(row_idx + 1))
+                num_item.setTextAlignment(Qt.AlignCenter)
+                self.sku_table.setItem(row_idx, 0, num_item)
+
+                self.sku_table.setItem(
+                    row_idx, 1, QTableWidgetItem(str(sku_data.get("SKU", "N/A")))
+                )
+
+                product = sku_data.get("Warehouse_Name", "")
+                if not product or (hasattr(pd, "isna") and pd.isna(product)):
+                    product = sku_data.get("Product_Name", "N/A")
+                self.sku_table.setItem(row_idx, 2, QTableWidgetItem(str(product)))
+
+                for col_idx, key in enumerate(
+                    ["Total_Quantity", "Fulfillable_Items", "Not_Fulfillable_Items"],
+                    start=3,
+                ):
+                    val_item = QTableWidgetItem(str(sku_data.get(key, 0)))
+                    val_item.setTextAlignment(Qt.AlignCenter)
+                    self.sku_table.setItem(row_idx, col_idx, val_item)
+
+            self.sku_table.resizeColumnToContents(0)
+            self.sku_table.resizeColumnToContents(1)
+            self.sku_table.setSortingEnabled(True)
+            if hasattr(self, "sku_search_input"):
+                self.sku_search_input.clear()
+
+    def _on_sku_search_changed(self, text: str):
+        """Filter the SKU Summary table by SKU/product substring."""
+        text = text.strip().lower()
+        for row in range(self.sku_table.rowCount()):
+            sku_item = self.sku_table.item(row, 1)
+            product_item = self.sku_table.item(row, 2)
+            sku_text = sku_item.text().lower() if sku_item else ""
+            product_text = product_item.text().lower() if product_item else ""
+            matches = not text or text in sku_text or text in product_text
+            self.sku_table.setRowHidden(row, not matches)
+```
+
+(`_on_sku_search_changed` is a new method placed directly after `update_statistics_tab` — mind the indentation, both are `MainWindow` methods at the same nesting level.)
+
+Also add `self.sku_table.setRowCount(0)` staying as-is in `_clear_statistics_view` (`gui/main_window_pyside.py:1355-1356`) — no change needed there, clearing rows with sorting left enabled is harmless (no populate loop involved).
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_main_window_statistics.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Run the full suite and lint, then commit**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest`
+Run: `ruff check gui/ui_manager.py gui/main_window_pyside.py tests/test_main_window_statistics.py`
+
+```bash
+git add gui/ui_manager.py gui/main_window_pyside.py tests/test_main_window_statistics.py
+git commit -m "Add sort + SKU/product filter to the Statistics SKU Summary table"
+```
+
+---
+
+## Task 5: Add Product to Order dialog — drop the info box, consolidate to one form
+
+**Files:**
+- Modify: `gui/add_product_dialog.py`
+- Test: `tests/test_add_product_dialog.py` (new)
+
+**Interfaces:**
+- Consumes: nothing new — `AddProductDialog.__init__(self, parent, analysis_df, stock_df, live_stock)` signature is unchanged.
+- Produces: same public surface as before (`order_input`, `sku_input`, `quantity_spin`, `order_status_label`, `product_info_label`, `warning_box`, `add_btn`, `_validate()`, `_on_add_clicked()`, `get_result()`) — `info_box` and the three `_create_*_section` helper methods are removed, nothing outside this file referenced them (`grep -rn "_create_order_section\|_create_product_section\|_create_quantity_section\|_create_info_box\|\.info_box\b"` outside `gui/add_product_dialog.py` returns no matches).
+
+The design doc's backend trace confirmed the info box's claims are accurate but redundant with the method's own docstring — safe to remove. The three `QGroupBox` sections collapse into one `QFormLayout`, dropping ~120 lines of repeated `QGroupBox`/`QVBoxLayout`/label-repeating-the-groupbox-title boilerplate. The hardcoded `resize(500, 500)` is dropped in favor of `setMinimumWidth(420)` plus Qt's own layout-driven `sizeHint()` — with the info box and two extra group boxes gone, the dialog needs meaningfully less vertical space, and there's no principled fixed number to replace 500 with (this is a judgment call, not the design doc calling out a specific replacement value).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_add_product_dialog.py`:
+
+```python
+"""Regression test: Add Product to Order dialog drops the static info box
+and consolidates its three QGroupBox sections into one QFormLayout (Phase 5
+Item 3) -- the live status labels and stock-warning box keep working
+unchanged since the backend behavior they describe wasn't touched.
+"""
+import pandas as pd
+import pytest
+from PySide6.QtWidgets import QApplication, QGroupBox
+
+from gui.add_product_dialog import AddProductDialog
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def dialog():
+    analysis_df = pd.DataFrame([
+        {"Order_Number": "1001", "Order_Fulfillment_Status": "Fulfillable"},
+    ])
+    stock_df = pd.DataFrame([
+        {"SKU": "SKU-A", "Product_Name": "Widget A"},
+    ])
+    live_stock = {"SKU-A": 2}
+    return AddProductDialog(None, analysis_df, stock_df, live_stock)
+
+
+def test_info_box_and_group_boxes_are_gone(dialog):
+    assert not hasattr(dialog, "info_box")
+    assert dialog.findChildren(QGroupBox) == []
+
+
+def test_order_status_label_still_updates(dialog):
+    dialog.order_input.setText("1001")
+    assert "Order found" in dialog.order_status_label.text()
+
+
+def test_low_stock_warning_still_shows(dialog):
+    dialog.sku_input.setText("SKU-A")
+    assert dialog.warning_box.isVisible()
+    assert "low stock" in dialog.warning_box.text().lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_add_product_dialog.py -v`
+Expected: FAIL — `test_info_box_and_group_boxes_are_gone` fails (`hasattr(dialog, "info_box")` is `True`, and `findChildren(QGroupBox)` returns 3 group boxes).
+
+- [ ] **Step 3: Rewrite `setup_ui` around a single `QFormLayout`, and drop the removed helpers**
+
+In `gui/add_product_dialog.py`, change the import block (lines 15-27) — remove `QGroupBox`, add `QFormLayout`:
+
+```python
+from PySide6.QtWidgets import (
+    QCompleter,
+    QDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+```
+
+Replace `setup_ui` (`gui/add_product_dialog.py:60-86`) with:
+
+```python
+    def setup_ui(self):
+        """Setup dialog UI components."""
+        self.setWindowTitle("Add Product to Order")
+        self.setModal(True)
+        self.setMinimumWidth(420)
+
+        layout = QVBoxLayout(self)
+
+        form_layout = QFormLayout()
+        self._build_form(form_layout)
+        layout.addLayout(form_layout)
+
+        self.warning_box = self._create_warning_box()
+        self.warning_box.setVisible(False)
+        layout.addWidget(self.warning_box)
+
+        layout.addWidget(self._create_buttons())
+```
+
+Replace `_create_order_section`, `_create_product_section`, and `_create_quantity_section` (`gui/add_product_dialog.py:88-137`) with a single `_build_form` method:
+
+```python
+    def _build_form(self, form_layout: QFormLayout):
+        """Populate the order/SKU/quantity form rows."""
+        self.order_input = QLineEdit()
+        self.order_input.setPlaceholderText("Type order number... (e.g., 1001)")
+        self.order_input.textChanged.connect(self._on_order_changed)
+        form_layout.addRow("Order Number:", self.order_input)
+
+        self.order_status_label = QLabel("")
+        form_layout.addRow("", self.order_status_label)
+
+        self.sku_input = QLineEdit()
+        self.sku_input.setPlaceholderText("Type SKU... (e.g., SKU-HAT)")
+        self.sku_input.textChanged.connect(self._on_sku_changed)
+        form_layout.addRow("Product SKU:", self.sku_input)
+
+        self.product_info_label = QLabel("")
+        form_layout.addRow("", self.product_info_label)
+
+        self.quantity_spin = QSpinBox()
+        self.quantity_spin.setMinimum(1)
+        self.quantity_spin.setMaximum(9999)
+        self.quantity_spin.setValue(1)
+        form_layout.addRow("Quantity:", self.quantity_spin)
+```
+
+Delete `_create_info_box` (`gui/add_product_dialog.py:157-181`) entirely — nothing else calls it after Step 3's `setup_ui` rewrite stops referencing it.
+
+`_create_warning_box`, `_create_buttons`, `setup_autocompleters`, `_on_order_changed`, `_on_sku_changed`, `_on_add_clicked`, `_validate`, and `get_result` are all unchanged — they only reference `order_input`, `sku_input`, `quantity_spin`, `order_status_label`, `product_info_label`, and `warning_box`, all of which still exist with the same names.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_add_product_dialog.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Run the full suite and lint, then commit**
+
+Run: `QT_QPA_PLATFORM=offscreen python -m pytest`
+Run: `ruff check gui/add_product_dialog.py tests/test_add_product_dialog.py`
+
+```bash
+git add gui/add_product_dialog.py tests/test_add_product_dialog.py
+git commit -m "Simplify Add Product to Order dialog to one QFormLayout, drop info box"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Item 1 (Manage Table Columns: grouping, display names, backend single-write) → Tasks 1 and 2.
+- Item 2 (Statistics tab: dead code, sort/filter) → Tasks 3 and 4.
+- Item 3 (Add Product to Order: remove info box, QFormLayout, resize) → Task 5.
+- Testing section's per-item guidance (round-trip test for Item 1's write path, sort-enabled/filter test for Item 2, `_validate`/`_on_add_clicked`-adjacent test for Item 3) → covered by each task's test file.
+
+**Placeholder scan:** no TBD/"add appropriate handling"/bare references — every step has real code, real file:line anchors, and real run commands.
+
+**Type consistency:** `TableConfigManager.save_config`'s new `additional_columns` parameter name and `None`-default match between Task 2's implementation and its caller update in the same task. `MainWindow._on_sku_search_changed(self, text: str)` signature matches both its `textChanged.connect(self.mw._on_sku_search_changed)` wiring in Task 4 Step 3 and its test calls in Task 4 Step 1. `_CATEGORY_HEADER_MARKER`/`COLUMN_CATEGORIES`/`COLUMN_DISPLAY_NAMES`/`CATEGORY_ORDER` names are consistent between Task 1's constants (Step 3) and every consumer (Steps 4-9) and test (Step 1).

--- a/docs/superpowers/plans/2026-08-11-phase5-table-stats-ux-plan.md
+++ b/docs/superpowers/plans/2026-08-11-phase5-table-stats-ux-plan.md
@@ -1,6 +1,6 @@
 # Phase 5 — Table & Stats UX Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Ship the three independent Phase 5 UI cleanups (Todoist `6h8v49wj4M3cFxJV`) scoped in `docs/superpowers/specs/2026-08-11-phase5-table-stats-ux-design.md`: a grouped Manage Table Columns list, two small Statistics-tab fixes, and a simplified Add Product to Order dialog.
 
@@ -29,7 +29,7 @@
 
 Currently `ColumnConfigPanel._load_columns` (`gui/column_config_dialog.py:255-292`) builds a flat, ungrouped `QListWidget` where each item's `text()` *is* the raw DataFrame column name (e.g. `Order_Fulfillment_Status`), and every other method in the class (`_on_item_changed`, `_on_move_up`, `_on_move_down`, `_get_config_from_ui`) reads that same `item.text()` back out as the column name. This task inserts non-checkable, bold category header rows between groups and swaps the checkable items' visible text for a friendlier display name — which means `item.text()` can no longer double as the raw column name. Every one of those call sites must switch to `item.data(Qt.UserRole)` in the same change, or they'll silently start writing display-name strings into `TableConfig.column_order`/`visible_columns` instead of real column names.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `tests/test_column_config_dialog.py`:
 
@@ -129,12 +129,12 @@ def test_locked_column_tooltip_still_shows_raw_name():
     assert "Order_Number" in item.toolTip()
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_column_config_dialog.py -v`
 Expected: FAIL — `ImportError: cannot import name '_CATEGORY_HEADER_MARKER'` (module constant doesn't exist yet).
 
-- [ ] **Step 3: Add the category/display-name lookup and import**
+- [x] **Step 3: Add the category/display-name lookup and import**
 
 In `gui/column_config_dialog.py`, add the import and module-level constants right after `logger = logging.getLogger(__name__)` (line 31):
 
@@ -231,7 +231,7 @@ def _column_category(col_name: str) -> str:
     return COLUMN_CATEGORIES.get(col_name, "Other")
 ```
 
-- [ ] **Step 4: Rewrite `_load_columns` to group by category**
+- [x] **Step 4: Rewrite `_load_columns` to group by category**
 
 Replace `ColumnConfigPanel._load_columns` (`gui/column_config_dialog.py:255-292`) with:
 
@@ -299,7 +299,7 @@ Replace `ColumnConfigPanel._load_columns` (`gui/column_config_dialog.py:255-292`
         self._update_button_states()
 ```
 
-- [ ] **Step 5: Update `_on_search_changed` to read raw names and hide headers while filtering**
+- [x] **Step 5: Update `_on_search_changed` to read raw names and hide headers while filtering**
 
 Replace `_on_search_changed` (`gui/column_config_dialog.py:294-305`) with:
 
@@ -323,7 +323,7 @@ Replace `_on_search_changed` (`gui/column_config_dialog.py:294-305`) with:
             item.setHidden(text not in column_name.lower())
 ```
 
-- [ ] **Step 6: Update `_on_item_changed` to skip headers and read raw names**
+- [x] **Step 6: Update `_on_item_changed` to skip headers and read raw names**
 
 Replace the body of `_on_item_changed` (`gui/column_config_dialog.py:307-324`) — add a header guard right after the `_is_loading` check, and switch `item.text()` to `item.data(Qt.UserRole)`:
 
@@ -351,7 +351,7 @@ Replace the body of `_on_item_changed` (`gui/column_config_dialog.py:307-324`) �
             )
 ```
 
-- [ ] **Step 7: Rewrite `_on_move_up`/`_on_move_down` to respect group boundaries and read raw names**
+- [x] **Step 7: Rewrite `_on_move_up`/`_on_move_down` to respect group boundaries and read raw names**
 
 Replace `_on_move_up` (`gui/column_config_dialog.py:326-358`) with:
 
@@ -443,7 +443,7 @@ Replace `_on_move_down` (`gui/column_config_dialog.py:360-390`) with:
 
 This drops the old hardcoded `current_row == 1`/`current_row == 0` special cases (which assumed `Order_Number` always sat at literal row 0 — no longer true once a header row precedes it) in favor of a general "can't swap across a locked column" rule that works regardless of row offsets.
 
-- [ ] **Step 8: Update `_on_show_all`/`_on_hide_all` to skip headers and read raw names**
+- [x] **Step 8: Update `_on_show_all`/`_on_hide_all` to skip headers and read raw names**
 
 Replace `_on_show_all` (`gui/column_config_dialog.py:392-402`) with:
 
@@ -486,7 +486,7 @@ Replace `_on_hide_all` (`gui/column_config_dialog.py:404-419`) with:
             self._is_loading = False
 ```
 
-- [ ] **Step 9: Update `_get_config_from_ui` to skip headers and read raw names**
+- [x] **Step 9: Update `_get_config_from_ui` to skip headers and read raw names**
 
 Replace the item-iteration loop in `_get_config_from_ui` (`gui/column_config_dialog.py:637-665`, the `for i in range(self.column_list.count()):` block) with:
 
@@ -504,12 +504,12 @@ Replace the item-iteration loop in `_get_config_from_ui` (`gui/column_config_dia
 
 (the rest of the method — building and returning the `TableConfig` — is unchanged)
 
-- [ ] **Step 10: Run the test to verify it passes**
+- [x] **Step 10: Run the test to verify it passes**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_column_config_dialog.py -v`
 Expected: PASS (5 tests)
 
-- [ ] **Step 11: Run the full suite and lint, then commit**
+- [x] **Step 11: Run the full suite and lint, then commit**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest` — expect all pre-existing tests still pass (no other file reads `column_list` internals — confirmed via `grep -rn "\.column_list\b" gui/ --include="*.py"` returning only `column_config_dialog.py` itself).
 Run: `ruff check gui/column_config_dialog.py tests/test_column_config_dialog.py`
@@ -534,7 +534,7 @@ git commit -m "Group Manage Table Columns list by category with display names"
 
 Today, `ColumnConfigPanel.apply_config()` (`gui/column_config_dialog.py:567-635`) calls `table_config_manager.save_config()` (one read-modify-write of `client_config.json`), then — if there's any additional-columns state — does a **second**, independent `self.table_config_manager.pm.load_client_config(...)` / `.save_client_config(...)` pair for the `additional_columns` key. Over a UNC file share that's two network round trips on every "Apply" click instead of one. This task moves the `additional_columns` write inside `TableConfigManager.save_config`'s existing read-modify-write.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `tests/test_table_config_manager.py`:
 
@@ -590,12 +590,12 @@ def test_save_config_without_additional_columns_leaves_existing_value_untouched(
     assert saved["ui_settings"]["table_view"]["additional_columns"] == seed
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_table_config_manager.py -v`
 Expected: FAIL — `TypeError: save_config() got an unexpected keyword argument 'additional_columns'`
 
-- [ ] **Step 3: Add the `additional_columns` parameter to `save_config`**
+- [x] **Step 3: Add the `additional_columns` parameter to `save_config`**
 
 Replace `TableConfigManager.save_config` (`gui/table_config_manager.py:161-210`) with:
 
@@ -665,12 +665,12 @@ Replace `TableConfigManager.save_config` (`gui/table_config_manager.py:161-210`)
             raise
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_table_config_manager.py -v`
 Expected: PASS (2 tests)
 
-- [ ] **Step 5: Update `apply_config` to use the single-write call and drop the second read-modify-write**
+- [x] **Step 5: Update `apply_config` to use the single-write call and drop the second read-modify-write**
 
 Replace `ColumnConfigPanel.apply_config` (`gui/column_config_dialog.py:567-635`) with:
 
@@ -742,7 +742,7 @@ Replace `ColumnConfigPanel.apply_config` (`gui/column_config_dialog.py:567-635`)
             )
 ```
 
-- [ ] **Step 6: Run the full suite and lint, then commit**
+- [x] **Step 6: Run the full suite and lint, then commit**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest`
 Run: `ruff check gui/table_config_manager.py gui/column_config_dialog.py tests/test_table_config_manager.py`
@@ -765,16 +765,16 @@ git commit -m "Fold column-config Apply into a single client_config.json write"
 
 `UIManager.create_statistics_tab` (`gui/ui_manager.py:825-856`) is a superseded, older `QGridLayout`-based statistics-tab builder with zero call sites anywhere in the codebase — confirmed by `grep -rn "create_statistics_tab\b" --include="*.py" .` matching only its own `def` line. It was replaced by `_create_statistics_subtab` back in PR #221 and never deleted. No test is needed for a pure dead-code deletion (nothing calls it, so nothing can regress) — the full suite passing is the verification.
 
-- [ ] **Step 1: Confirm zero call sites**
+- [x] **Step 1: Confirm zero call sites**
 
 Run: `grep -rn "create_statistics_tab\b" --include="*.py" .`
 Expected: exactly one match — `gui/ui_manager.py:825:    def create_statistics_tab(self, tab_widget):` (the definition itself, no callers).
 
-- [ ] **Step 2: Delete the method**
+- [x] **Step 2: Delete the method**
 
 Delete lines 825-856 of `gui/ui_manager.py` (the entire `def create_statistics_tab(self, tab_widget):` method, from its `def` line up to and including the blank line right before `def set_ui_busy(self, is_busy):`).
 
-- [ ] **Step 3: Confirm it's gone and the suite still passes**
+- [x] **Step 3: Confirm it's gone and the suite still passes**
 
 Run: `grep -rn "create_statistics_tab\b" --include="*.py" .`
 Expected: no matches.
@@ -784,7 +784,7 @@ Expected: same pass count as before this task (no test referenced the deleted me
 
 Run: `ruff check gui/ui_manager.py`
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add gui/ui_manager.py
@@ -808,7 +808,7 @@ The SKU Summary `QTableWidget` (`gui/ui_manager.py:1817-1837`) has no sorting an
 
 **Gotcha this task must handle:** once `setSortingEnabled(True)` is set, Qt re-sorts the table after every `insertRow`/`setItem` call, so `update_statistics_tab`'s populate loop (which uses a running `row_idx` counter to address rows) would silently write values into the wrong (just-resorted) row. Sorting must be disabled for the duration of the populate loop and re-enabled after.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `tests/test_main_window_statistics.py`:
 
@@ -872,12 +872,12 @@ def test_empty_search_shows_all_rows():
     assert table.isRowHidden(1) is False
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_main_window_statistics.py -v`
 Expected: FAIL — `AttributeError: type object 'MainWindow' has no attribute '_on_sku_search_changed'`
 
-- [ ] **Step 3: Add the search box and enable sorting in `_create_statistics_subtab`**
+- [x] **Step 3: Add the search box and enable sorting in `_create_statistics_subtab`**
 
 In `gui/ui_manager.py`, replace the "SKU Summary" block (`gui/ui_manager.py:1817-1837`) with:
 
@@ -913,7 +913,7 @@ In `gui/ui_manager.py`, replace the "SKU Summary" block (`gui/ui_manager.py:1817
 
 (`QLineEdit` and `QHeaderView` are already imported at the top of `gui/ui_manager.py` — no import changes needed there.)
 
-- [ ] **Step 4: Guard the populate loop against sorting, and add the filter handler**
+- [x] **Step 4: Guard the populate loop against sorting, and add the filter handler**
 
 In `gui/main_window_pyside.py`, replace the "SKU table" block inside `update_statistics_tab` (`gui/main_window_pyside.py:1304-1333`) with:
 
@@ -969,12 +969,12 @@ In `gui/main_window_pyside.py`, replace the "SKU table" block inside `update_sta
 
 Also add `self.sku_table.setRowCount(0)` staying as-is in `_clear_statistics_view` (`gui/main_window_pyside.py:1355-1356`) — no change needed there, clearing rows with sorting left enabled is harmless (no populate loop involved).
 
-- [ ] **Step 5: Run the test to verify it passes**
+- [x] **Step 5: Run the test to verify it passes**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_main_window_statistics.py -v`
 Expected: PASS (3 tests)
 
-- [ ] **Step 6: Run the full suite and lint, then commit**
+- [x] **Step 6: Run the full suite and lint, then commit**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest`
 Run: `ruff check gui/ui_manager.py gui/main_window_pyside.py tests/test_main_window_statistics.py`
@@ -998,7 +998,7 @@ git commit -m "Add sort + SKU/product filter to the Statistics SKU Summary table
 
 The design doc's backend trace confirmed the info box's claims are accurate but redundant with the method's own docstring — safe to remove. The three `QGroupBox` sections collapse into one `QFormLayout`, dropping ~120 lines of repeated `QGroupBox`/`QVBoxLayout`/label-repeating-the-groupbox-title boilerplate. The hardcoded `resize(500, 500)` is dropped in favor of `setMinimumWidth(420)` plus Qt's own layout-driven `sizeHint()` — with the info box and two extra group boxes gone, the dialog needs meaningfully less vertical space, and there's no principled fixed number to replace 500 with (this is a judgment call, not the design doc calling out a specific replacement value).
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `tests/test_add_product_dialog.py`:
 
@@ -1048,12 +1048,12 @@ def test_low_stock_warning_still_shows(dialog):
     assert "low stock" in dialog.warning_box.text().lower()
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_add_product_dialog.py -v`
 Expected: FAIL — `test_info_box_and_group_boxes_are_gone` fails (`hasattr(dialog, "info_box")` is `True`, and `findChildren(QGroupBox)` returns 3 group boxes).
 
-- [ ] **Step 3: Rewrite `setup_ui` around a single `QFormLayout`, and drop the removed helpers**
+- [x] **Step 3: Rewrite `setup_ui` around a single `QFormLayout`, and drop the removed helpers**
 
 In `gui/add_product_dialog.py`, change the import block (lines 15-27) — remove `QGroupBox`, add `QFormLayout`:
 
@@ -1127,12 +1127,12 @@ Delete `_create_info_box` (`gui/add_product_dialog.py:157-181`) entirely — not
 
 `_create_warning_box`, `_create_buttons`, `setup_autocompleters`, `_on_order_changed`, `_on_sku_changed`, `_on_add_clicked`, `_validate`, and `get_result` are all unchanged — they only reference `order_input`, `sku_input`, `quantity_spin`, `order_status_label`, `product_info_label`, and `warning_box`, all of which still exist with the same names.
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest tests/test_add_product_dialog.py -v`
 Expected: PASS (3 tests)
 
-- [ ] **Step 5: Run the full suite and lint, then commit**
+- [x] **Step 5: Run the full suite and lint, then commit**
 
 Run: `QT_QPA_PLATFORM=offscreen python -m pytest`
 Run: `ruff check gui/add_product_dialog.py tests/test_add_product_dialog.py`

--- a/docs/superpowers/specs/2026-08-11-phase5-table-stats-ux-design.md
+++ b/docs/superpowers/specs/2026-08-11-phase5-table-stats-ux-design.md
@@ -56,9 +56,12 @@ display-name map for known columns, raw name in a tooltip. Category assignment f
 known analysis columns needs a lookup table (doesn't exist yet — build it from
 `shopify_tool/core.py`'s output columns, next task's job, not this doc's).
 
-**Decision needed from user**: (a) vs (b) above — (a) is the more "properly grouped" result the
-screenshot implies; (b) is the lazier, smaller, still-correct fix. Recommend (b) first pass,
-upgrade to (a) later only if users still report it's hard to navigate.
+**Decision (made autonomously — no user present to ask, per runner guardrails):** going with
+**(b)** — keep `QListWidget`, insert non-checkable bold category header rows. Smaller diff, same
+widget/reorder/search logic, still resolves the "no grouping" complaint. Upgrade to (a)
+(`QTreeWidget`) later only if users report it's still hard to navigate once grouped. This was the
+doc's own first-pass recommendation, so taking it rather than blocking on a question nobody's
+here to answer.
 
 ## Item 2 — Statistics tab
 

--- a/docs/superpowers/specs/2026-08-11-phase5-table-stats-ux-design.md
+++ b/docs/superpowers/specs/2026-08-11-phase5-table-stats-ux-design.md
@@ -1,0 +1,169 @@
+# Phase 5 — Table & Stats UX — Design
+
+## Context
+
+Phase 5 (Todoist `6h8v49wj4M3cFxJV`, light-epic) covers three independent UI/data-display
+cleanups: Manage Table Columns window, Statistics tab, and Add Product to Order dialog. Per the
+workflow guide, a light-epic gets "a small design per item... doesn't need the full multi-file
+spec treatment" — this doc is that, one section per item, code-verified against current `main`
+rather than assumed from the original 2026-07-28 backlog wording.
+
+**Headline finding: two of the three items are substantially smaller than their Todoist wording
+suggests**, because prior work already shipped fixes the backlog text doesn't reflect. Verifying
+against code before scoping — not the original task text — is the main output of this doc.
+
+Scope: design only. No code changes in this branch. Each item still needs a
+`writing-plans` pass (or a quick decision + direct implementation for the smaller items) when
+picked up.
+
+## Item 1 — Manage Table Columns window
+
+**Current state** (`gui/column_config_dialog.py`, `ColumnConfigPanel`, 936 lines +
+`gui/table_config_manager.py`, `TableConfigManager`, 1116 lines): the complaint is accurate —
+`self.column_list` is a flat `QListWidget`, one checkable `QListWidgetItem` per raw DataFrame
+column name (`Order_Number`, `Order_Fulfillment_Status`, `Internal_Tags`, ...), no grouping, no
+friendlier labels. Everything else around it — search filter, up/down reorder, show/hide all,
+auto-hide-empty toggle, named views (save/delete/switch), an "Additional CSV Columns" section,
+reset-to-default — is already there and reasonably capable. This is one panel used from **two
+entry points**: a standalone popup (`ColumnConfigDialog`, opened via `main_window_pyside.py:624`
+— this is the "window" in the screenshot) and an embedded tab inside the Settings window
+(`settings_window_pyside.py:3368`). A layout fix to the panel benefits both automatically.
+
+**Backend verification** (the task also asks to "verify the backend actually persists/applies
+the configuration correctly"): `TableConfigManager.load_config`/`save_config` persist under
+`client_config.json` → `ui_settings.table_view.views[view_name]`, with a debounce timer for
+resize/move and explicit cleanup of a documented past bug (corrupted zero-width column entries).
+No correctness bug found. One inefficiency, not a bug: `ColumnConfigPanel.apply_config()`
+(`column_config_dialog.py:567`) calls `table_config_manager.save_config()` (one read-modify-write
+of `client_config.json`) and then, for the "Additional CSV Columns" section, does a **second**,
+separate read-modify-write of the same file (`column_config_dialog.py:589-598`). Over a UNC
+share this is two network round-trips instead of one on every "Apply" click — worth folding into
+a single write while this file is being touched anyway, not worth its own task.
+
+**Proposal**: replace the flat list with grouped sections. Two ways to do it, pick one:
+
+- **(a) `QTreeWidget` with category parent nodes** (Order info / Product info / Fulfillment /
+  Tags & Lot / Additional CSV), checkable leaf items per column, parent checkbox tri-state
+  reflects children. More natural "collapse a group I never touch" UX; requires rewriting
+  `_load_columns`/`_on_item_changed`/reorder handlers against `QTreeWidgetItem` instead of
+  `QListWidgetItem`.
+- **(b) Keep `QListWidget`, insert non-checkable bold "category header" rows** between groups
+  (skip them in checkable-item iteration). Smaller diff — same widget, same reorder/search logic,
+  just an insertion-order and item-flag change in `_load_columns`.
+
+Also: replace raw `col_name` labels (`Order_Fulfillment_Status`) with a small
+display-name map for known columns, raw name in a tooltip. Category assignment for the ~20-30
+known analysis columns needs a lookup table (doesn't exist yet — build it from
+`shopify_tool/core.py`'s output columns, next task's job, not this doc's).
+
+**Decision needed from user**: (a) vs (b) above — (a) is the more "properly grouped" result the
+screenshot implies; (b) is the lazier, smaller, still-correct fix. Recommend (b) first pass,
+upgrade to (a) later only if users still report it's hard to navigate.
+
+## Item 2 — Statistics tab
+
+**Current state is materially different from the Todoist wording.** The backlog item
+(`6h8v4VhWRJmCCVw3`, written 2026-07-28) asks for "better UI for stats: display by courier,
+session totals, fulfillable vs non-fulfillable tag breakdowns, and a better SKU summary table" as
+if none of this exists. It already does — `git log -S _create_statistics_subtab` shows this
+landed in **PR #221** ("Statistics page redesign with stat cards"), well before the current
+Phase 1-7 roadmap was written. `gui/ui_manager.py:1705` (`_create_statistics_subtab`, the
+function actually wired to the tab via `ui_manager.py:431`) already builds: a Session Totals
+card row, a horizontally-scrolling By Courier card row, side-by-side Fulfillable/Not-Fulfillable
+Tags card rows, and a 6-column SKU Summary `QTableWidget` (#, SKU, Product, Total Qty,
+Fulfillable, Not Fulfillable) — populated by `main_window_pyside.py:1249`
+(`update_statistics_tab`). `shared/stats.py`, named in the Todoist description, doesn't exist —
+the actual file is `shared/stats_manager.py` (server-side aggregate stats, a different thing
+from this per-session tab; the Todoist file pointer is stale).
+
+Also checked: a separate, not-yet-promoted backlog item (`6h8rg4FrqFfcqRQV`, "Refactor: Internal
+tags... Statistic window") complains tag counts should be per-order, not per-line. Already fixed
+— `shopify_tool/analysis.py:1598` (`_build_order_tag_counts`) explicitly dedupes `(Order_Number,
+tag)` pairs before counting. Recommend closing/archiving that raw-backlog item as resolved; it's
+not one of Phase 5's three official subtasks so it doesn't block anything here, but it's stale
+and duplicative if left open.
+
+**What's genuinely left**, verified against the code:
+
+1. **Dead code**: `ui_manager.py:825` (`create_statistics_tab`, singular — a plainer, older
+   `QGridLayout` version) has zero call sites anywhere in `gui/`. Superseded by
+   `_create_statistics_subtab` since #221 and never deleted. Delete it — pure cleanup, not a
+   design decision.
+2. **SKU Summary table has no sort or filter.** It's a plain `QTableWidget` populated by manual
+   `QTableWidgetItem` construction (`main_window_pyside.py:1304-1333`), no
+   `setSortingEnabled(True)`, no search box — unlike the main Analysis Results table, which
+   already has `PandasModel` + `QSortFilterProxyModel` (per this repo's own documented pattern
+   in `CLAUDE.md`). For a client with a large catalog this is the one real "better SKU summary
+   table" gap. Fix: `setSortingEnabled(True)` (near-free, click-to-sort already works on
+   `QTableWidget` once enabled) + a `QLineEdit` search box above it filtering by SKU/product
+   substring (same filter-text pattern already used elsewhere, e.g. `column_config_dialog.py`'s
+   search input).
+3. No other correctness issues found in courier-card or tag-card population.
+
+**Proposal**: this item shrinks from "redesign" to "verify (done, findings above) + two small
+fixes (delete dead code, add sort/filter to SKU table)." No open design decision — recommend
+implementing directly rather than a further brainstorming pass.
+
+## Item 3 — Add Product to Order dialog
+
+**Current state** (`gui/add_product_dialog.py`, 418 lines): `AddProductDialog` — order number
+input with autocomplete, SKU input with autocomplete + live stock/warning display, quantity
+spinbox, a permanent info box (`_create_info_box`, `main_layout` line 82-83) explaining "Source:
+Manual / recalculated for this order only / saved to session / no full re-analysis," and
+Cancel/Add buttons.
+
+**Backend verification** (task asks to "verify the backend logic it describes still holds"):
+traced the full path in `gui/actions_handler.py:1259` (`_add_product_to_order`) and `:1358`
+(`_recalculate_order_fulfillment`). All three claims in the info banner check out against
+current code:
+- `new_row["Source"] = "Manual"` — `actions_handler.py:1302`.
+- Fulfillment is recalculated for the **single order only**, explicitly not touching others or
+  re-running full analysis — `_recalculate_order_fulfillment`'s own docstring plus its
+  implementation (rebuilds `live_stock` from the current `Final_Stock` column, doesn't call
+  `core.run_full_analysis`).
+- Saved to session — `_save_manual_addition(product_data)` call at `actions_handler.py:1338`.
+
+No backend bug. The banner is accurate; it's just permanent, static UI real estate for something
+that's true 100% of the time this dialog is ever used (it has exactly one workflow, no mode
+switch) — the Todoist ask to remove it and document elsewhere (or let it be self-evident) is
+sound. Recommend: drop the info box entirely; if the "no full re-analysis" guarantee needs to be
+documented somewhere for future maintainers, that's a code comment on
+`_add_product_to_order`, not runtime UI (arguably already adequately covered — the method's own
+docstring already says this).
+
+**Proposal for "better UI"**: current layout is three stacked `QGroupBox` sections (ORDER
+NUMBER, PRODUCT SKU, QUANTITY), each with a redundant `QLabel` repeating what the group title
+already says ("Enter order number:" under a group literally titled "ORDER NUMBER"). Consolidate
+to a single `QFormLayout` (Order Number / SKU / Quantity as form rows) with the existing
+inline status labels (`order_status_label`, `product_info_label`) kept as-is directly under
+their field — those are genuinely useful (live existence/stock feedback) and shouldn't be
+touched. Keep `warning_box` (low/zero-stock warning) — also genuinely useful, real-time. Net
+result: same functionality, ~120 fewer lines of boilerplate `QGroupBox`/`QVBoxLayout` scaffolding,
+shorter dialog (currently hardcoded to 500×500 — recompute after the layout change, likely
+smaller).
+
+**No open decision needed** — this is a straightforward mechanical simplification once the info
+box is confirmed removable, which the backend trace above confirms.
+
+## Testing
+
+No existing test file covers any of the three areas (`tests/` has no `test_column_config*`,
+`test_table_config*`, `test_add_product*`, or statistics-tab test). Whoever implements each item
+should add a focused test: for Item 1, a `TableConfigManager` round-trip test if the
+single-write refactor happens; for Item 2, none needed for the dead-code deletion, a lightweight
+sort-enabled assertion for the SKU table fix; for Item 3, a `_validate()`/`_on_add_clicked()`
+unit test using a stub `analysis_df`/`stock_df` (no full GUI needed, mirrors how
+`test_actions_handler.py` likely already stubs `self.mw`).
+
+## Recommended sequencing
+
+Items 2 and 3 are small enough (verify-and-fix, not redesign) to implement directly without a
+further `writing-plans` pass — quick-fix-sized once scoped, per the code findings above. Item 1
+needs the (a)-vs-(b) decision above before a plan is worth writing, and is the only one of the
+three with any real design surface left. None of the three block each other; any order works.
+
+## Next steps
+
+Get the Item 1 (a)/(b) call from the user, then this doc is ready to feed a `writing-plans` pass
+(or, given how small each item nets out to, three short direct-implementation sessions instead of
+a formal 3-file plan — light-epic, doesn't need the heavier ceremony a Phase 3/6/7 epic would).

--- a/docs/superpowers/specs/2026-08-11-ui-design-system-vision-design.md
+++ b/docs/superpowers/specs/2026-08-11-ui-design-system-vision-design.md
@@ -1,0 +1,176 @@
+# UI/UX Design System — Vision — Design
+
+## Context
+
+Phase 6 (client settings unification) and Phase 7 (session lifecycle & cross-tool sync)
+already carry five-plus "fresh look" / "better UI" tasks (Profile manager/client settings,
+Mappings, Rule engine, Tag categories, Packing list/Stock export, Session Setup, Session
+Browser) with nothing shared to redesign *into* — no type scale, no icon system, no
+reusable layout components. This doc is a vision/audit pass (same tier as the 2026-08-09
+packaging-unlock audit doc, not a single implementation plan) proposing a small foundation
+those tasks can build on, instead of each becoming its own bespoke, inconsistent redesign.
+
+**Scope: `shopify-fulfillment-tool` only, for now.** `shared/theme.py` (the token/stylesheet
+system) is synced one-way from `packing-tool` and must never be hand-edited here (see this
+repo's `CLAUDE.md`). Everything below therefore layers on top of `ThemeTokens` from within
+`gui/theme_manager.py` — the repo-owned customization seam — without touching
+`shared/theme.py`. Anything that would genuinely belong upstream (e.g. if the type scale or
+icon-color tokens prove useful to `packing-tool` too) is flagged as a future
+packing-tool-side change, not attempted here.
+
+**Current state, verified against code** (see also the 2026-08-11 Phase 5 doc, which covers
+a separate, narrower set of items and is unaffected by this doc):
+- `shared/theme.py`: flat light/dark QSS, hardcoded `font_family = "Segoe UI, sans-serif"`
+  (Windows default, never embedded), scattered inline font sizes (e.g. `font-size: 10pt` on
+  `QPushButton`), no type-scale concept.
+- Zero custom iconography anywhere in `gui/*.py` — the 5 main tabs use OS-native
+  `QStyle.SP_*` stock icons (`ui_manager.py:130-134`). No SVG icon set, no consistent visual
+  language.
+- Zero app/window branding — no `setWindowIcon` call anywhere in `gui_main.py` or
+  `main_window_pyside.py`.
+- The only bundled font files in the repo (`JetBrainsMono-*.ttf`,
+  `shopify_tool/templates/assets/fonts/`) are baked into printed label templates, unrelated
+  to the live GUI.
+- Phase 6 already names "two competing client-settings windows" as fragments that grew
+  organically (`settings_window_pyside.py`, 3595 lines), and separately lists 5 more
+  settings-adjacent surfaces, each its own top-level popup window today.
+
+## Decisions made in this brainstorm
+
+- **Iconography**: bundle a free, open SVG icon set (e.g. Lucide, ISC license) rather than
+  design custom icons or keep OS-native ones. No new Python dependency — static SVG files,
+  recolored at runtime per-theme via `QPixmap` + `QPainter.CompositionMode_SourceIn`
+  (standard technique for single-color line icons).
+- **Typography**: embed a free, open UI font (e.g. Inter or IBM Plex Sans, SIL OFL) as
+  bundled `.ttf` files loaded via `QFontDatabase.addApplicationFont()` at startup — same
+  bundling mechanism already proven for `JetBrainsMono` in label templates, applied to the
+  live app for the first time — paired with a formal type scale.
+- **Settings structure**: consolidate the growing pile of separate settings windows into one
+  Settings Hub (left-nav categories + `QStackedWidget` content), directly resolving Phase
+  6's flagged "duplicate windows" problem rather than just visually harmonizing N separate
+  popups.
+- **Layout/placement conventions** ("repositioning buttons and windows"): a documented,
+  enforced placement rule (primary action bottom-right, cancel/secondary bottom-left in
+  every dialog; consistent header-row/icon-button placement; consistent margins from the
+  token scale) that new dialogs follow by default — not a one-off pass over existing
+  screens.
+
+## Track 1 — Design tokens & type scale
+
+Add a `TYPE_SCALE` (caption/body/label/heading/title → point sizes + weights) as a local
+dict/dataclass in `gui/theme_manager.py`, replacing scattered hardcoded font sizes in
+`shared/theme.py`'s QSS and any inline `setStyleSheet` font sizes across `gui/*.py`. Widgets
+reference the scale going forward instead of hardcoding sizes. `theme_manager.py`'s
+`apply_theme()` uses `dataclasses.replace()` on the `ThemeTokens` it gets from
+`shared.theme.get_theme()` to override `font_family`/`font_family_mono` with the embedded
+font names (Track 2) before building the stylesheet — `shared/theme.py` itself stays
+untouched.
+
+## Track 2 — Iconography & font embedding
+
+- Bundle Lucide (or equivalent open, single-color SVG icon set) under `gui/assets/icons/`.
+  Render each icon to a `QPixmap` once per theme color and cache it (standard Qt recolor
+  pattern), replacing the `QStyle.SP_*` icons on the 5 main tabs
+  (`ui_manager.py:130-140`) and giving dialogs/buttons a consistent icon language for the
+  first time.
+- Add a real window/app icon (`setWindowIcon` in `gui_main.py`) — one glyph from the bundled
+  set is enough for a first pass; a full brand identity/logo is explicitly out of scope
+  (see Non-goals).
+- Bundle a static open font (e.g. Inter) as `.ttf` files under a new
+  `gui/assets/fonts/` (or reuse `shopify_tool/templates/assets/fonts/`'s pattern), loaded
+  via `QFontDatabase.addApplicationFont()` in `gui_main.py` at startup, before the theme is
+  first applied.
+
+## Track 3 — Component library & layout conventions
+
+A small `gui/components/` module formalizing patterns that already exist ad hoc elsewhere in
+the codebase:
+
+- **`Card`** — the elevated-container look already hand-rolled per-widget in the Statistics
+  tab's stat cards (`ui_manager.py:1705`, `_create_statistics_subtab`, from PR #221) and in
+  `ClientCard` (`gui/client_card.py`). One base widget, reused instead of reimplemented per
+  screen.
+- **`FormSection`** — replaces the `QGroupBox` + `QVBoxLayout` + redundant-`QLabel` pattern
+  the 2026-08-11 Phase 5 doc flagged in the Add Product dialog (three stacked `QGroupBox`
+  sections, each repeating what its own title already says) with a single
+  `QFormLayout`-based row builder. Any settings panel migrated into Track 4's Hub uses this
+  instead of hand-rolled group boxes.
+- **Placement conventions** — documented and applied by construction in `Card`/`FormSection`
+  usage: primary action bottom-right, cancel/secondary bottom-left in every dialog;
+  consistent header-row layout (icon buttons via Track 2 instead of the current plain-text
+  `"☰"` sidebar-toggle button in `ui_manager.py:159`); consistent margins/spacing pulled
+  from Track 1's tokens instead of per-widget magic numbers. New dialogs follow this by
+  default; existing screens adopt it incrementally as they're touched (Track 5).
+
+## Track 4 — Settings Hub
+
+One window: left-nav categories (Client Profile, Mappings, Rule Engine, Tag Categories,
+Packing List & Stock Export) + right-side `QStackedWidget` content, built from
+`Card`/`FormSection`. Directly resolves Phase 6's flagged "two competing client-settings
+windows" and gives every future settings-adjacent feature one obvious home instead of a new
+top-level popup each time.
+
+**Direct dependency, not incidental**: Track C from the 2026-08-09 packaging-unlock audit
+doc (splitting `settings_window_pyside.py`, 3595 lines, before Phase 6's UI work lands on
+top of it) is the structural prerequisite for this Hub — its nav/content-stack shape needs
+those module boundaries to exist first. Track C was already recommended to run before Phase
+6; this doc doesn't change that recommendation, it explains why Track C matters more than
+originally framed (scaffolding for the Hub, not just risk reduction).
+
+## Track 5 — Migration path for Phase 6/7's existing "fresh look" tasks
+
+Once Tracks 1-4 exist, Phase 6's remaining UI tasks (Mappings, Rule engine, Tag categories,
+Packing list/Stock export) become "migrate this panel's content into the Hub using
+`Card`/`FormSection`" instead of four separate from-scratch redesigns — smaller, more
+consistent diffs per item. Phase 7's Session Setup/Session Browser aren't settings surfaces
+and aren't required to touch the Hub, but can adopt the tokens/icons/component patterns
+opportunistically when next touched. Phase 5's items (already speced separately) are
+unaffected and proceed independently.
+
+## Non-goals
+
+- No direct edits to `packing-tool`/`shared/theme.py` — flagged as a future cross-repo
+  change if this direction proves out, not attempted here.
+- Not re-scoping Phase 5 (separate doc, separate open decision already pending: the
+  Manage-Table-Columns `QTreeWidget` vs. `QListWidget`-with-headers call).
+- Not the Analysis-run freeze fix (Todoist `6hFm6xj6w9gFFQQV`) — orthogonal correctness bug,
+  unaffected by any of this, still highest daily-use priority per the 2026-08-09 audit.
+- Not a full rebrand/logo design — one bundled-set glyph covers "the app has no icon
+  anywhere"; a real brand identity is a separate, much bigger ask if ever wanted.
+- Not migrating every existing window in one shot — foundation (Tracks 1-3) + one flagship
+  consumer (Track 4); everything else adopts incrementally as it's touched (Track 5), same
+  incremental spirit as Phase 6's existing task-by-task list.
+
+## Recommended sequencing
+
+Extends, rather than replaces, the 2026-08-09 audit's queue:
+
+1. **Track A** (2026-08-09 audit) — Analysis-run freeze fix. Unchanged, do first — highest
+   daily-use payoff, orthogonal to everything in this doc.
+2. **Tracks 1-3 here** — tokens/type scale, iconography/fonts, component library + layout
+   conventions. No dependency on Track C; can start right after Track A.
+3. **Track C** (2026-08-09 audit) — settings structural split. Can run in parallel with
+   Tracks 1-3; required before Track 4 here.
+4. **Track 4 here** — Settings Hub (needs Track C done, consumes Tracks 1-3).
+5. **Phase 6, remaining UI tasks** — now smaller: migrate into the Hub (Track 5).
+6. **Phase 5** — independent, can interleave anywhere.
+7. **Track B** (2026-08-09 audit) — pypdf → pikepdf migration, opportunistic, unchanged.
+8. **Phase 7** — last, unchanged; Session Setup/Browser optionally adopt the component
+   library.
+
+## Testing
+
+No existing test coverage for theming/iconography/layout (expected — this is visual/UX
+work). Whoever implements each track should add what's checkable without a full GUI test
+harness: Track 1/2 — a self-check asserting the embedded font registers via
+`QFontDatabase.addApplicationFont()` and the type-scale tokens resolve to expected point
+sizes (mirrors `shared/theme.py`'s own `__main__` self-check pattern). Track 3 —
+`Card`/`FormSection` construction tests with stub data (no full window needed). Track 4 —
+a `TableConfigManager`-style state test if the Hub persists its own nav-selection state.
+
+## Next steps
+
+Same as the 2026-08-09 audit doc: this is a vision/audit doc, not one implementation plan.
+Each track (1-4 above) is its own future `brainstorming` → spec → `writing-plans` pass when
+picked up. Todoist gets updated to reflect these as new Roadmap entries, sequenced per
+above, alongside the existing Phase 5/6/7 structure.

--- a/gui/add_product_dialog.py
+++ b/gui/add_product_dialog.py
@@ -15,7 +15,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QCompleter,
     QDialog,
-    QGroupBox,
+    QFormLayout,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -61,80 +61,43 @@ class AddProductDialog(QDialog):
         """Setup dialog UI components."""
         self.setWindowTitle("Add Product to Order")
         self.setModal(True)
-        self.resize(500, 500)
+        self.setMinimumWidth(420)
 
         layout = QVBoxLayout(self)
 
-        # Section 1: Order Number Input
-        layout.addWidget(self._create_order_section())
+        form_layout = QFormLayout()
+        self._build_form(form_layout)
+        layout.addLayout(form_layout)
 
-        # Section 2: Product/SKU Input
-        layout.addWidget(self._create_product_section())
-
-        # Section 3: Quantity
-        layout.addWidget(self._create_quantity_section())
-
-        # Section 4: Info/Warning
         self.warning_box = self._create_warning_box()
         self.warning_box.setVisible(False)
         layout.addWidget(self.warning_box)
 
-        self.info_box = self._create_info_box()
-        layout.addWidget(self.info_box)
-
-        # Section 5: Buttons
         layout.addWidget(self._create_buttons())
 
-    def _create_order_section(self):
-        """Create order number input section."""
-        group = QGroupBox("ORDER NUMBER")
-        layout = QVBoxLayout(group)
-
-        layout.addWidget(QLabel("Enter order number:"))
-
+    def _build_form(self, form_layout: QFormLayout):
+        """Populate the order/SKU/quantity form rows."""
         self.order_input = QLineEdit()
         self.order_input.setPlaceholderText("Type order number... (e.g., 1001)")
         self.order_input.textChanged.connect(self._on_order_changed)
-        layout.addWidget(self.order_input)
+        form_layout.addRow("Order Number:", self.order_input)
 
-        # Status label (shows if order found)
         self.order_status_label = QLabel("")
-        layout.addWidget(self.order_status_label)
-
-        return group
-
-    def _create_product_section(self):
-        """Create SKU input section."""
-        group = QGroupBox("PRODUCT SKU")
-        layout = QVBoxLayout(group)
-
-        layout.addWidget(QLabel("Enter product SKU:"))
+        form_layout.addRow("", self.order_status_label)
 
         self.sku_input = QLineEdit()
         self.sku_input.setPlaceholderText("Type SKU... (e.g., SKU-HAT)")
         self.sku_input.textChanged.connect(self._on_sku_changed)
-        layout.addWidget(self.sku_input)
+        form_layout.addRow("Product SKU:", self.sku_input)
 
-        # Product info label (shows name + stock)
         self.product_info_label = QLabel("")
-        layout.addWidget(self.product_info_label)
-
-        return group
-
-    def _create_quantity_section(self):
-        """Create quantity input section."""
-        group = QGroupBox("QUANTITY")
-        layout = QVBoxLayout(group)
-
-        layout.addWidget(QLabel("Quantity to add:"))
+        form_layout.addRow("", self.product_info_label)
 
         self.quantity_spin = QSpinBox()
         self.quantity_spin.setMinimum(1)
         self.quantity_spin.setMaximum(9999)
         self.quantity_spin.setValue(1)
-        layout.addWidget(self.quantity_spin)
-
-        return group
+        form_layout.addRow("Quantity:", self.quantity_spin)
 
     def _create_warning_box(self):
         """Create warning box for low/zero stock."""
@@ -148,32 +111,6 @@ class AddProductDialog(QDialog):
                 background-color: #FFEBEE;
                 color: #1A1A1A;
                 border: 2px solid {theme.accent_red};
-                border-radius: 5px;
-                padding: 10px;
-            }}
-        """)
-        return label
-
-    def _create_info_box(self):
-        """Create info box."""
-        theme = get_theme_manager().get_current_theme()
-        text = (
-            "INFO\n\n"
-            "• Product will be added with Source: 'Manual'\n"
-            "• Fulfillment will be recalculated for this order\n"
-            "• Manual addition will be saved in session\n"
-            "• NO full re-analysis needed"
-        )
-
-        label = QLabel(text)
-        label.setWordWrap(True)
-        # ponytail: literal info-tint background, not worth a new
-        # ThemeTokens field for a handful of call sites.
-        label.setStyleSheet(f"""
-            QLabel {{
-                background-color: #E3F2FD;
-                color: #1A1A1A;
-                border: 2px solid {theme.accent_blue};
                 border-radius: 5px;
                 padding: 10px;
             }}

--- a/gui/column_config_dialog.py
+++ b/gui/column_config_dialog.py
@@ -716,31 +716,27 @@ class ColumnConfigPanel(QWidget):
             if hasattr(self.parent_window, 'current_client_id') and self.parent_window.current_client_id:
                 client_id = self.parent_window.current_client_id
                 view_name = self.view_combo.currentText() or "Default"
-                self.table_config_manager.save_config(client_id, config, view_name)
 
-                if hasattr(self, 'additional_columns_config'):
-                    if self.additional_columns_config:
-                        logger.debug("Syncing UI checkbox states to config before saving...")
-                        self._sync_ui_to_config()
+                additional_columns = None
+                if hasattr(self, 'additional_columns_config') and self.additional_columns_config:
+                    logger.debug("Syncing UI checkbox states to config before saving...")
+                    self._sync_ui_to_config()
+                    additional_columns = self.additional_columns_config
 
-                    enabled_cols = [col for col in self.additional_columns_config if col.get('enabled', False)]
-                    disabled_cols = [col for col in self.additional_columns_config if not col.get('enabled', False)]
+                self.table_config_manager.save_config(
+                    client_id, config, view_name, additional_columns=additional_columns
+                )
 
-                    logger.debug(f"Saving additional columns config: {len(self.additional_columns_config)} columns")
+                if additional_columns is not None:
+                    enabled_cols = [col for col in additional_columns if col.get('enabled', False)]
+                    disabled_cols = [col for col in additional_columns if not col.get('enabled', False)]
+                    logger.debug(f"Saved additional columns config: {len(additional_columns)} columns")
                     logger.debug(f"  Enabled: {len(enabled_cols)} - {[col['csv_name'] for col in enabled_cols]}")
                     logger.debug(f"  Disabled: {len(disabled_cols)}")
-
-                    client_config = self.table_config_manager.pm.load_client_config(client_id)
-
-                    if "ui_settings" not in client_config:
-                        client_config["ui_settings"] = {}
-                    if "table_view" not in client_config["ui_settings"]:
-                        client_config["ui_settings"]["table_view"] = {}
-
-                    client_config["ui_settings"]["table_view"]["additional_columns"] = self.additional_columns_config
-
-                    self.table_config_manager.pm.save_client_config(client_id, client_config)
-                    logger.info(f"Saved additional columns: {len(enabled_cols)} enabled ({', '.join([col['csv_name'] for col in enabled_cols])})")
+                    logger.info(
+                        f"Saved additional columns: {len(enabled_cols)} enabled "
+                        f"({', '.join([col['csv_name'] for col in enabled_cols])})"
+                    )
 
                 if hasattr(self.parent_window, 'tableView') and \
                    hasattr(self.parent_window, 'analysis_results_df') and \
@@ -752,7 +748,7 @@ class ColumnConfigPanel(QWidget):
 
                 logger.info("Column configuration applied successfully")
 
-                if hasattr(self, 'additional_columns_config') and any(col.get('enabled', False) for col in self.additional_columns_config):
+                if additional_columns and any(col.get('enabled', False) for col in additional_columns):
                     QMessageBox.information(
                         self,
                         "Configuration Saved",

--- a/gui/column_config_dialog.py
+++ b/gui/column_config_dialog.py
@@ -416,8 +416,11 @@ class ColumnConfigPanel(QWidget):
                 item.setHidden(bool(text))
                 continue
 
+            # Match the display name too -- the row shows the friendly label,
+            # so typing what you see ("Order Name") has to find it.
             column_name = item.data(Qt.UserRole)
-            item.setHidden(text not in column_name.lower())
+            haystack = f"{column_name} {item.text()}".lower()
+            item.setHidden(text not in haystack)
 
     def _on_item_changed(self, item: QListWidgetItem):
         """Handle item check state change."""
@@ -775,7 +778,14 @@ class ColumnConfigPanel(QWidget):
             )
 
     def _get_config_from_ui(self):
-        """Create TableConfig from current UI state."""
+        """Create TableConfig from current UI state.
+
+        Note: `column_order` is read off the grouped list, so Apply rewrites
+        the saved order into category order and confines reordering to within
+        a category. That is the grouped-list model, not a bug -- but it does
+        overwrite an order the user built by dragging headers in the main
+        table (table_config_manager.on_column_moved writes the same field).
+        """
         from gui.table_config_manager import TableConfig
 
         visible_columns = {}

--- a/gui/column_config_dialog.py
+++ b/gui/column_config_dialog.py
@@ -9,6 +9,7 @@ Phase 4 of table customization feature.
 import logging
 
 from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -29,6 +30,92 @@ from PySide6.QtWidgets import (
 from gui.theme_manager import get_theme_manager
 
 logger = logging.getLogger(__name__)
+
+_CATEGORY_HEADER_MARKER = "__category_header__"
+
+# Category assignment for known analysis-output columns (see
+# shopify_tool/core.py and shopify_tool/analysis.py for the full
+# output-column list). Columns not listed here fall into "Other" rather
+# than being dropped from the list.
+COLUMN_CATEGORIES: dict[str, str] = {
+    "Order_Number": "Order Info",
+    "Name": "Order Info",
+    "Order_Type": "Order Info",
+    "Destination_Country": "Order Info",
+    "Shipping_Method": "Order Info",
+    "Shipping_Provider": "Order Info",
+    "Priority": "Order Info",
+    "Order_Min_Box": "Order Info",
+    "Execution_Date": "Order Info",
+    "Repeat": "Order Info",
+    "SKU": "Product Info",
+    "Product_Name": "Product Info",
+    "Warehouse_Name": "Product Info",
+    "Quantity": "Product Info",
+    "Has_SKU": "Product Info",
+    "Order_Fulfillment_Status": "Fulfillment",
+    "Fulfillable": "Fulfillment",
+    "Stock": "Fulfillment",
+    "Final_Stock": "Fulfillment",
+    "Stock_Alert": "Fulfillment",
+    "Summary_Missing": "Fulfillment",
+    "Summary_Present": "Fulfillment",
+    "Status_Note": "Fulfillment",
+    "Error": "Fulfillment",
+    "System_note": "Fulfillment",
+    "Notes": "Fulfillment",
+    "Tags": "Tags & Lot",
+    "Internal_Tags": "Tags & Lot",
+    "Lot_Details": "Tags & Lot",
+    "Lot_Batch": "Tags & Lot",
+    "Lot_Expiry": "Tags & Lot",
+    "Expiry_Date": "Tags & Lot",
+}
+
+CATEGORY_ORDER: list[str] = ["Order Info", "Product Info", "Fulfillment", "Tags & Lot", "Other"]
+
+COLUMN_DISPLAY_NAMES: dict[str, str] = {
+    "Order_Number": "Order Number",
+    "Name": "Order Name",
+    "Order_Type": "Order Type",
+    "Destination_Country": "Destination Country",
+    "Shipping_Method": "Shipping Method",
+    "Shipping_Provider": "Shipping Provider",
+    "Priority": "Priority",
+    "Order_Min_Box": "Min Box",
+    "Execution_Date": "Execution Date",
+    "Repeat": "Repeat Order",
+    "SKU": "SKU",
+    "Product_Name": "Product Name",
+    "Warehouse_Name": "Warehouse Name",
+    "Quantity": "Quantity",
+    "Has_SKU": "Has SKU",
+    "Order_Fulfillment_Status": "Fulfillment Status",
+    "Fulfillable": "Fulfillable",
+    "Stock": "Stock",
+    "Final_Stock": "Final Stock",
+    "Stock_Alert": "Stock Alert",
+    "Summary_Missing": "Missing Summary",
+    "Summary_Present": "Present Summary",
+    "Status_Note": "Status Note",
+    "Error": "Error",
+    "System_note": "System Note",
+    "Notes": "Notes",
+    "Tags": "Tags",
+    "Internal_Tags": "Internal Tags",
+    "Lot_Details": "Lot Details",
+    "Lot_Batch": "Lot Batch",
+    "Lot_Expiry": "Lot Expiry",
+    "Expiry_Date": "Expiry Date",
+}
+
+
+def _column_display_name(col_name: str) -> str:
+    return COLUMN_DISPLAY_NAMES.get(col_name, col_name)
+
+
+def _column_category(col_name: str) -> str:
+    return COLUMN_CATEGORIES.get(col_name, "Other")
 
 
 class ColumnConfigPanel(QWidget):
@@ -253,7 +340,7 @@ class ColumnConfigPanel(QWidget):
             self._is_loading = False
 
     def _load_columns(self, config):
-        """Load columns into the list widget."""
+        """Load columns into the list widget, grouped under category headers."""
         self.column_list.clear()
         self._current_columns = []
 
@@ -273,21 +360,44 @@ class ColumnConfigPanel(QWidget):
         else:
             columns = all_columns
 
+        grouped: dict[str, list[str]] = {category: [] for category in CATEGORY_ORDER}
         for col_name in columns:
-            item = QListWidgetItem(col_name)
-            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            grouped[_column_category(col_name)].append(col_name)
 
-            is_visible = config.visible_columns.get(col_name, True)
-            item.setCheckState(Qt.Checked if is_visible else Qt.Unchecked)
+        theme = get_theme_manager().get_current_theme()
 
-            if col_name in config.locked_columns:
-                item.setToolTip("Locked column (always visible and first)")
-                font = item.font()
-                font.setBold(True)
-                item.setFont(font)
+        for category in CATEGORY_ORDER:
+            cols_in_category = grouped[category]
+            if not cols_in_category:
+                continue
 
-            self.column_list.addItem(item)
-            self._current_columns.append(col_name)
+            header_item = QListWidgetItem(category)
+            header_item.setFlags(Qt.NoItemFlags)
+            header_item.setData(Qt.UserRole, _CATEGORY_HEADER_MARKER)
+            header_font = header_item.font()
+            header_font.setBold(True)
+            header_item.setFont(header_font)
+            header_item.setForeground(QColor(theme.text_secondary))
+            self.column_list.addItem(header_item)
+
+            for col_name in cols_in_category:
+                item = QListWidgetItem(_column_display_name(col_name))
+                item.setData(Qt.UserRole, col_name)
+                item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+
+                is_visible = config.visible_columns.get(col_name, True)
+                item.setCheckState(Qt.Checked if is_visible else Qt.Unchecked)
+
+                if col_name in config.locked_columns:
+                    item.setToolTip(f"{col_name} (locked column, always visible and first)")
+                    font = item.font()
+                    font.setBold(True)
+                    item.setFont(font)
+                else:
+                    item.setToolTip(col_name)
+
+                self.column_list.addItem(item)
+                self._current_columns.append(col_name)
 
         self._update_button_states()
 
@@ -297,19 +407,27 @@ class ColumnConfigPanel(QWidget):
 
         for i in range(self.column_list.count()):
             item = self.column_list.item(i)
-            column_name = item.text()
 
-            if text in column_name.lower():
-                item.setHidden(False)
-            else:
-                item.setHidden(True)
+            if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+                # ponytail: headers just hide/show with any active filter
+                # rather than tracking per-group match counts -- upgrade to
+                # "hide only if the whole group is filtered out" if a user
+                # reports it's confusing to lose the grouping while typing.
+                item.setHidden(bool(text))
+                continue
+
+            column_name = item.data(Qt.UserRole)
+            item.setHidden(text not in column_name.lower())
 
     def _on_item_changed(self, item: QListWidgetItem):
         """Handle item check state change."""
         if self._is_loading:
             return
 
-        column_name = item.text()
+        if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return
+
+        column_name = item.data(Qt.UserRole)
         config = self.table_config_manager.get_current_config()
 
         if column_name in config.locked_columns and item.checkState() == Qt.Unchecked:
@@ -324,14 +442,21 @@ class ColumnConfigPanel(QWidget):
             )
 
     def _on_move_up(self):
-        """Move selected column up in the order."""
+        """Move selected column up in the order (within its category group)."""
         current_row = self.column_list.currentRow()
         if current_row <= 0:
             return
 
-        config = self.table_config_manager.get_current_config()
         item = self.column_list.currentItem()
-        column_name = item.text()
+        if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return
+
+        above_item = self.column_list.item(current_row - 1)
+        if above_item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return  # already first in its category group
+
+        config = self.table_config_manager.get_current_config()
+        column_name = item.data(Qt.UserRole)
 
         if column_name in config.locked_columns:
             QMessageBox.warning(
@@ -341,31 +466,41 @@ class ColumnConfigPanel(QWidget):
             )
             return
 
-        if current_row == 1 and "Order_Number" in config.locked_columns:
-            target_col = self.column_list.item(0).text()
-            if target_col == "Order_Number":
-                QMessageBox.warning(
-                    self,
-                    "Cannot Move Column",
-                    "Cannot move column before locked 'Order_Number' column."
-                )
-                return
+        above_column_name = above_item.data(Qt.UserRole)
+        if above_column_name in config.locked_columns:
+            QMessageBox.warning(
+                self,
+                "Cannot Move Column",
+                f"Cannot move above locked column '{above_column_name}'."
+            )
+            return
 
         item = self.column_list.takeItem(current_row)
         self.column_list.insertItem(current_row - 1, item)
         self.column_list.setCurrentRow(current_row - 1)
 
-        self._current_columns.insert(current_row - 1, self._current_columns.pop(current_row))
+        self._current_columns = [
+            self.column_list.item(i).data(Qt.UserRole)
+            for i in range(self.column_list.count())
+            if self.column_list.item(i).data(Qt.UserRole) != _CATEGORY_HEADER_MARKER
+        ]
 
     def _on_move_down(self):
-        """Move selected column down in the order."""
+        """Move selected column down in the order (within its category group)."""
         current_row = self.column_list.currentRow()
         if current_row < 0 or current_row >= self.column_list.count() - 1:
             return
 
-        config = self.table_config_manager.get_current_config()
         item = self.column_list.currentItem()
-        column_name = item.text()
+        if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return
+
+        below_item = self.column_list.item(current_row + 1)
+        if below_item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+            return  # already last in its category group
+
+        config = self.table_config_manager.get_current_config()
+        column_name = item.data(Qt.UserRole)
 
         if column_name in config.locked_columns:
             QMessageBox.warning(
@@ -375,11 +510,12 @@ class ColumnConfigPanel(QWidget):
             )
             return
 
-        if current_row == 0 and "Order_Number" in config.locked_columns:
+        below_column_name = below_item.data(Qt.UserRole)
+        if below_column_name in config.locked_columns:
             QMessageBox.warning(
                 self,
                 "Cannot Move Column",
-                "Cannot move locked column."
+                f"Cannot move below locked column '{below_column_name}'."
             )
             return
 
@@ -387,7 +523,11 @@ class ColumnConfigPanel(QWidget):
         self.column_list.insertItem(current_row + 1, item)
         self.column_list.setCurrentRow(current_row + 1)
 
-        self._current_columns.insert(current_row + 1, self._current_columns.pop(current_row))
+        self._current_columns = [
+            self.column_list.item(i).data(Qt.UserRole)
+            for i in range(self.column_list.count())
+            if self.column_list.item(i).data(Qt.UserRole) != _CATEGORY_HEADER_MARKER
+        ]
 
     def _on_show_all(self):
         """Show all columns and disable auto-hide."""
@@ -395,6 +535,8 @@ class ColumnConfigPanel(QWidget):
         try:
             for i in range(self.column_list.count()):
                 item = self.column_list.item(i)
+                if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+                    continue
                 item.setCheckState(Qt.Checked)
         finally:
             self._is_loading = False
@@ -409,7 +551,9 @@ class ColumnConfigPanel(QWidget):
         try:
             for i in range(self.column_list.count()):
                 item = self.column_list.item(i)
-                column_name = item.text()
+                if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+                    continue
+                column_name = item.data(Qt.UserRole)
 
                 if column_name in config.locked_columns:
                     continue
@@ -643,7 +787,9 @@ class ColumnConfigPanel(QWidget):
 
         for i in range(self.column_list.count()):
             item = self.column_list.item(i)
-            column_name = item.text()
+            if item.data(Qt.UserRole) == _CATEGORY_HEADER_MARKER:
+                continue
+            column_name = item.data(Qt.UserRole)
             is_visible = item.checkState() == Qt.Checked
 
             visible_columns[column_name] = is_visible

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -1309,7 +1309,11 @@ class MainWindow(QMainWindow):
             for row_idx, sku_data in enumerate(sku_summary):
                 self.sku_table.insertRow(row_idx)
 
-                num_item = QTableWidgetItem(str(row_idx + 1))
+                # Numeric columns store real ints, not strings -- a
+                # QTableWidgetItem built from str() sorts lexicographically,
+                # which orders 10 before 2.
+                num_item = QTableWidgetItem()
+                num_item.setData(Qt.DisplayRole, row_idx + 1)
                 num_item.setTextAlignment(Qt.AlignCenter)
                 self.sku_table.setItem(row_idx, 0, num_item)
 
@@ -1326,7 +1330,11 @@ class MainWindow(QMainWindow):
                     ["Total_Quantity", "Fulfillable_Items", "Not_Fulfillable_Items"],
                     start=3,
                 ):
-                    val_item = QTableWidgetItem(str(sku_data.get(key, 0)))
+                    raw = sku_data.get(key, 0)
+                    if raw is None or (hasattr(pd, "isna") and pd.isna(raw)):
+                        raw = 0
+                    val_item = QTableWidgetItem()
+                    val_item.setData(Qt.DisplayRole, int(raw))
                     val_item.setTextAlignment(Qt.AlignCenter)
                     self.sku_table.setItem(row_idx, col_idx, val_item)
 

--- a/gui/main_window_pyside.py
+++ b/gui/main_window_pyside.py
@@ -1303,6 +1303,7 @@ class MainWindow(QMainWindow):
 
         # === 4. SKU table ===
         if hasattr(self, "sku_table"):
+            self.sku_table.setSortingEnabled(False)
             self.sku_table.setRowCount(0)
             sku_summary = self.analysis_stats.get("sku_summary") or []
             for row_idx, sku_data in enumerate(sku_summary):
@@ -1331,6 +1332,20 @@ class MainWindow(QMainWindow):
 
             self.sku_table.resizeColumnToContents(0)
             self.sku_table.resizeColumnToContents(1)
+            self.sku_table.setSortingEnabled(True)
+            if hasattr(self, "sku_search_input"):
+                self.sku_search_input.clear()
+
+    def _on_sku_search_changed(self, text: str):
+        """Filter the SKU Summary table by SKU/product substring."""
+        text = text.strip().lower()
+        for row in range(self.sku_table.rowCount()):
+            sku_item = self.sku_table.item(row, 1)
+            product_item = self.sku_table.item(row, 2)
+            sku_text = sku_item.text().lower() if sku_item else ""
+            product_text = product_item.text().lower() if product_item else ""
+            matches = not text or text in sku_text or text in product_text
+            self.sku_table.setRowHidden(row, not matches)
 
     def _clear_statistics_view(self):
         """Clear statistics display when no analysis results."""

--- a/gui/table_config_manager.py
+++ b/gui/table_config_manager.py
@@ -158,13 +158,22 @@ class TableConfigManager:
             self._current_config = TableConfig()
             return self._current_config
 
-    def save_config(self, client_id: str, config: TableConfig, view_name: str = "Default"):
+    def save_config(
+        self,
+        client_id: str,
+        config: TableConfig,
+        view_name: str = "Default",
+        additional_columns: list[dict] | None = None,
+    ):
         """Save table configuration for a client.
 
         Args:
             client_id: Client ID to save config for
             config: TableConfig to save
             view_name: Name of the view to save (default: "Default")
+            additional_columns: Optional "Additional CSV Columns" config to
+                persist in the same write. Pass None to leave whatever's
+                already stored untouched.
 
         Raises:
             Exception: If config saving fails (logs error)
@@ -195,7 +204,11 @@ class TableConfigManager:
             # Update active view
             table_view_settings["active_view"] = view_name
 
-            # Persist to file
+            if additional_columns is not None:
+                table_view_settings["additional_columns"] = additional_columns
+
+            # Persist to file (single read-modify-write for both view and
+            # additional_columns, instead of a second round trip)
             self.pm.save_client_config(client_id, client_config)
 
             # Update cached config if this is the current client

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -1786,6 +1786,11 @@ class UIManager:
         sku_layout = QVBoxLayout(sku_group)
         sku_layout.setContentsMargins(8, 8, 8, 8)
 
+        self.mw.sku_search_input = QLineEdit()
+        self.mw.sku_search_input.setPlaceholderText("Filter by SKU or product...")
+        self.mw.sku_search_input.textChanged.connect(self.mw._on_sku_search_changed)
+        sku_layout.addWidget(self.mw.sku_search_input)
+
         self.mw.sku_table = QTableWidget()
         self.mw.sku_table.setColumnCount(6)
         self.mw.sku_table.setHorizontalHeaderLabels(
@@ -1799,6 +1804,7 @@ class UIManager:
         self.mw.sku_table.setSelectionBehavior(QTableWidget.SelectRows)
         self.mw.sku_table.setAlternatingRowColors(True)
         self.mw.sku_table.verticalHeader().setVisible(False)
+        self.mw.sku_table.setSortingEnabled(True)
         self.mw.sku_table.setMinimumHeight(200)
         sku_layout.addWidget(self.mw.sku_table)
         layout.addWidget(sku_group, 1)

--- a/gui/ui_manager.py
+++ b/gui/ui_manager.py
@@ -5,7 +5,6 @@ from PySide6.QtGui import QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QCheckBox,
     QFrame,
-    QGridLayout,
     QGroupBox,
     QHBoxLayout,
     QHeaderView,
@@ -821,38 +820,6 @@ class UIManager:
         main_layout.addLayout(settings_layout)
 
         return group
-
-    def create_statistics_tab(self, tab_widget):
-        """Creates and lays out the UI elements for the 'Statistics' tab.
-
-        Args:
-            tab_widget (QWidget): The parent widget (the tab) to populate.
-        """
-        layout = QGridLayout(tab_widget)
-        layout.setAlignment(Qt.AlignmentFlag.AlignTop)
-        self.mw.stats_labels = {}
-        stat_keys = {
-            "total_orders_completed": "Total Orders Completed:",
-            "total_orders_not_completed": "Total Orders Not Completed:",
-            "total_items_to_write_off": "Total Items to Write Off:",
-            "total_items_not_to_write_off": "Total Items Not to Write Off:",
-        }
-        row_counter = 0
-        for key, text in stat_keys.items():
-            label = QLabel(text)
-            value_label = QLabel("-")
-            self.mw.stats_labels[key] = value_label
-            layout.addWidget(label, row_counter, 0)
-            layout.addWidget(value_label, row_counter, 1)
-            row_counter += 1
-
-        courier_header = QLabel("Couriers Stats:")
-        courier_header.setStyleSheet("font-weight: bold; margin-top: 15px;")
-        layout.addWidget(courier_header, row_counter, 0, 1, 2)
-        row_counter += 1
-        self.mw.courier_stats_layout = QGridLayout()
-        layout.addLayout(self.mw.courier_stats_layout, row_counter, 0, 1, 2)
-        self.log.info("Statistics tab created.")
 
     def set_ui_busy(self, is_busy):
         """Enables or disables key UI elements based on application state.

--- a/tests/test_add_product_dialog.py
+++ b/tests/test_add_product_dialog.py
@@ -1,0 +1,48 @@
+"""Regression test: Add Product to Order dialog drops the static info box
+and consolidates its three QGroupBox sections into one QFormLayout (Phase 5
+Item 3) -- the live status labels and stock-warning box keep working
+unchanged since the backend behavior they describe wasn't touched.
+"""
+import pandas as pd
+import pytest
+from PySide6.QtWidgets import QApplication, QGroupBox
+
+from gui.add_product_dialog import AddProductDialog
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def dialog():
+    analysis_df = pd.DataFrame([
+        {"Order_Number": "1001", "Order_Fulfillment_Status": "Fulfillable"},
+    ])
+    stock_df = pd.DataFrame([
+        {"SKU": "SKU-A", "Product_Name": "Widget A"},
+    ])
+    live_stock = {"SKU-A": 2}
+    dlg = AddProductDialog(None, analysis_df, stock_df, live_stock)
+    # isVisible() on a child only reflects reality once the top-level widget
+    # itself has been shown -- otherwise it's always False regardless of
+    # setVisible() calls on the child.
+    dlg.show()
+    return dlg
+
+
+def test_info_box_and_group_boxes_are_gone(dialog):
+    assert not hasattr(dialog, "info_box")
+    assert dialog.findChildren(QGroupBox) == []
+
+
+def test_order_status_label_still_updates(dialog):
+    dialog.order_input.setText("1001")
+    assert "Order found" in dialog.order_status_label.text()
+
+
+def test_low_stock_warning_still_shows(dialog):
+    dialog.sku_input.setText("SKU-A")
+    assert dialog.warning_box.isVisible()
+    assert "low stock" in dialog.warning_box.text().lower()

--- a/tests/test_column_config_dialog.py
+++ b/tests/test_column_config_dialog.py
@@ -1,0 +1,93 @@
+"""Regression test: Manage Table Columns list must group columns under
+category header rows (grouped-list redesign, Phase 5 Item 1) without
+breaking the underlying visible/order round-trip. Root cause risk: switching
+list items to show display names instead of raw column names would break
+every call site that read item.text() as the column name -- this locks in
+item.data(Qt.UserRole) as the source of truth instead.
+"""
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from gui.column_config_dialog import _CATEGORY_HEADER_MARKER, ColumnConfigPanel
+from gui.table_config_manager import TableConfig
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def _make_panel(columns, locked_columns=None):
+    config = TableConfig(
+        visible_columns={col: True for col in columns},
+        column_order=columns,
+        locked_columns=locked_columns if locked_columns is not None else ["Order_Number"],
+    )
+    tcm = Mock()
+    tcm.get_current_config.return_value = config
+    tcm.get_current_view_name.return_value = "Default"
+    tcm.list_views.return_value = ["Default"]
+    tcm.pm.load_client_config.return_value = {}
+    main_window = Mock()
+    main_window.current_client_id = "TESTCLIENT"
+    main_window.analysis_results_df = None
+    return ColumnConfigPanel(tcm, main_window=main_window)
+
+
+def test_columns_are_grouped_under_category_headers():
+    panel = _make_panel(["Order_Number", "SKU", "Fulfillable", "Tags"])
+
+    categories_seen = [
+        panel.column_list.item(i).text()
+        for i in range(panel.column_list.count())
+        if panel.column_list.item(i).data(Qt.UserRole) == _CATEGORY_HEADER_MARKER
+    ]
+
+    assert categories_seen == ["Order Info", "Product Info", "Fulfillment", "Tags & Lot"]
+
+
+def test_get_config_from_ui_skips_header_rows():
+    panel = _make_panel(["Order_Number", "SKU", "Fulfillable"])
+
+    config = panel._get_config_from_ui()
+
+    assert set(config.column_order) == {"Order_Number", "SKU", "Fulfillable"}
+    assert _CATEGORY_HEADER_MARKER not in config.column_order
+
+
+def test_move_up_is_blocked_at_the_top_of_a_category_group():
+    panel = _make_panel(["SKU", "Product_Name"])  # both "Product Info"
+
+    # row 0 = "Product Info" header, row 1 = SKU, row 2 = Product_Name.
+    # Product_Name moving up swaps with SKU -- allowed.
+    panel.column_list.setCurrentRow(2)
+    panel._on_move_up()
+    assert panel.column_list.item(1).data(Qt.UserRole) == "Product_Name"
+
+    # Now at row 1, directly under the header -- moving up again must no-op
+    # instead of swapping with the header row.
+    panel._on_move_up()
+    assert panel.column_list.item(1).data(Qt.UserRole) == "Product_Name"
+
+
+def test_move_up_is_blocked_above_a_locked_column(monkeypatch):
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+    panel = _make_panel(["Order_Number", "Name"])  # both "Order Info"
+
+    # row 0 = header, row 1 = Order_Number (locked), row 2 = Name.
+    panel.column_list.setCurrentRow(2)
+    panel._on_move_up()
+
+    assert panel.column_list.item(1).data(Qt.UserRole) == "Order_Number"
+    assert panel.column_list.item(2).data(Qt.UserRole) == "Name"
+
+
+def test_locked_column_tooltip_still_shows_raw_name():
+    panel = _make_panel(["Order_Number"])
+
+    item = panel.column_list.item(1)  # row 0 = "Order Info" header
+    assert item.data(Qt.UserRole) == "Order_Number"
+    assert "Order_Number" in item.toolTip()

--- a/tests/test_column_config_dialog.py
+++ b/tests/test_column_config_dialog.py
@@ -91,3 +91,24 @@ def test_locked_column_tooltip_still_shows_raw_name():
     item = panel.column_list.item(1)  # row 0 = "Order Info" header
     assert item.data(Qt.UserRole) == "Order_Number"
     assert "Order_Number" in item.toolTip()
+
+
+def test_search_matches_the_display_name_the_user_can_see():
+    """"Name" renders as "Order Name" -- searching the visible label has to
+    find it, or the box no longer matches what the list shows.
+    """
+    panel = _make_panel(["Order_Number", "Name"])
+
+    panel._on_search_changed("order name")
+
+    # row 0 = "Order Info" header, row 1 = Order_Number, row 2 = Name.
+    assert panel.column_list.item(2).isHidden() is False
+
+
+def test_search_still_matches_the_raw_column_name():
+    panel = _make_panel(["Order_Number", "Name"])
+
+    panel._on_search_changed("order_number")
+
+    assert panel.column_list.item(1).isHidden() is False
+    assert panel.column_list.item(2).isHidden() is True

--- a/tests/test_main_window_statistics.py
+++ b/tests/test_main_window_statistics.py
@@ -2,6 +2,7 @@
 substring (Phase 5 Item 2's "add sort/filter to the SKU table" gap).
 """
 import pytest
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication, QTableWidget, QTableWidgetItem
 
 from gui.main_window_pyside import MainWindow
@@ -55,3 +56,43 @@ def test_empty_search_shows_all_rows():
 
     assert table.isRowHidden(0) is False
     assert table.isRowHidden(1) is False
+
+
+class _FakeStatsWindow:
+    """Minimal stand-in for update_statistics_tab: every other block in that
+    method is hasattr/getattr-guarded, so only these three attrs are needed.
+    """
+
+    def __init__(self, table, sku_summary):
+        self.sku_table = table
+        self.analysis_stats = {"sku_summary": sku_summary}
+        self.active_profile_config = None
+
+
+def test_sku_quantity_columns_sort_numerically():
+    """Quantities must be stored as ints, not strings -- a str-built
+    QTableWidgetItem sorts lexicographically and puts 10 before 2.
+    """
+    table = QTableWidget()
+    table.setColumnCount(6)
+    sku_summary = [
+        {"SKU": "SKU-A", "Product_Name": "A", "Total_Quantity": 2},
+        {"SKU": "SKU-B", "Product_Name": "B", "Total_Quantity": 10},
+        {"SKU": "SKU-C", "Product_Name": "C", "Total_Quantity": 9},
+    ]
+
+    MainWindow.update_statistics_tab(_FakeStatsWindow(table, sku_summary))
+    table.sortItems(3)
+
+    sorted_qtys = [table.item(r, 3).data(Qt.DisplayRole) for r in range(3)]
+    assert sorted_qtys == [2, 9, 10]
+
+
+def test_missing_quantity_falls_back_to_zero():
+    table = QTableWidget()
+    table.setColumnCount(6)
+    sku_summary = [{"SKU": "SKU-A", "Product_Name": "A"}]
+
+    MainWindow.update_statistics_tab(_FakeStatsWindow(table, sku_summary))
+
+    assert table.item(0, 3).data(Qt.DisplayRole) == 0

--- a/tests/test_main_window_statistics.py
+++ b/tests/test_main_window_statistics.py
@@ -1,0 +1,57 @@
+"""Regression test: SKU Summary table search box filters by SKU or product
+substring (Phase 5 Item 2's "add sort/filter to the SKU table" gap).
+"""
+import pytest
+from PySide6.QtWidgets import QApplication, QTableWidget, QTableWidgetItem
+
+from gui.main_window_pyside import MainWindow
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def _make_sku_table(rows):
+    table = QTableWidget()
+    table.setColumnCount(3)
+    for row_idx, (sku, product) in enumerate(rows):
+        table.insertRow(row_idx)
+        table.setItem(row_idx, 1, QTableWidgetItem(sku))
+        table.setItem(row_idx, 2, QTableWidgetItem(product))
+    return table
+
+
+class _FakeMainWindow:
+    def __init__(self, table):
+        self.sku_table = table
+
+
+def test_sku_search_hides_non_matching_rows():
+    table = _make_sku_table([("SKU-A", "Widget A"), ("SKU-B", "Gadget B")])
+    mw = _FakeMainWindow(table)
+
+    MainWindow._on_sku_search_changed(mw, "gadget")
+
+    assert table.isRowHidden(0) is True
+    assert table.isRowHidden(1) is False
+
+
+def test_sku_search_matches_by_sku_too():
+    table = _make_sku_table([("SKU-A", "Widget A"), ("SKU-B", "Gadget B")])
+    mw = _FakeMainWindow(table)
+
+    MainWindow._on_sku_search_changed(mw, "sku-a")
+
+    assert table.isRowHidden(0) is False
+    assert table.isRowHidden(1) is True
+
+
+def test_empty_search_shows_all_rows():
+    table = _make_sku_table([("SKU-A", "Widget A"), ("SKU-B", "Gadget B")])
+    mw = _FakeMainWindow(table)
+
+    MainWindow._on_sku_search_changed(mw, "")
+
+    assert table.isRowHidden(0) is False
+    assert table.isRowHidden(1) is False

--- a/tests/test_table_config_manager.py
+++ b/tests/test_table_config_manager.py
@@ -1,0 +1,55 @@
+"""Regression test: applying column config must persist to client_config.json
+in a single write, not two separate read-modify-write round trips (one for
+the view, one for additional_columns) -- each was its own UNC-share round
+trip on every Apply click.
+"""
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from gui.table_config_manager import TableConfig, TableConfigManager
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def test_save_config_writes_view_and_additional_columns_in_one_call(profile_manager):
+    profile_manager.create_client_profile("TESTCLIENT", "Test Client")
+    tcm = TableConfigManager(main_window=Mock(), profile_manager=profile_manager)
+
+    # A freshly created profile's config.json predates ui_settings/table_view,
+    # so its first load auto-migrates and auto-saves once (see
+    # ProfileManager.load_client_config). Prime that here, before installing
+    # the spy, so the assertion below isolates save_config's own write count.
+    profile_manager.load_client_config("TESTCLIENT")
+
+    save_spy = Mock(wraps=profile_manager.save_client_config)
+    profile_manager.save_client_config = save_spy
+
+    config = TableConfig(visible_columns={"SKU": True}, column_order=["SKU"])
+    additional_columns = [{"csv_name": "Extra", "internal_name": "extra", "enabled": True}]
+
+    tcm.save_config("TESTCLIENT", config, "Default", additional_columns=additional_columns)
+
+    assert save_spy.call_count == 1
+
+    saved = profile_manager.load_client_config("TESTCLIENT")
+    table_view = saved["ui_settings"]["table_view"]
+    assert table_view["views"]["Default"]["column_order"] == ["SKU"]
+    assert table_view["additional_columns"] == additional_columns
+
+
+def test_save_config_without_additional_columns_leaves_existing_value_untouched(profile_manager):
+    profile_manager.create_client_profile("TESTCLIENT", "Test Client")
+    tcm = TableConfigManager(main_window=Mock(), profile_manager=profile_manager)
+
+    seed = [{"csv_name": "Extra", "internal_name": "extra", "enabled": True}]
+    tcm.save_config("TESTCLIENT", TableConfig(), "Default", additional_columns=seed)
+
+    tcm.save_config("TESTCLIENT", TableConfig(visible_columns={"SKU": True}), "Default")
+
+    saved = profile_manager.load_client_config("TESTCLIENT")
+    assert saved["ui_settings"]["table_view"]["additional_columns"] == seed


### PR DESCRIPTION
## Phase 5 — Table & stats UX

Implements all three Phase 5 Todoist subtasks (5 plan tasks). **This work was
implemented and pushed on 2026-08-11 but no PR was ever opened** — the runner's
`state.md` had mistakenly recorded this branch as already merged via #265. This
PR recovers that dropped thread; the code below is that work plus the fixes from
a fresh code review run today.

### What changed

| Area | Change |
|---|---|
| `gui/column_config_dialog.py` | Manage Table Columns list is grouped under bold category headers with friendly display names instead of a flat list of raw DataFrame column names |
| `gui/table_config_manager.py` | Applying config folds two `client_config.json` read-modify-write cycles into a single write (new `additional_columns` param on `save_config`) |
| `gui/main_window_pyside.py` | Deleted dead `create_statistics_tab` (superseded by `_create_statistics_subtab`); added sorting + a SKU/product search filter to the SKU Summary table |
| `gui/add_product_dialog.py` | Removed the explanatory info banner; collapsed `QGroupBox`+`QVBoxLayout`+redundant-`QLabel` into one `QFormLayout` |

The riskiest piece was the column list: item `text()` previously doubled as the
raw column name, so all seven call sites had to move to `item.data(Qt.UserRole)`
at once or they'd silently write display-name strings into
`TableConfig.column_order` / `visible_columns` and corrupt saved configs. The
review verified that migration is complete (`grep '\.text()'` leaves exactly one
hit, an unrelated `QCheckBox`) and that header rows are skipped at every site.

### Review fixes included (b47c01c)

- **SKU sort was lexicographic.** `QTableWidgetItem(str(...))` sorts as text, so
  "Sort by Total Qty" put 10 before 2 for any client with ≥10 units. Now stores
  real ints via `setData(Qt.DisplayRole, int)`, with a `pd.isna`/None guard.
- **Column search didn't match the labels it displays.** It filtered on the raw
  name while showing the friendly one, so typing "Order Name" (for `Name`) hid
  everything. Now matches both.

Both are covered by new tests that were confirmed to fail without the fix.

### ⚠️ One thing worth your decision

Apply now derives `column_order` from the grouped list, so **the first Apply
after this lands rewrites a user's saved column order into category order**, and
reordering is confined within a category from then on. That follows from the
grouped-list model, but the same `column_order` field is written by
drag-to-reorder on the main table (`table_config_manager.on_column_moved`) — so
a dragged layout gets clobbered the next time someone opens the dialog and hits
Apply. Documented in a docstring on `_get_config_from_ui`; flagging it here
because it's a product call, not a code call. Say the word if you'd rather
preserve the prior order and apply only within-group moves.

### Also on this branch (unrelated to Phase 5)

- `docs/superpowers/specs/2026-08-11-ui-design-system-vision-design.md` — the
  UI/UX design-system vision doc that seeded the new p3 epic in Todoist
- A `CLAUDE.md` "Session Resource Check" section

### Gate

`382 passed` (378 + 4 new), `ruff check . --exclude shared` clean. Merges into
`main` cleanly (branch predates #266; no conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7Wi5hV79ZYj2heiTU7oCr
