### PR TITLE
UI Design System Track 4: Settings Hub

### DIFF
--- a/docs/superpowers/plans/2026-08-13-settings-hub-plan.md
+++ b/docs/superpowers/plans/2026-08-13-settings-hub-plan.md
@@ -1,0 +1,1252 @@
+# UI Design System Track 4 — Settings Hub Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the settings package Track C extracted into a designed Hub — a `collect()` contract that cannot silently drop config, a `FormSection` component, real primary/secondary button hierarchy, and a nav that looks like a sidebar and remembers where you were.
+
+**Architecture:** Four independent slices over `gui/settings/` and `gui/components/`. The contract change (Task 1) is the only one that touches saved data and goes first. `FormSection` (Tasks 2-4) is built against real call sites, then adopted. Button roles (Tasks 5-6) and Hub chrome (Task 7) are pure QSS layered through `gui/theme_manager.py`, the repo-owned seam — `shared/theme.py` is sync-owned by `packing-tool` and is never edited.
+
+**Tech Stack:** Python 3, PySide6, pytest (`QT_QPA_PLATFORM=offscreen`), ruff.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-settings-hub-design.md`
+
+## Global Constraints
+
+- **Never hand-edit anything under `shared/`.** It is one-way synced from `../packing-tool/shared/`. Every style change in this plan goes in `gui/theme_manager.py`.
+- **No hardcoded colors.** Use `theme.*` tokens (`background`, `background_elevated`, `text`, `text_secondary`, `border`, `border_subtle`, `hover`, `accent_blue`, `button_hover_light`, `button_hover_dark`, `radius`, `spacing_*`). Never `#666`, `#999`, `color: gray`.
+- **No font sizes outside the type scale.** Use `font_css(role)` / `apply_font(target, role)` from `gui/theme_manager.py`. Roles: `caption` (9pt), `body` (10pt), `label` (12pt bold), `heading` (14pt bold), `display` (17pt bold). An unknown role must raise `KeyError` — that rule is set by Tracks 1-3 and every new component keeps it.
+- **No UI calls from background threads.**
+- **Gate before finishing:** `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest` and `.venv/bin/ruff check . --exclude shared`. `python` is not on PATH on this machine — always go through `.venv/bin/`. Run `./scripts/setup_venv.sh` once in a fresh worktree.
+- **Do not move `ClientSettingsDialog` or `GroupsManagementDialog` into the Hub.** The spec explains why; it is an open question for the user, not this plan's work.
+- **Commit after every task.**
+
+---
+
+### Task 1: `collect()` replaces instead of merging
+
+The shell merges dict-valued sections with `dict.update()`, which can add and overwrite but never remove. Both Important findings in PR #272's review trace to that one line. Replace it with plain assignment, and make the pages that own dict sub-trees hold the *live* dict so keys they do not render are never dropped.
+
+**Files:**
+- Modify: `gui/settings/base.py` (docstring)
+- Modify: `gui/settings/window.py:231-236`
+- Modify: `gui/settings/general.py:18-21`, `76-84`
+- Modify: `gui/settings/weight.py:30-45`, `809-...` (the `return` at the end of `collect`)
+- Modify: `gui/settings/mappings.py:206-210` (comment only)
+- Test: `tests/test_settings_roundtrip.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the contract every later task relies on — `SettingsPage.collect() -> dict` where each value **replaces** `config_data[key]`, and a page owning a dict sub-tree returns the live dict it was constructed with.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_settings_roundtrip.py`. This is the behaviour the live-dict rule buys and nothing currently proves:
+
+```python
+def test_a_key_no_page_renders_survives_a_save(qapp, no_modals, started_workers):
+    """Live client configs on the server can carry keys this build's UI does
+    not know about -- profile_migrations.py exists because that has happened.
+    A page returning a fresh dict would drop them on every save."""
+    config = settings_fixture_config()
+    config["settings"]["legacy_key_no_page_renders"] = "keep me"
+    config["weight_config"]["legacy_weight_key"] = 123
+
+    win = SettingsWindow(client_id="M", client_config=config, profile_manager=Mock())
+    win.save_settings()
+
+    assert no_modals == [], f"save_settings() reported a problem: {no_modals}"
+    assert win.config_data["settings"]["legacy_key_no_page_renders"] == "keep me"
+    assert win.config_data["weight_config"]["legacy_weight_key"] == 123
+    win.deleteLater()
+```
+
+- [ ] **Step 2: Run it and confirm it passes for the wrong reason, then prove that**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_roundtrip.py::test_a_key_no_page_renders_survives_a_save -v`
+
+Expected: **PASS** — today's `dict.update()` merge preserves those keys by accident. That is not proof; it is the trap. Prove the test has teeth by temporarily changing `window.py:231-236` to the unconditional assignment this task is about to make permanent:
+
+```python
+for page in self._pages:
+    for key, value in page.collect().items():
+        self.config_data[key] = value
+```
+
+Re-run. Expected: **FAIL** on both asserts — `GeneralPage` and `WeightPage` return fresh dicts. **Leave this assignment in place**; Steps 3-4 make the pages correct under it.
+
+- [ ] **Step 3: Make `GeneralPage` hold the live `settings` dict**
+
+In `gui/settings/general.py`, store the constructor's dict and update it in place:
+
+```python
+    def __init__(self, settings: dict, parent=None):
+        super().__init__(parent)
+        # Held by reference so collect() can update it in place. The shell
+        # assigns collect()'s value straight over config_data[key], so a
+        # fresh dict here would drop any key this page does not render.
+        self._settings = settings
+        main_layout = QVBoxLayout(self)
+```
+
+and:
+
+```python
+    def collect(self) -> dict:
+        self._settings.update({
+            "stock_csv_delimiter": self.stock_delimiter_edit.text(),
+            "orders_csv_delimiter": self.orders_delimiter_edit.text(),
+            "low_stock_threshold": int(self.low_stock_edit.text()),
+            "repeat_detection_days": self.repeat_days_input.value(),
+        })
+        return {"settings": self._settings}
+```
+
+- [ ] **Step 4: Make `WeightPage` hold the live `weight_config` dict**
+
+In `gui/settings/weight.py`, `weight_cfg` is already "whichever dict we actually used" — `weight_config` when truthy, a fresh default when not. Keep a handle to it right after line 41-45:
+
+```python
+        weight_cfg = weight_config or {
+            "volumetric_divisor": 6000,
+            "products": {},
+            "boxes": []
+        }
+        # Held by reference for collect() -- see SettingsPage's contract. Note
+        # this is weight_cfg, not weight_config: an empty config substitutes a
+        # fresh dict above, and that substitute is the one to keep.
+        self._weight_config = weight_cfg
+```
+
+Then change the `return` at the end of `collect()` (around `weight.py:873`) from building a fresh dict to updating the held one:
+
+```python
+        self._weight_config.update({
+            "volumetric_divisor": divisor,
+            "products": products,
+            "boxes": boxes,
+        })
+        return {"weight_config": self._weight_config}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_roundtrip.py -v`
+
+Expected: all PASS, including the new test and the four existing ones.
+
+- [ ] **Step 6: Write the contract down where implementers will read it**
+
+`gui/settings/base.py`:
+
+```python
+class SettingsPage(QWidget):
+    """One page in the settings window.
+
+    The window builds each page, shows it in the nav stack, and on save
+    calls validate() then collect() on every page in turn. Pages that
+    persist their own data immediately (Sets, Column Config) inherit both
+    defaults and contribute nothing to the window's single write.
+
+    collect() returns {config_key: value}, and each value REPLACES
+    config_data[key] outright -- the window does not merge. A page that
+    owns a dict sub-tree must therefore mutate and return the live dict it
+    was constructed with, so keys it does not render survive the save.
+    Returning a freshly built dict silently drops them.
+
+    collect() writing into config_data before the window assigns is safe by
+    construction: save_settings() runs validate() across every page before
+    calling collect() on any of them, so no page mutates during a save a
+    later page will block. config_data is a deep copy, so a failed server
+    write cannot reach the caller's config either.
+    """
+```
+
+Replace the stale one-liner on `collect` itself:
+
+```python
+    def collect(self) -> dict:
+        """The config keys this page owns. Each value replaces config_data[key]."""
+        return {}
+```
+
+- [ ] **Step 7: Retarget the `MappingsPage` comment at the contract**
+
+`gui/settings/mappings.py:206-210` describes the merge it was working around. That merge is gone. Replace those five comment lines with:
+
+```python
+        # SettingsPage's contract: the returned value replaces
+        # config_data[key], so these must be the live dicts handed to
+        # __init__ -- clear-and-refill in place, never a fresh dict.
+```
+
+The `clear()`/`update()` calls below it stay exactly as they are.
+
+- [ ] **Step 8: Prove the guard tests still bite**
+
+The discipline PR #272 established: a guard test never shown to fail is decoration. Temporarily make `GeneralPage.collect()` return `{"settings": dict(self._settings)}` (a copy).
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_roundtrip.py -v`
+
+Expected: `test_a_key_no_page_renders_survives_a_save` FAILS. Restore, re-run, confirm green.
+
+- [ ] **Step 9: Full gate and commit**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+git add gui/settings/base.py gui/settings/window.py gui/settings/general.py gui/settings/weight.py gui/settings/mappings.py tests/test_settings_roundtrip.py
+git commit -m "fix(settings): collect() replaces instead of merging
+
+The shell's one-level dict.update() merge could add and overwrite but
+never remove, which is the root cause of both Important findings in
+#272's review. Pages owning a dict sub-tree now hold the live dict, so
+keys they do not render survive without the merge."
+```
+
+---
+
+### Task 2: The `FormSection` component
+
+Track 3 deferred `FormSection` so a real page would shape its API (`2026-08-12-component-library-design.md:12-17`). The call sites now exist: a title, an optional description paragraph, and either form rows or an arbitrary child widget.
+
+**Files:**
+- Create: `gui/components/form_section.py`
+- Modify: `gui/components/__init__.py`
+- Test: `tests/test_components_form_section.py`
+
+**Interfaces:**
+- Consumes: `font_css(role)` and `get_theme_manager()` from `gui/theme_manager.py`.
+- Produces: `FormSection(title: str, description: str = "", parent=None)` with `.add_row(label: str, widget: QWidget, tooltip: str = "") -> QLabel` (returns the label it built) and `.add_widget(widget: QWidget) -> None`. Tasks 3 and 4 consume exactly these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_components_form_section.py`, matching the construction-test style of `tests/test_components_card.py` (no window needed):
+
+```python
+"""Construction tests for the FormSection component. No window needed."""
+import pytest
+from PySide6.QtWidgets import QApplication, QFormLayout, QLabel, QLineEdit
+
+from gui.components.form_section import FormSection
+from gui.theme_manager import TYPE_SCALE
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _app():
+    yield QApplication.instance() or QApplication([])
+
+
+def test_title_renders_at_the_label_role():
+    section = FormSection("General Settings")
+    title = section.layout().itemAt(0).widget()
+    assert isinstance(title, QLabel)
+    assert title.text() == "General Settings"
+    assert f"font-size: {TYPE_SCALE['label'].size_pt}pt" in title.styleSheet()
+
+
+def test_description_is_omitted_when_not_given():
+    section = FormSection("General Settings")
+    # title + the form body, nothing else
+    assert section.layout().count() == 2
+
+
+def test_description_wraps_and_renders_at_caption():
+    section = FormSection("Courier Mappings", "Map provider names to codes.")
+    desc = section.layout().itemAt(1).widget()
+    assert desc.text() == "Map provider names to codes."
+    assert desc.wordWrap() is True
+    assert f"font-size: {TYPE_SCALE['caption'].size_pt}pt" in desc.styleSheet()
+
+
+def test_add_row_builds_the_label_and_puts_both_in_the_form():
+    section = FormSection("S")
+    field = QLineEdit()
+    label = section.add_row("Stock CSV Delimiter:", field)
+    form = section.form
+    assert isinstance(form, QFormLayout)
+    assert form.rowCount() == 1
+    assert form.itemAt(0, QFormLayout.LabelRole).widget() is label
+    assert form.itemAt(0, QFormLayout.FieldRole).widget() is field
+    assert label.text() == "Stock CSV Delimiter:"
+
+
+def test_add_row_tooltip_reaches_the_label_too():
+    """Hovering the label should explain the field. Today only the input
+    carries the tooltip, so the explanation is invisible to anyone reading
+    the form rather than clicking into it."""
+    section = FormSection("S")
+    field = QLineEdit()
+    label = section.add_row("Low Stock Threshold:", field, tooltip="Alert below this.")
+    assert label.toolTip() == "Alert below this."
+    assert field.toolTip() == "Alert below this."
+
+
+def test_add_row_leaves_an_existing_widget_tooltip_alone():
+    section = FormSection("S")
+    field = QLineEdit()
+    field.setToolTip("set by the caller")
+    section.add_row("X:", field)
+    assert field.toolTip() == "set by the caller"
+
+
+def test_add_widget_appends_below_the_form():
+    section = FormSection("Courier Mappings")
+    child = QLineEdit()
+    section.add_widget(child)
+    assert section.layout().indexOf(child) == section.layout().count() - 1
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_components_form_section.py -v`
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'gui.components.form_section'`.
+
+- [ ] **Step 3: Write the component**
+
+Create `gui/components/form_section.py`:
+
+```python
+"""A titled settings section: heading, optional description, form rows.
+
+Deferred here from Track 3 so real call sites would shape the API -- see
+docs/superpowers/specs/2026-08-12-component-library-design.md:12-17.
+
+Replaces two patterns at once. QGroupBox + QFormLayout in the settings
+pages, where the OS group-box chrome duplicates a title the nav already
+shows; and the hand-rolled font_css("heading") label written three times
+(sets.py, window.py's _ColumnConfigPage, mappings.py's instructions
+paragraph). One component rather than a second PageHeader type.
+"""
+
+from PySide6.QtWidgets import QFormLayout, QFrame, QLabel, QVBoxLayout, QWidget
+
+from gui.theme_manager import font_css, get_theme_manager
+
+
+class FormSection(QFrame):
+    """A titled block of form rows.
+
+    Args:
+        title: Section heading, rendered at the `label` type-scale role.
+        description: Optional wrapped paragraph under the title, at
+            `caption` in the secondary text colour. Omitted entirely when
+            empty -- an empty QLabel still takes vertical space.
+    """
+
+    def __init__(self, title: str, description: str = "", parent=None) -> None:
+        super().__init__(parent)
+        theme = get_theme_manager().get_current_theme()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(
+            theme.spacing_md, theme.spacing_sm, theme.spacing_md, theme.spacing_sm
+        )
+        layout.setSpacing(theme.spacing_xs)
+
+        title_label = QLabel(title)
+        title_label.setStyleSheet(font_css("label"))
+        layout.addWidget(title_label)
+
+        if description:
+            desc_label = QLabel(description)
+            desc_label.setWordWrap(True)
+            desc_label.setStyleSheet(
+                f"color: {theme.text_secondary}; {font_css('caption')}"
+            )
+            layout.addWidget(desc_label)
+
+        self.form = QFormLayout()
+        self.form.setContentsMargins(0, 0, 0, 0)
+        self.form.setSpacing(theme.spacing_sm)
+        layout.addLayout(self.form)
+
+    def add_row(self, label: str, widget: QWidget, tooltip: str = "") -> QLabel:
+        """Append a labelled row and return the label it built.
+
+        The pages currently name a QLabel variable per row purely to hand it
+        to addRow. The label is returned for the rare caller that needs a
+        handle to it.
+
+        `tooltip` is applied to the label as well as the widget, so hovering
+        the row's text explains the field. A widget that already carries its
+        own tooltip keeps it.
+        """
+        row_label = QLabel(label)
+        if tooltip:
+            row_label.setToolTip(tooltip)
+            if not widget.toolTip():
+                widget.setToolTip(tooltip)
+        self.form.addRow(row_label, widget)
+        return row_label
+
+    def add_widget(self, widget: QWidget) -> None:
+        """Append a widget below the form rows.
+
+        Not every section that wants a title holds form rows -- the courier
+        mappings section is a title over a button-and-rows column.
+        """
+        self.layout().addWidget(widget)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_components_form_section.py -v`
+
+Expected: all 7 PASS.
+
+- [ ] **Step 5: Export it**
+
+`gui/components/__init__.py` currently holds only a docstring. Append:
+
+```python
+from gui.components.card import Card
+from gui.components.form_section import FormSection
+
+__all__ = ["Card", "FormSection"]
+```
+
+- [ ] **Step 6: Gate and commit**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+git add gui/components/form_section.py gui/components/__init__.py tests/test_components_form_section.py
+git commit -m "feat(components): add FormSection, deferred to Track 4 from Track 3"
+```
+
+---
+
+### Task 3: Adopt `FormSection` in General and Mappings
+
+Four `QGroupBox` sites, and the four-lines-per-field label ceremony in `general.py`.
+
+**Files:**
+- Modify: `gui/settings/general.py:20-74`
+- Modify: `gui/settings/mappings.py:43-44`, `65-66`, `87-97`, `110`
+- Test: `tests/test_settings_roundtrip.py` (existing tests must stay green)
+
+**Interfaces:**
+- Consumes: `FormSection(title, description="")`, `.add_row(label, widget, tooltip="")`, `.add_widget(widget)` from Task 2.
+- Produces: nothing new. Widget attribute names (`self.stock_delimiter_edit`, `self.orders_delimiter_edit`, `self.low_stock_edit`, `self.repeat_days_input`, `self.orders_mapping_widget`, `self.stock_mapping_widget`, `self.courier_mappings_container`) are unchanged — `collect()` and the existing tests reference them.
+
+- [ ] **Step 1: Confirm the safety net is green before touching anything**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_roundtrip.py -v`
+
+Expected: all PASS. This is a pure layout change — every one of these tests must still pass at the end, unchanged. If one needs editing, the change stopped being pure and you should stop and say so.
+
+- [ ] **Step 2: Rewrite `GeneralPage`'s body**
+
+Replace `gui/settings/general.py` lines 20-74 (from `main_layout = QVBoxLayout(self)` through `main_layout.addStretch()`) with:
+
+```python
+        main_layout = QVBoxLayout(self)
+
+        section = FormSection("General Settings")
+
+        self.stock_delimiter_edit = QLineEdit(settings.get("stock_csv_delimiter", ";"))
+        self.stock_delimiter_edit.setMaximumWidth(100)
+        section.add_row(
+            "Stock CSV Delimiter:",
+            self.stock_delimiter_edit,
+            tooltip=(
+                "Character used to separate columns in stock CSV file.\n\n"
+                "Common values:\n"
+                "  • Semicolon (;) - for exports from local warehouse\n"
+                "  • Comma (,) - for Shopify exports\n\n"
+                "Make sure this matches your stock CSV file format."
+            ),
+        )
+
+        self.orders_delimiter_edit = QLineEdit(settings.get("orders_csv_delimiter", ","))
+        self.orders_delimiter_edit.setMaximumWidth(100)
+        self.orders_delimiter_edit.setPlaceholderText(",")
+        section.add_row(
+            "Orders CSV Delimiter:",
+            self.orders_delimiter_edit,
+            tooltip=(
+                "Character used to separate columns in orders CSV file.\n\n"
+                "Common values:\n"
+                "  • Comma (,) - standard Shopify exports\n"
+                "  • Semicolon (;) - European Excel exports\n"
+                "  • Tab (\\t) - tab-separated files\n\n"
+                "The tool will auto-detect delimiter when you select a file,\n"
+                "but you can override it here if needed."
+            ),
+        )
+
+        self.low_stock_edit = QLineEdit(str(settings.get("low_stock_threshold", 5)))
+        self.low_stock_edit.setMaximumWidth(100)
+        section.add_row(
+            "Low Stock Threshold:",
+            self.low_stock_edit,
+            tooltip=(
+                "Trigger stock alerts when quantity falls below this number.\n\n"
+                "Items with stock below this threshold will be marked in analysis."
+            ),
+        )
+
+        self.repeat_days_input = QSpinBox()
+        self.repeat_days_input.setMinimum(1)
+        self.repeat_days_input.setMaximum(365)
+        self.repeat_days_input.setValue(settings.get("repeat_detection_days", 1))
+        section.add_row(
+            "Repeat Detection Window (days):",
+            self.repeat_days_input,
+            tooltip=(
+                "Orders fulfilled within this many days are marked as 'Repeat'.\n"
+                "Default: 1 day (only yesterday's fulfillments)\n"
+                "Increase for longer detection window (e.g., 7 days, 30 days)"
+            ),
+        )
+
+        main_layout.addWidget(section)
+        main_layout.addStretch()
+```
+
+Fix the imports at the top of the file: drop `QFormLayout`, `QGroupBox` and `QLabel` (no longer used), add `from gui.components.form_section import FormSection`. The remaining PySide6 imports are `QLineEdit`, `QSpinBox`, `QVBoxLayout`.
+
+Note the tooltip strings are copied verbatim — including the `\\t` escape in the orders-delimiter text, which renders as a literal `\t` for the user and must not be turned into a tab.
+
+- [ ] **Step 3: Swap the three `QGroupBox` sites in `MappingsPage`**
+
+In `gui/settings/mappings.py`:
+
+```python
+        # line 43-44
+        orders_box = FormSection("Orders CSV Column Mapping")
+        # ...unchanged field/mapping setup...
+        orders_box.add_widget(self.orders_mapping_widget)   # was orders_layout.addWidget
+        scroll_layout.addWidget(orders_box)
+```
+
+```python
+        # line 65-66
+        stock_box = FormSection("Stock CSV Column Mapping")
+        # ...unchanged...
+        stock_box.add_widget(self.stock_mapping_widget)     # was stock_layout.addWidget
+        scroll_layout.addWidget(stock_box)
+```
+
+The courier section's instructions paragraph is exactly what `description` is for — the hand-rolled `instructions2` label at lines 90-97 goes away:
+
+```python
+        courier_mappings_box = FormSection(
+            "Courier Mappings",
+            "Map different shipping provider names to standardized courier codes. "
+            "You can specify multiple patterns (comma-separated) for each courier.",
+        )
+
+        self.courier_mappings_container = QWidget()
+        self.courier_mappings_layout = QVBoxLayout(self.courier_mappings_container)
+        self.courier_mappings_layout.setContentsMargins(0, 0, 0, 0)
+        courier_mappings_box.add_widget(self.courier_mappings_container)
+
+        add_courier_btn = QPushButton("+ Add Courier Mapping")
+        add_courier_btn.clicked.connect(lambda: self.add_courier_mapping_row())
+        courier_mappings_box.add_widget(add_courier_btn)
+```
+
+The old `courier_main_layout.addWidget(add_courier_btn, 0, Qt.AlignLeft)` had a left-align flag that `add_widget` does not take. Give the button `add_courier_btn.setMaximumWidth(200)` instead so it does not stretch the full section width.
+
+Then fix imports: drop `QGroupBox`, and drop `QLabel`, `font_css`, `get_theme_manager` and `Qt` **only if** nothing else in the file still uses them — grep before deleting, this file is 8.5K and has more below line 120.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest -v`
+
+Expected: all PASS, `tests/test_settings_roundtrip.py` included and unmodified.
+
+- [ ] **Step 5: Report the diff honestly**
+
+Run: `git diff --stat gui/settings/general.py gui/settings/mappings.py`
+
+The spec claims `FormSection` earns its keep at six sites. Four of them are here. Note in the commit message whether these two files got shorter or longer. If they got meaningfully longer, say so — that is information the user needs about whether the component was worth building, not something to hide.
+
+- [ ] **Step 6: Gate and commit**
+
+```bash
+.venv/bin/ruff check . --exclude shared
+git add gui/settings/general.py gui/settings/mappings.py
+git commit -m "refactor(settings): General and Mappings use FormSection"
+```
+
+---
+
+### Task 4: Adopt `FormSection` for the two hand-rolled headers
+
+`SetsPage` and `_ColumnConfigPage` each build a `font_css("heading")` label by hand; one of them also builds an italic secondary-coloured description. That is `FormSection`'s title and description written out longhand.
+
+**Files:**
+- Modify: `gui/settings/sets.py:43-46`
+- Modify: `gui/settings/window.py:334-363`
+- Test: `tests/test_settings_roundtrip.py` (existing, must stay green)
+
+**Interfaces:**
+- Consumes: `FormSection(title, description="")` and `.add_widget(widget)` from Task 2.
+- Produces: nothing. `SetsPage.set_decoders` and `_ColumnConfigPage.panel` keep their names.
+
+- [ ] **Step 1: Replace `SetsPage`'s header**
+
+`gui/settings/sets.py:43-46` currently reads:
+
+```python
+        # Header
+        header_label = QLabel("Set/Bundle Definitions")
+        header_label.setStyleSheet(font_css("heading"))
+        main_layout.addWidget(header_label)
+```
+
+The search box and table below it are separate widgets in `main_layout`, so this section holds only a title. Replace with:
+
+```python
+        main_layout.addWidget(FormSection("Set/Bundle Definitions"))
+```
+
+Add `from gui.components.form_section import FormSection` to the imports. Leave `font_css` imported only if something else in the file uses it — grep first.
+
+Note this drops the header from `heading` (14pt) to `label` (12pt), matching every other settings section. That is the point: nine pages should not each pick their own header size.
+
+- [ ] **Step 2: Replace `_ColumnConfigPage`'s header**
+
+`gui/settings/window.py:343-358` builds a heading label, then fetches the theme purely to colour an italic help paragraph. All of it collapses:
+
+```python
+        from gui.column_config_dialog import ColumnConfigPanel
+
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.addWidget(FormSection(
+            "Column Configuration",
+            "Configure which columns are visible in the analysis table, "
+            "their order, and saved views.",
+        ))
+
+        self.panel = ColumnConfigPanel(
+            main_window.table_config_manager, main_window=main_window, parent=self
+        )
+        layout.addWidget(self.panel)
+```
+
+Add `from gui.components.form_section import FormSection` to `window.py`'s imports. Remove the now-unused `font_css` import and the local `from gui.theme_manager import get_theme_manager` at line 348 — but check `apply_font` is still imported, `_build_settings_nav` uses it.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest -v`
+
+Expected: all PASS. `test_window_registers_every_page` in particular proves `_ColumnConfigPage` still constructs.
+
+- [ ] **Step 4: Gate and commit**
+
+```bash
+.venv/bin/ruff check . --exclude shared
+git add gui/settings/sets.py gui/settings/window.py
+git commit -m "refactor(settings): Sets and Column Config headers use FormSection
+
+Both hand-rolled a font_css('heading') label; one also hand-rolled the
+italic description. Same widget, third and fourth copy."
+```
+
+---
+
+### Task 5: The button `role` property and its stylesheet
+
+`shared/theme.py:203-211` styles every `QPushButton` accent-blue on white. In the Rules page, "Add Rule", "Add Step", "Delete" and the window's "Save" render identically. Track 3 recorded that no `:default` rule exists and that hierarchy has to be built.
+
+**Files:**
+- Modify: `gui/theme_manager.py`
+- Test: `tests/test_theme_button_roles.py` (create)
+
+**Interfaces:**
+- Consumes: `ThemeTokens` from `shared.theme`, already imported in `theme_manager.py`.
+- Produces: `role_stylesheet(theme: ThemeTokens) -> str` and `set_button_role(button, role: str) -> None`, both importable from `gui.theme_manager`. Task 6 and Task 7 consume `set_button_role`; Task 7 extends `role_stylesheet`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_theme_button_roles.py`:
+
+```python
+"""The primary/secondary button hierarchy Track 3 said had to be built.
+
+shared/theme.py paints every QPushButton accent-blue, and it is sync-owned
+by packing-tool so it cannot be edited here. These rules are layered on in
+gui/theme_manager.py, the repo-owned seam.
+"""
+import pytest
+from PySide6.QtWidgets import QApplication, QPushButton
+
+from gui.theme_manager import role_stylesheet, set_button_role
+from shared.theme import get_theme
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _app():
+    yield QApplication.instance() or QApplication([])
+
+
+@pytest.mark.parametrize("theme_name", ["light", "dark"])
+def test_both_roles_have_a_rule(theme_name):
+    qss = role_stylesheet(get_theme(theme_name))
+    assert 'QPushButton[role="primary"]' in qss
+    assert 'QPushButton[role="secondary"]' in qss
+
+
+@pytest.mark.parametrize("theme_name", ["light", "dark"])
+def test_the_two_roles_do_not_render_the_same(theme_name):
+    """A token that happens to resolve to the same colour in one theme is
+    invisible on Linux and only shows up on the Windows machines that run
+    this app."""
+    theme = get_theme(theme_name)
+    qss = role_stylesheet(theme)
+    primary = qss.split('QPushButton[role="primary"]')[1].split("}")[0]
+    secondary = qss.split('QPushButton[role="secondary"]')[1].split("}")[0]
+    assert "background-color" in primary
+    assert "background-color" in secondary
+    assert primary != secondary
+
+
+def test_set_button_role_sets_the_property():
+    button = QPushButton("Save")
+    set_button_role(button, "primary")
+    assert button.property("role") == "primary"
+
+
+def test_set_button_role_rejects_an_unknown_role():
+    """Same rule Tracks 1-3 set for the type scale: a typo fails in
+    development rather than silently rendering as an unstyled button."""
+    button = QPushButton("Save")
+    with pytest.raises(ValueError):
+        set_button_role(button, "tertiary")
+
+
+def test_the_suffix_is_actually_applied_to_the_app():
+    from gui.theme_manager import get_theme_manager
+
+    get_theme_manager().apply_theme()
+    assert 'QPushButton[role="primary"]' in QApplication.instance().styleSheet()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_theme_button_roles.py -v`
+
+Expected: FAIL with `ImportError: cannot import name 'role_stylesheet'`.
+
+- [ ] **Step 3: Add the stylesheet builder and the setter**
+
+In `gui/theme_manager.py`, after `apply_font` at the end of the file:
+
+```python
+BUTTON_ROLES = ("primary", "secondary")
+
+
+def role_stylesheet(theme: ThemeTokens) -> str:
+    """QSS for the button hierarchy, appended after shared.theme's sheet.
+
+    shared/theme.py paints every QPushButton accent-blue and is sync-owned
+    by packing-tool, so it cannot be edited here -- these rules layer on in
+    this module, the same seam Track 1 used for the font override.
+
+    Deliberately opt-in: a button with no `role` property keeps exactly its
+    current appearance. The opposite arrangement (neutral by default, mark
+    the primaries) is fewer edits but restyles every button in the app at
+    once, and this is a Windows-only app with three tracks of visual change
+    not yet verified on Windows.
+    """
+    hover = theme.button_hover_dark if theme.name == "dark" else theme.button_hover_light
+    return f"""
+        QPushButton[role="primary"] {{
+            background-color: {theme.accent_blue};
+            color: white;
+            border: 1px solid {theme.accent_blue};
+            font-weight: bold;
+        }}
+        QPushButton[role="primary"]:hover {{ background-color: {hover}; }}
+
+        QPushButton[role="secondary"] {{
+            background-color: {theme.background_elevated};
+            color: {theme.text};
+            border: 1px solid {theme.border};
+        }}
+        QPushButton[role="secondary"]:hover {{ background-color: {theme.hover}; }}
+
+        QPushButton[role="primary"]:disabled, QPushButton[role="secondary"]:disabled {{
+            background-color: {theme.background};
+            color: {theme.text_disabled};
+            border: 1px solid {theme.border_subtle};
+        }}
+    """
+
+
+def set_button_role(button, role: str) -> None:
+    """Mark a button primary or secondary.
+
+    Qt does not restyle a widget when a dynamic property changes after the
+    stylesheet was applied -- the classic trap. Every call site here sets
+    the role at construction, where it would not matter, but unpolish/polish
+    runs unconditionally so a later live-flipping caller cannot step in it.
+    """
+    if role not in BUTTON_ROLES:
+        raise ValueError(f"Unknown button role {role!r}; expected one of {BUTTON_ROLES}")
+    button.setProperty("role", role)
+    button.style().unpolish(button)
+    button.style().polish(button)
+```
+
+- [ ] **Step 4: Append the suffix in `apply_theme`**
+
+`gui/theme_manager.py:74` currently reads `app.setStyleSheet(build_stylesheet(theme))`. Change to:
+
+```python
+        app.setStyleSheet(build_stylesheet(theme) + role_stylesheet(theme))
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_theme_button_roles.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Gate and commit**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+git add gui/theme_manager.py tests/test_theme_button_roles.py
+git commit -m "feat(theme): opt-in primary/secondary button roles
+
+Track 3 recorded that no :default rule exists anywhere, so hierarchy had
+to be built rather than re-enabled. Layered in theme_manager because
+shared/theme.py is sync-owned by packing-tool."
+```
+
+---
+
+### Task 6: Apply the roles inside the Hub
+
+Inside the Hub, Save should be the only accent-blue button on screen. Scope is `gui/settings/` and nothing else — the rest of the app adopts the property as its screens are touched, per Track 5's incremental rule.
+
+**Files:**
+- Modify: `tests/conftest.py`, `tests/test_settings_roundtrip.py:19-148` (fixtures move)
+- Modify: `gui/settings/window.py:167-171`
+- Modify: `gui/settings/rules.py`, `packing_lists.py`, `stock_exports.py`, `mappings.py`, `weight.py`, `sets.py` — action buttons only
+- Test: `tests/test_settings_button_roles.py` (create)
+
+**Interfaces:**
+- Consumes: `set_button_role(button, role)` from Task 5.
+- Produces: the `qapp`, `no_modals`, `started_workers` and `window` fixtures plus the `settings_fixture_config()` helper, now in `tests/conftest.py` — Task 7's tests use them too.
+
+- [ ] **Step 1: Promote the settings fixtures into `conftest.py`**
+
+Tasks 6 and 7 both need `SettingsWindow` fixtures that today live inside `tests/test_settings_roundtrip.py`. **Do not import them across test files** — `tests/` has no `__init__.py`, so `from tests.test_settings_roundtrip import ...` fails outright and the bare `from test_settings_roundtrip import ...` form only works by way of pytest's rootdir sys.path insertion. `conftest.py` is the mechanism pytest provides for exactly this and needs no import at all.
+
+Cut `qapp`, `no_modals`, `settings_fixture_config`, `started_workers` and `window` (lines 19-148, including their docstrings — they explain four real gotchas and must survive the move) out of `tests/test_settings_roundtrip.py` and paste them at the end of `tests/conftest.py`. Add the imports they need to the top of `conftest.py`:
+
+```python
+from unittest.mock import Mock
+
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from gui.settings.window import SettingsWindow
+```
+
+and extend `conftest.py`'s module docstring, which currently claims to be backend-only:
+
+```python
+"""Shared fixtures for the test suite.
+
+Column names mirror the DEFAULT Shopify/Bulgarian-ERP mapping hardcoded in
+shopify_tool.analysis._clean_and_prepare_data (used when column_mappings=None),
+so fixtures exercise the exact same path production runs through.
+
+The SettingsWindow fixtures at the bottom are here rather than in a test
+module because three test files need them and `tests/` is not a package --
+conftest is the only sharing mechanism that does not depend on sys.path.
+"""
+```
+
+`test_settings_roundtrip.py` keeps its six test functions (five original plus the one Task 1 added). Five of them take only fixtures and need no imports beyond `copy`. The sixth — `test_a_key_no_page_renders_survives_a_save` — builds its own window, so switch it to the factory fixture rather than re-importing the helper:
+
+```python
+def test_a_key_no_page_renders_survives_a_save(
+    qapp, no_modals, started_workers, make_settings_config
+):
+    config = make_settings_config()
+    config["settings"]["legacy_key_no_page_renders"] = "keep me"
+    config["weight_config"]["legacy_weight_key"] = 123
+
+    win = SettingsWindow(client_id="M", client_config=config, profile_manager=Mock())
+    ...
+```
+
+which leaves `test_settings_roundtrip.py` importing `copy`, `Mock` and `SettingsWindow`.
+
+**`settings_fixture_config` is a plain function, not a fixture**, so pytest will *not* inject it into other test modules the way it does `window`. Task 7 needs two fresh configs inside one test, so expose it as a factory fixture alongside the function:
+
+```python
+@pytest.fixture
+def make_settings_config():
+    """Factory, not a value: test_settings_nav builds two windows in one test
+    and each needs its own config to mutate."""
+    return settings_fixture_config
+```
+
+The `window` fixture in `conftest.py` keeps calling the module-level `settings_fixture_config()` directly — they are in the same file.
+
+- [ ] **Step 2: Verify the move changed nothing**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_roundtrip.py -v`
+
+Expected: the same five tests, all PASS. A collection error here means an import did not come along.
+
+- [ ] **Step 3: Write the failing test**
+
+Create `tests/test_settings_button_roles.py`. The fixtures arrive from `conftest.py`, so there is nothing to import:
+
+```python
+"""Inside the Hub, Save is the only accent-filled button on screen."""
+from PySide6.QtWidgets import QPushButton
+
+
+def test_the_footer_marks_save_primary_and_cancel_secondary(window):
+    assert window.save_button.property("role") == "primary"
+    cancel = window.save_button.parent().buttons()[1]
+    assert cancel.property("role") == "secondary"
+
+
+def test_no_page_leaves_an_unmarked_button_competing_with_save(window):
+    """An unmarked button still renders accent-blue, so it would read as a
+    second primary action. Inside the Hub every in-page button is secondary."""
+    unmarked = []
+    for page in window._pages:
+        for button in page.findChildren(QPushButton):
+            if button.property("role") is None:
+                unmarked.append(f"{type(page).__name__}: {button.text()!r}")
+    assert unmarked == [], "unmarked buttons inside the Hub: " + ", ".join(unmarked)
+```
+
+- [ ] **Step 4: Run it to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_button_roles.py -v`
+
+Expected: both FAIL — the first on `None != "primary"`, the second listing every button in the package.
+
+- [ ] **Step 5: Mark the footer**
+
+`gui/settings/window.py:167-171`:
+
+```python
+        button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        self.save_button = button_box.button(QDialogButtonBox.Save)
+        set_button_role(self.save_button, "primary")
+        set_button_role(button_box.button(QDialogButtonBox.Cancel), "secondary")
+        button_box.accepted.connect(self.save_settings)
+        button_box.rejected.connect(self.reject)
+        main_layout.addWidget(button_box)
+```
+
+Import `set_button_role` alongside the existing `apply_font, font_css` import from `gui.theme_manager`.
+
+- [ ] **Step 6: Mark every in-page button secondary, driven by the failing test**
+
+Do not guess the list. Run the test from Step 4 and work through the names it prints — that is the authoritative inventory, and it covers buttons created in loops (per-rule Delete, per-filter `X`) that a grep for `QPushButton(` would find but a grep for a variable name would not.
+
+For buttons built inside row/item factories, mark them where they are constructed so every instance gets it:
+
+```python
+        delete_btn = QPushButton("X")
+        set_button_role(delete_btn, "secondary")
+```
+
+`gui/settings/fields.py:151` builds the shared filter-row delete button used by both Packing Lists and Stock Exports — marking it once there covers both pages.
+
+Re-run the test after each file and watch the list shrink.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_button_roles.py -v`
+
+Expected: both PASS, and the second one now guards against a future page adding an unmarked button.
+
+- [ ] **Step 8: Gate and commit**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+git add gui/settings/ tests/conftest.py tests/test_settings_roundtrip.py tests/test_settings_button_roles.py
+git commit -m "feat(settings): Save is the Hub's only primary button
+
+Settings fixtures move to conftest.py so the new test files can reach
+them -- tests/ is not a package, so cross-file fixture imports do not
+work."
+```
+
+---
+
+### Task 7: Nav styling and remembered page
+
+The nav is a bare `QListWidget` at a fixed 170px — a list dropped next to the content rather than a sidebar. And with nine pages, every open lands on "General".
+
+**Files:**
+- Modify: `gui/theme_manager.py` (`role_stylesheet`)
+- Modify: `gui/settings/window.py:121-124`, `189-216`
+- Test: `tests/test_settings_nav.py` (create)
+
+**Interfaces:**
+- Consumes: `role_stylesheet` from Task 5, `SETTINGS_NAV_GROUPS` and `_page_index_by_name` from `window.py`.
+- Produces: `SettingsWindow.NAV_SETTINGS_KEY = "settings_hub/last_page"`, and `SettingsWindow._save_nav_selection()` / `_restore_nav_selection()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_settings_nav.py`:
+
+```python
+"""The Hub remembers which page you were on.
+
+Nine pages and one QListWidget; the Weight and Rules pages are the ones
+people return to.
+
+Fixtures (qapp, no_modals, started_workers, window, make_settings_config)
+all come from conftest.py.
+"""
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtCore import QSettings, Qt
+
+from gui.settings.window import SettingsWindow
+
+
+@pytest.fixture(autouse=True)
+def clean_nav_setting():
+    """QSettings is process-global and persists to disk on this machine, so
+    a leftover value would leak between tests and between runs."""
+    store = QSettings("ShopifyFulfillmentTool", "FulfillmentApp")
+    store.remove(SettingsWindow.NAV_SETTINGS_KEY)
+    yield
+    store.remove(SettingsWindow.NAV_SETTINGS_KEY)
+
+
+def _current_page_name(win):
+    return win._settings_nav.currentItem().text()
+
+
+def test_a_fresh_profile_lands_on_the_first_entry(window):
+    assert _current_page_name(window) == "General"
+
+
+def test_the_selected_page_is_remembered_by_name(
+    qapp, no_modals, started_workers, make_settings_config
+):
+    first = SettingsWindow(client_id="M", client_config=make_settings_config(),
+                           profile_manager=Mock())
+    for row in range(first._settings_nav.count()):
+        if first._settings_nav.item(row).text() == "Weight":
+            first._settings_nav.setCurrentRow(row)
+            break
+    first.deleteLater()
+
+    second = SettingsWindow(client_id="M", client_config=make_settings_config(),
+                            profile_manager=Mock())
+    assert _current_page_name(second) == "Weight"
+    second.deleteLater()
+
+
+def test_a_page_name_that_no_longer_exists_falls_back(
+    qapp, no_modals, started_workers, make_settings_config
+):
+    """Nav groups have gained entries twice already. Storing a row index
+    would silently point at a different page; a stale *name* must degrade to
+    the first entry rather than raise or select nothing."""
+    QSettings("ShopifyFulfillmentTool", "FulfillmentApp").setValue(
+        SettingsWindow.NAV_SETTINGS_KEY, "A Page That Was Removed"
+    )
+
+    win = SettingsWindow(client_id="M", client_config=make_settings_config(),
+                         profile_manager=Mock())
+    assert _current_page_name(win) == "General"
+    win.deleteLater()
+
+
+def test_headers_are_not_selectable_and_are_never_stored(window):
+    headers = [
+        window._settings_nav.item(row)
+        for row in range(window._settings_nav.count())
+        if not window._settings_nav.item(row).flags() & Qt.ItemFlag.ItemIsSelectable
+    ]
+    assert [h.text() for h in headers] == ["DATA", "FULFILLMENT LOGIC", "OUTPUT", "ORGANIZATION"]
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_nav.py -v`
+
+Expected: FAIL with `AttributeError: type object 'SettingsWindow' has no attribute 'NAV_SETTINGS_KEY'`.
+
+- [ ] **Step 3: Persist and restore the selection**
+
+In `gui/settings/window.py`, add the key as a class attribute next to `SETTINGS_NAV_GROUPS`:
+
+```python
+    # Stored by *name*, not row index: the nav groups have gained entries
+    # twice already and an index would silently point at a different page.
+    NAV_SETTINGS_KEY = "settings_hub/last_page"
+```
+
+Replace the "select the first real entry" tail of `_build_settings_nav` (lines 204-208) with a call to a restore helper, and add both helpers:
+
+```python
+        self._settings_nav.currentItemChanged.connect(self._on_settings_nav_changed)
+        self._restore_nav_selection()
+
+    def _first_selectable_row(self) -> int:
+        for row in range(self._settings_nav.count()):
+            if self._settings_nav.item(row).flags() & Qt.ItemFlag.ItemIsSelectable:
+                return row
+        return -1
+
+    def _restore_nav_selection(self) -> None:
+        """Select the last-viewed page, or the first entry if it is gone."""
+        wanted = QSettings("ShopifyFulfillmentTool", "FulfillmentApp").value(
+            self.NAV_SETTINGS_KEY
+        )
+        for row in range(self._settings_nav.count()):
+            item = self._settings_nav.item(row)
+            if item.text() == wanted and item.flags() & Qt.ItemFlag.ItemIsSelectable:
+                self._settings_nav.setCurrentRow(row)
+                return
+        row = self._first_selectable_row()
+        if row >= 0:
+            self._settings_nav.setCurrentRow(row)
+```
+
+Record the choice in the existing selection handler, which already ignores headers because they cannot become current:
+
+```python
+    def _on_settings_nav_changed(self, current, _previous):
+        if current is None:
+            return
+        index = current.data(Qt.ItemDataRole.UserRole)
+        if index is not None:
+            self.tab_widget.setCurrentIndex(index)
+            QSettings("ShopifyFulfillmentTool", "FulfillmentApp").setValue(
+                self.NAV_SETTINGS_KEY, current.text()
+            )
+```
+
+Add `QSettings` to the `PySide6.QtCore` import at the top of the file (currently `from PySide6.QtCore import Qt, QThreadPool`).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_nav.py -v`
+
+Expected: all 4 PASS.
+
+- [ ] **Step 5: Style the nav as a sidebar**
+
+Give the nav an object name so the QSS can target it without hitting every `QListWidget` in the app. In `window.py:121`:
+
+```python
+        self._settings_nav = QListWidget()
+        self._settings_nav.setObjectName("settingsNav")
+```
+
+Append to the returned string in `role_stylesheet` (`gui/theme_manager.py`), before the closing quotes:
+
+```python
+        QListWidget#settingsNav {{
+            background-color: {theme.background};
+            border: none;
+            border-right: 1px solid {theme.border_subtle};
+            outline: none;
+        }}
+        QListWidget#settingsNav::item {{
+            padding: 6px 10px;
+            border-radius: {theme.radius}px;
+        }}
+        QListWidget#settingsNav::item:hover {{ background-color: {theme.hover}; }}
+        QListWidget#settingsNav::item:selected {{
+            background-color: {theme.active_background};
+            color: {theme.text};
+            border-left: 2px solid {theme.accent_blue};
+        }}
+        QListWidget#settingsNav::item:disabled {{
+            color: {theme.text_secondary};
+            padding-top: 10px;
+        }}
+```
+
+Group headers are already non-selectable (`Qt.ItemFlag.NoItemFlags`) and already bold `caption`, so `::item:disabled` is what colours them — the extra top padding is what separates one group from the previous group's last entry.
+
+- [ ] **Step 6: Extend the Task 5 stylesheet test to cover the nav**
+
+Add to `tests/test_theme_button_roles.py`:
+
+```python
+@pytest.mark.parametrize("theme_name", ["light", "dark"])
+def test_the_settings_nav_is_styled_as_a_sidebar(theme_name):
+    qss = role_stylesheet(get_theme(theme_name))
+    assert "QListWidget#settingsNav" in qss
+    assert "QListWidget#settingsNav::item:selected" in qss
+```
+
+- [ ] **Step 7: Full gate and commit**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+git add gui/settings/window.py gui/theme_manager.py tests/test_settings_nav.py tests/test_theme_button_roles.py
+git commit -m "feat(settings): sidebar-styled nav that remembers the last page"
+```
+
+---
+
+### Task 8: Refresh the knowledge graph
+
+Required by this repo's `CLAUDE.md`: a stale graph returns wrong answers about `shared/` ownership and theme delegation silently, with no error.
+
+**Files:** none tracked — `graphify-out/` is the tool's own output.
+
+- [ ] **Step 1: Run it**
+
+```bash
+graphify update .
+```
+
+- [ ] **Step 2: Commit if the output is tracked**
+
+```bash
+git status --short graphify-out/
+```
+
+If `graphify-out/` shows changes and is not gitignored, commit them:
+
+```bash
+git add graphify-out/
+git commit -m "chore: refresh knowledge graph after Track 4"
+```
+
+If it is gitignored, there is nothing to commit — say so and move on.
+
+---
+
+## Verification
+
+Before the branch is considered done:
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+```
+
+Both must be clean, and the pytest count must be **higher** than the 498 that PR #272 left — this plan adds roughly 20 tests across four new files. A count that did not move means a test file is not being collected.
+
+## What this plan deliberately does not do
+
+Carried from the spec so an executor does not "helpfully" add them:
+
+- **Client Profile stays its own dialog.** Open question for the user; see the spec's reasoning. Do not fold `ClientSettingsDialog` into the Hub.
+- **`GroupsManagementDialog` stays where it is.** It has no `client_id`.
+- **The repeating-item `QGroupBox`es in `rules.py` / `packing_lists.py` / `stock_exports.py` stay.** They are item containers, not titled form sections. `weight.py`'s "Quick Add" box also stays.
+- **No button role outside `gui/settings/`.** The mechanism is app-wide; the application of it is not.
+- **`shared/theme.py` is not edited.** Ever, in this repo.

--- a/docs/superpowers/specs/2026-08-13-settings-hub-design.md
+++ b/docs/superpowers/specs/2026-08-13-settings-hub-design.md
@@ -1,0 +1,305 @@
+# UI Design System Track 4 — Settings Hub — Design
+
+## Context
+
+The 2026-08-11 vision doc (`2026-08-11-ui-design-system-vision-design.md`) describes Track 4
+as:
+
+> One window: left-nav categories + right-side `QStackedWidget` content, built from
+> `Card`/`FormSection`. Directly resolves Phase 6's flagged "two competing client-settings
+> windows".
+
+**Most of that shipped already, in Track C (PR #272).** Splitting
+`settings_window_pyside.py` into `gui/settings/` was scoped as structural risk reduction,
+but it also delivered the Hub's shape:
+
+| Vision doc's Track 4 item | State after #272 |
+|---|---|
+| Left-nav categories | `SettingsWindow.SETTINGS_NAV_GROUPS`, `window.py:56-61` — four groups, nine pages |
+| Right-side `QStackedWidget` | `window.py:126` |
+| "Two competing client-settings windows" | `profile_manager_dialog.py` deleted; `ClientSettingsDialog` retitled "Client Profile". Guarded by `tests/test_settings_entry_points.py` |
+| Tag Categories / Column Config as separate popups | Absorbed as Hub pages (`_TagCategoriesPage`, `_ColumnConfigPage`) |
+| Built from `Card`/`FormSection` | **Not done.** `FormSection` does not exist |
+
+So Track 4 is smaller than the vision doc anticipated, and its content shifts: the
+structure exists, what is missing is that the Hub does not yet *look* or *behave* like a
+designed surface, and its page contract has a known sharp edge that #272's review found and
+recommended designing away rather than testing around.
+
+This doc covers what actually remains.
+
+## Problems this design solves
+
+**1. `collect()`'s merge semantics are a silent-data-loss trap.**
+`window.py:231-236` merges each page's `collect()` output one level deep:
+
+```python
+if isinstance(value, dict) and isinstance(self.config_data.get(key), dict):
+    self.config_data[key].update(value)
+else:
+    self.config_data[key] = value
+```
+
+`update()` can add and overwrite but never remove. Both Important findings in #272's review
+trace to this single line:
+
+- A page that *stops* producing a config field cannot be detected — the fixture's stale
+  value survives the merge. The reviewer proved it by deleting `repeat_detection_days` from
+  `GeneralPage.collect()` and watching the round-trip test stay green.
+- Deleting a courier row could not stick, because the removed key survived the merge.
+  `MappingsPage` works around this by mutating and returning its live sub-dicts
+  (`mappings.py:206-218`) — a correct fix, but one explained only in a comment. A future
+  `deepcopy` anywhere upstream silently reinstates the bug with the whole suite green.
+
+The workaround is right; the contract is wrong. One page discovered the rule and the other
+two did not, which is the definition of a contract that should not be implicit.
+
+**2. There is no visual hierarchy on any button, anywhere.**
+`shared/theme.py:203-211` styles *every* `QPushButton` accent-blue on white. In the Hub's
+Rules page, "Add Rule", "Add Step", "Delete", and the window's "Save" all render identically.
+Track 3 explicitly recorded that no `:default` rule exists and that primary/secondary
+differentiation "still has to be built, not re-enabled".
+
+**3. `FormSection` was deferred to here so a real page would shape its API.**
+Track 3 deferred it on purpose (`2026-08-12-component-library-design.md:12-17`) because its
+motivating example moved into Track C. The real call sites now exist and can be counted.
+
+**4. The Hub forgets where you were.**
+Nine pages, one `QListWidget`, and every open lands on "General". The Weight page and the
+Rules page are the ones people return to.
+
+## Non-goals, and why
+
+**Client Profile does not move into the Hub.** The vision doc lists "Client Profile" as a
+Hub nav category. Two facts changed since it was written:
+
+- The duplication it was meant to fix is already gone. Phase 6's "two competing
+  client-settings windows" were `settings_window_pyside.py` and `profile_manager_dialog.py`.
+  The latter is deleted and `tests/test_settings_entry_points.py:13` asserts it stays
+  deleted. The remaining `ClientSettingsDialog` was retitled "Client Profile" and edits a
+  genuinely different thing — display name, colour, group membership — not fulfillment
+  config.
+- The entry points do not line up. `SettingsWindow` is bound to the *active* client
+  (`actions_handler.py:383` passes `self.mw.current_client_id`). `ClientSettingsDialog` is
+  launched from the sidebar's per-row Edit for *any* client
+  (`client_sidebar.py:719-728`). Folding it in means either the Hub accepts an arbitrary
+  client — new coupling, and a modal settings window that edits a client you are not working
+  on — or the sidebar's Edit silently switches the active client. Both are worse than one
+  small focused dialog.
+
+Moving it later stays cheap; moving it now and reverting does not. **Flagged as an open
+question for the user** rather than decided silently — see Open Questions.
+
+**`GroupsManagementDialog` does not move in either.** Client groups are a sidebar
+organisation concern, not per-client fulfillment config. It has no `client_id` at all.
+
+**The repeating-item group boxes are not migrated to `FormSection`.** There are 13
+`QGroupBox(...)` sites in `gui/settings/`. Eight are *item containers or their sub-boxes* —
+one box per rule, per report, per step, plus the IF/THEN and Filters boxes nested inside
+them (`rules.py:263,418,426,444`, `packing_lists.py:50,60`, `stock_exports.py:50,58`). Two
+of those are `QGroupBox()` with no title at all. They are card-like repeating rows, not
+titled form sections; `FormSection` is the wrong tool and forcing it there would be a large
+diff that makes the code worse. Of the five that *are* page-level titled sections, four are
+migrated below; `weight.py:102`'s "Quick Add" box is left alone because `weight.py` is
+already being edited for the contract change and is the largest page in the package —
+adding a layout rewrite there buys little and risks more.
+
+**No button restyle outside `gui/settings/`.** The mechanism is app-wide, the application of
+it is scoped to the Hub. See "Button hierarchy" for why that is deliberate and not laziness.
+
+**`shared/theme.py` is not edited.** It is sync-owned by `packing-tool` (this repo's
+`CLAUDE.md`). Everything below layers on top through `gui/theme_manager.py`, the same
+repo-owned seam Track 1 used for the `font_family` override.
+
+## Design
+
+### 1. The `collect()` contract: replace, never merge
+
+**New contract, stated in `SettingsPage`'s docstring:**
+
+> `collect()` returns `{config_key: value}`. Each returned value **replaces**
+> `config_data[key]` outright. A page that owns a dict sub-tree must mutate and return the
+> live dict it was constructed with, so keys it does not render survive.
+
+The shell becomes an unconditional assignment:
+
+```python
+for page in self._pages:
+    for key, value in page.collect().items():
+        self.config_data[key] = value
+```
+
+The `isinstance` branch disappears, and with it the reasoning about whether a given key is
+shrinkable.
+
+**Why "mutate the live dict" rather than "return a fresh complete dict".** These are live
+warehouse client configs on a production file server. `config["settings"]` is *canonically*
+the four keys `GeneralPage` renders (`profile_manager.py:403-408`), but a config written by
+an older build can carry keys nothing in the current UI knows about —
+`profile_migrations.py` exists precisely because that has happened before. A fresh-dict
+return silently drops them on every save. Holding the live sub-dict means unrendered keys
+are never removed in the first place, so preservation is structural rather than a rule
+someone has to remember.
+
+**Three pages return dict values and are affected:**
+
+| page | key | change |
+|---|---|---|
+| `MappingsPage` | `column_mappings`, `courier_mappings` | None — already correct. Its explanatory comment is rewritten to cite the contract instead of describing the merge it was working around |
+| `GeneralPage` | `settings` | Hold the constructor's dict as `self._settings`; `collect()` updates it in place and returns it |
+| `WeightPage` | `weight_config` | Same. **Watch `weight.py:41**: `weight_cfg = weight_config or {...}` substitutes a *fresh* dict when the config is empty, so the page must hold whichever dict it actually used, not the parameter |
+
+`RulesPage`, `PackingListsPage`, `StockExportsPage` return lists — they already replace
+wholesale and are unaffected. `SetsPage` and `_ColumnConfigPage` self-save and collect
+nothing.
+
+**`collect()` gains a side effect** (it writes into `config_data` before the shell assigns).
+This is safe by construction: `save_settings` runs `validate()` across *all* pages before
+calling `collect()` on any of them, so no page mutates during a save that a later page will
+block. `config_data` is already a deep copy (`window.py:78`), so a failed server write
+cannot leak into the caller's config. The docstring says this explicitly.
+
+**Testing.** `test_no_page_silently_drops_a_field` (added in #272 for exactly this) already
+compares each page's `collect()` output directly and keeps working. Add one test asserting
+that a key present in the loaded config but rendered by no page survives a full save
+round-trip — that is the behaviour the live-dict rule buys, and nothing currently proves it.
+
+### 2. `FormSection`
+
+`gui/components/form_section.py`, alongside the existing `Card`.
+
+```python
+FormSection(title: str, description: str = "", parent=None)
+    .add_row(label: str, widget: QWidget, tooltip: str = "") -> QWidget
+    .add_widget(widget: QWidget) -> None
+```
+
+A `QFrame` with a title label at the `label` type-scale role, an optional wrapped
+description at `caption` in `theme.text_secondary`, and a `QFormLayout` body. Margins and
+spacing come from Track 1's tokens, not per-widget magic numbers. `add_row` builds the
+`QLabel` itself — the pages currently construct a named `QLabel` variable per row purely to
+pass it to `addRow` (`general.py:25,37,52,61`), which is four lines of ceremony per field.
+`tooltip` is applied to both the label and the widget, so hovering the *label* explains the
+field; today only the input carries the tooltip.
+
+`add_widget` exists because the sections that need a title do not all contain form rows —
+`mappings.py:87` is a title over a button-and-rows column, and `SetsPage`
+(`sets.py:44-46`) and `_ColumnConfigPage` (`window.py:344-358`) each hand-roll a
+`font_css("heading")` label plus, in one case, an italic description. That is the same
+widget written three times. One component covers all of them; a separate `PageHeader` type
+would be a second component for the same job.
+
+**Adopted at these call sites, and no others:**
+
+| site | today | becomes |
+|---|---|---|
+| `general.py:22` | `QGroupBox("General Settings")` + 4 hand-built label/row pairs | One `FormSection`, 4 `add_row` calls |
+| `mappings.py:43,65,87` | 3 `QGroupBox` | 3 `FormSection` |
+| `sets.py:44` | bare `font_css("heading")` label | `FormSection` title |
+| `window.py:344` (`_ColumnConfigPage`) | hand-rolled heading + italic help `QLabel` | `FormSection` title + description |
+
+Six sites. If it does not earn its keep at six, it should not exist — the count is stated
+here so the implementation can report honestly whether the diff shrank.
+
+**Testing.** Construction test with stub rows, no window needed (the shape Track 3's `Card`
+tests already use): assert `add_row` labels the row and propagates the tooltip to both
+widgets, and that an unknown type-scale role raises rather than silently rendering at a
+default size — the rule Tracks 1-3 set.
+
+### 3. Button hierarchy
+
+A `role` dynamic property read by QSS:
+
+```python
+button.setProperty("role", "primary")    # accent fill — the commit action
+button.setProperty("role", "secondary")  # neutral fill, bordered — everything else
+```
+
+The rules live in a small stylesheet suffix appended in `ThemeManager.apply_theme()`, after
+`build_stylesheet(theme)`. `theme_manager.py` is already established as the repo-owned
+customization seam (Track 1 layered `font_family` there via `dataclasses.replace`), and an
+app-level suffix means every dialog picks the rules up without importing anything.
+
+**Unmarked buttons keep exactly today's appearance.** The opposite arrangement — make the
+default neutral and mark primaries — is fewer edits, but it restyles every button in the
+application in one commit. This is a Windows-only app developed on Linux with three tracks
+of unverified visual change already stacked and no screenshot pass yet (see Open Questions).
+Opt-in means the blast radius is exactly the widgets that were touched deliberately.
+
+**Applied within `gui/settings/` only**: the Hub footer's Save becomes `primary` and Cancel
+`secondary`; the in-page action buttons (Add Rule, Add Step, Add Filter, delete `X`, Browse)
+become `secondary`. That is the point of the exercise — inside the Hub, Save should be the
+only accent-blue button on screen. The rest of the app adopts the property as its screens are
+touched, per Track 5's incremental rule.
+
+One catch worth stating because it is a classic Qt trap: **Qt does not restyle a widget when
+a dynamic property changes after the stylesheet is applied.** Setting `role` before the
+widget is polished (i.e. at construction, which is every call site here) is fine. If any site
+ever needs to flip it live, it must call `style().unpolish(w); style().polish(w)`. The helper
+that sets the property does the unpolish/polish unconditionally so the trap cannot be
+stepped in.
+
+**Testing.** Assert the generated stylesheet suffix contains a rule for each role and that
+the two roles produce different background colours in both light and dark themes — a
+property typo or a token that resolves to the same colour in one theme is otherwise
+invisible until someone looks at Windows.
+
+### 4. Hub chrome: nav styling and remembered selection
+
+**Nav styling.** The nav is a bare `QListWidget` at a fixed 170px (`window.py:121-124`). It
+reads as a list dropped next to the content, not as a sidebar. The same stylesheet suffix
+from §3 gives `QListWidget#settingsNav` a subdued background (`theme.background`, against the
+content's `background_elevated`), no frame, and a clear selected-row treatment. Group headers
+are already non-selectable and already use the `caption` role bold (`window.py:194-196`) —
+they need only the secondary text colour to stop competing with the entries under them.
+
+**Remembered selection.** `QSettings("ShopifyFulfillmentTool", "FulfillmentApp")` — the same
+store `ThemeManager` uses (`theme_manager.py:80`) — under key `settings_hub/last_page`. Store
+the page *name*, not the row index: nav groups have gained entries twice already, and an
+index would silently point at a different page after the next one. On open, select the saved
+name if it still exists, else fall back to today's behaviour (first selectable row).
+
+**Testing.** A `TableConfigManager`-style state test, as the vision doc anticipated: save a
+page name, reopen, assert the selection lands there; then assert an unknown/removed name
+falls back to the first entry rather than raising or landing on nothing.
+
+## Files touched
+
+| file | change |
+|---|---|
+| `gui/components/form_section.py` | new |
+| `gui/components/__init__.py` | export `FormSection` |
+| `gui/settings/base.py` | contract docstring |
+| `gui/settings/window.py` | assignment not merge; nav object name; selection persistence; `_ColumnConfigPage` header → `FormSection` |
+| `gui/settings/general.py` | live `settings` dict; `FormSection` |
+| `gui/settings/weight.py` | live `weight_config` dict |
+| `gui/settings/mappings.py` | comment cites contract; 3 × `FormSection` |
+| `gui/settings/sets.py` | header → `FormSection` |
+| `gui/settings/rules.py`, `packing_lists.py`, `stock_exports.py` | `role="secondary"` on action buttons only |
+| `gui/theme_manager.py` | stylesheet suffix (button roles, nav) + the `role` helper |
+| `tests/` | new tests per section above; existing `test_settings_roundtrip.py` extended |
+
+## Risks
+
+**The contract change is the only one that can lose data**, and it is the reason the live-dict
+rule exists rather than a fresh-dict return. The mitigation is the round-trip test for
+unrendered keys, and the mutation discipline #272 established: introduce the bug, watch the
+new test fail, restore. A guard test never shown to fail is decoration.
+
+**Everything else is visual and unverifiable on Linux.** Nothing in §2-§4 changes what is
+written to a config file. The failure mode is "looks wrong on Windows", not "corrupts a
+client config" — which is why the button work is opt-in and Hub-scoped.
+
+## Open questions for the user
+
+1. **Should Client Profile move into the Hub after all?** This design says no, with the
+   reasoning above, and the "no" is the reversible choice. If the intent behind the vision
+   doc was genuinely one window for everything client-related, say so and it becomes its own
+   task — it needs the Hub to accept a client independent of the active one, which is a
+   real change, not a page move.
+
+2. **Windows visual check, still outstanding.** Tracks 1-3 (type scale, Inter embedding,
+   icon-only header buttons) plus Track C's relabelled buttons plus this track's button
+   hierarchy and nav styling are now five layers of visual change with no screenshot on the
+   target OS. One pass covering all of them is the standing recommendation. This track adds
+   to the stack; it does not create the problem.

--- a/docs/superpowers/specs/2026-08-13-settings-hub-design.md
+++ b/docs/superpowers/specs/2026-08-13-settings-hub-design.md
@@ -170,7 +170,7 @@ round-trip — that is the behaviour the live-dict rule buys, and nothing curren
 
 ```python
 FormSection(title: str, description: str = "", parent=None)
-    .add_row(label: str, widget: QWidget, tooltip: str = "") -> QWidget
+    .add_row(label: str, widget: QWidget, tooltip: str = "") -> QLabel
     .add_widget(widget: QWidget) -> None
 ```
 

--- a/gui/components/__init__.py
+++ b/gui/components/__init__.py
@@ -1,1 +1,6 @@
 """Shared UI components. See docs/superpowers/specs/2026-08-12-component-library-design.md."""
+
+from gui.components.card import Card
+from gui.components.form_section import FormSection
+
+__all__ = ["Card", "FormSection"]

--- a/gui/components/form_section.py
+++ b/gui/components/form_section.py
@@ -1,0 +1,80 @@
+"""A titled settings section: heading, optional description, form rows.
+
+Deferred here from Track 3 so real call sites would shape the API -- see
+docs/superpowers/specs/2026-08-12-component-library-design.md:12-17.
+
+Replaces two patterns at once. QGroupBox + QFormLayout in the settings
+pages, where the OS group-box chrome duplicates a title the nav already
+shows; and the hand-rolled font_css("heading") label written three times
+(sets.py, window.py's _ColumnConfigPage, mappings.py's instructions
+paragraph). One component rather than a second PageHeader type.
+"""
+
+from PySide6.QtWidgets import QFormLayout, QFrame, QLabel, QVBoxLayout, QWidget
+
+from gui.theme_manager import font_css, get_theme_manager
+
+
+class FormSection(QFrame):
+    """A titled block of form rows.
+
+    Args:
+        title: Section heading, rendered at the `label` type-scale role.
+        description: Optional wrapped paragraph under the title, at
+            `caption` in the secondary text colour. Omitted entirely when
+            empty -- an empty QLabel still takes vertical space.
+    """
+
+    def __init__(self, title: str, description: str = "", parent=None) -> None:
+        super().__init__(parent)
+        theme = get_theme_manager().get_current_theme()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(
+            theme.spacing_md, theme.spacing_sm, theme.spacing_md, theme.spacing_sm
+        )
+        layout.setSpacing(theme.spacing_xs)
+
+        title_label = QLabel(title)
+        title_label.setStyleSheet(font_css("label"))
+        layout.addWidget(title_label)
+
+        if description:
+            desc_label = QLabel(description)
+            desc_label.setWordWrap(True)
+            desc_label.setStyleSheet(
+                f"color: {theme.text_secondary}; {font_css('caption')}"
+            )
+            layout.addWidget(desc_label)
+
+        self.form = QFormLayout()
+        self.form.setContentsMargins(0, 0, 0, 0)
+        self.form.setSpacing(theme.spacing_sm)
+        layout.addLayout(self.form)
+
+    def add_row(self, label: str, widget: QWidget, tooltip: str = "") -> QLabel:
+        """Append a labelled row and return the label it built.
+
+        The pages currently name a QLabel variable per row purely to hand it
+        to addRow. The label is returned for the rare caller that needs a
+        handle to it.
+
+        `tooltip` is applied to the label as well as the widget, so hovering
+        the row's text explains the field. A widget that already carries its
+        own tooltip keeps it.
+        """
+        row_label = QLabel(label)
+        if tooltip:
+            row_label.setToolTip(tooltip)
+            if not widget.toolTip():
+                widget.setToolTip(tooltip)
+        self.form.addRow(row_label, widget)
+        return row_label
+
+    def add_widget(self, widget: QWidget) -> None:
+        """Append a widget below the form rows.
+
+        Not every section that wants a title holds form rows -- the courier
+        mappings section is a title over a button-and-rows column.
+        """
+        self.layout().addWidget(widget)

--- a/gui/settings/base.py
+++ b/gui/settings/base.py
@@ -10,10 +10,22 @@ class SettingsPage(QWidget):
     calls validate() then collect() on every page in turn. Pages that
     persist their own data immediately (Sets, Column Config) inherit both
     defaults and contribute nothing to the window's single write.
+
+    collect() returns {config_key: value}, and each value REPLACES
+    config_data[key] outright -- the window does not merge. A page that
+    owns a dict sub-tree must therefore mutate and return the live dict it
+    was constructed with, so keys it does not render survive the save.
+    Returning a freshly built dict silently drops them.
+
+    collect() writing into config_data before the window assigns is safe by
+    construction: save_settings() runs validate() across every page before
+    calling collect() on any of them, so no page mutates during a save a
+    later page will block. config_data is a deep copy, so a failed server
+    write cannot reach the caller's config either.
     """
 
     def collect(self) -> dict:
-        """The config keys this page owns, merged into config_data on save."""
+        """The config keys this page owns. Each value replaces config_data[key]."""
         return {}
 
     def validate(self) -> tuple[bool, list[str]]:

--- a/gui/settings/fields.py
+++ b/gui/settings/fields.py
@@ -6,6 +6,7 @@ reverse, so there is no cycle back through window.py.
 
 from PySide6.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QWidget
 
+from gui.theme_manager import set_button_role
 from gui.wheel_ignore_combobox import WheelIgnoreComboBox
 
 FILTERABLE_COLUMNS: list[str] = [
@@ -149,6 +150,7 @@ def add_filter_row(parent_widget_refs, fields, operators, analysis_df, config=No
     op_combo.addItems(operators)
     value_edit = QLineEdit()
     delete_btn = QPushButton("X")
+    set_button_role(delete_btn, "secondary")
 
     row_layout.addWidget(field_combo)
     row_layout.addWidget(op_combo)

--- a/gui/settings/general.py
+++ b/gui/settings/general.py
@@ -17,6 +17,10 @@ class GeneralPage(SettingsPage):
 
     def __init__(self, settings: dict, parent=None):
         super().__init__(parent)
+        # Held by reference so collect() can update it in place. The shell
+        # assigns collect()'s value straight over config_data[key], so a
+        # fresh dict here would drop any key this page does not render.
+        self._settings = settings
         main_layout = QVBoxLayout(self)
 
         settings_box = QGroupBox("General Settings")
@@ -74,11 +78,10 @@ class GeneralPage(SettingsPage):
         main_layout.addStretch()
 
     def collect(self) -> dict:
-        return {
-            "settings": {
-                "stock_csv_delimiter": self.stock_delimiter_edit.text(),
-                "orders_csv_delimiter": self.orders_delimiter_edit.text(),
-                "low_stock_threshold": int(self.low_stock_edit.text()),
-                "repeat_detection_days": self.repeat_days_input.value(),
-            }
-        }
+        self._settings.update({
+            "stock_csv_delimiter": self.stock_delimiter_edit.text(),
+            "orders_csv_delimiter": self.orders_delimiter_edit.text(),
+            "low_stock_threshold": int(self.low_stock_edit.text()),
+            "repeat_detection_days": self.repeat_days_input.value(),
+        })
+        return {"settings": self._settings}

--- a/gui/settings/general.py
+++ b/gui/settings/general.py
@@ -1,14 +1,8 @@
 """General settings: CSV delimiters and analysis thresholds."""
 
-from PySide6.QtWidgets import (
-    QFormLayout,
-    QGroupBox,
-    QLabel,
-    QLineEdit,
-    QSpinBox,
-    QVBoxLayout,
-)
+from PySide6.QtWidgets import QLineEdit, QSpinBox, QVBoxLayout
 
+from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
 
 
@@ -23,58 +17,65 @@ class GeneralPage(SettingsPage):
         self._settings = settings
         main_layout = QVBoxLayout(self)
 
-        settings_box = QGroupBox("General Settings")
-        settings_layout = QFormLayout(settings_box)
+        section = FormSection("General Settings")
 
-        delimiter_label = QLabel("Stock CSV Delimiter:")
         self.stock_delimiter_edit = QLineEdit(settings.get("stock_csv_delimiter", ";"))
         self.stock_delimiter_edit.setMaximumWidth(100)
-        self.stock_delimiter_edit.setToolTip(
-            "Character used to separate columns in stock CSV file.\n\n"
-            "Common values:\n"
-            "  • Semicolon (;) - for exports from local warehouse\n"
-            "  • Comma (,) - for Shopify exports\n\n"
-            "Make sure this matches your stock CSV file format."
+        section.add_row(
+            "Stock CSV Delimiter:",
+            self.stock_delimiter_edit,
+            tooltip=(
+                "Character used to separate columns in stock CSV file.\n\n"
+                "Common values:\n"
+                "  • Semicolon (;) - for exports from local warehouse\n"
+                "  • Comma (,) - for Shopify exports\n\n"
+                "Make sure this matches your stock CSV file format."
+            ),
         )
-        settings_layout.addRow(delimiter_label, self.stock_delimiter_edit)
 
-        orders_delimiter_label = QLabel("Orders CSV Delimiter:")
         self.orders_delimiter_edit = QLineEdit(settings.get("orders_csv_delimiter", ","))
         self.orders_delimiter_edit.setMaximumWidth(100)
         self.orders_delimiter_edit.setPlaceholderText(",")
-        self.orders_delimiter_edit.setToolTip(
-            "Character used to separate columns in orders CSV file.\n\n"
-            "Common values:\n"
-            "  • Comma (,) - standard Shopify exports\n"
-            "  • Semicolon (;) - European Excel exports\n"
-            "  • Tab (\\t) - tab-separated files\n\n"
-            "The tool will auto-detect delimiter when you select a file,\n"
-            "but you can override it here if needed."
+        section.add_row(
+            "Orders CSV Delimiter:",
+            self.orders_delimiter_edit,
+            tooltip=(
+                "Character used to separate columns in orders CSV file.\n\n"
+                "Common values:\n"
+                "  • Comma (,) - standard Shopify exports\n"
+                "  • Semicolon (;) - European Excel exports\n"
+                "  • Tab (\\t) - tab-separated files\n\n"
+                "The tool will auto-detect delimiter when you select a file,\n"
+                "but you can override it here if needed."
+            ),
         )
-        settings_layout.addRow(orders_delimiter_label, self.orders_delimiter_edit)
 
-        threshold_label = QLabel("Low Stock Threshold:")
         self.low_stock_edit = QLineEdit(str(settings.get("low_stock_threshold", 5)))
         self.low_stock_edit.setMaximumWidth(100)
-        self.low_stock_edit.setToolTip(
-            "Trigger stock alerts when quantity falls below this number.\n\n"
-            "Items with stock below this threshold will be marked in analysis."
+        section.add_row(
+            "Low Stock Threshold:",
+            self.low_stock_edit,
+            tooltip=(
+                "Trigger stock alerts when quantity falls below this number.\n\n"
+                "Items with stock below this threshold will be marked in analysis."
+            ),
         )
-        settings_layout.addRow(threshold_label, self.low_stock_edit)
 
-        repeat_days_label = QLabel("Repeat Detection Window (days):")
         self.repeat_days_input = QSpinBox()
         self.repeat_days_input.setMinimum(1)
         self.repeat_days_input.setMaximum(365)
         self.repeat_days_input.setValue(settings.get("repeat_detection_days", 1))
-        self.repeat_days_input.setToolTip(
-            "Orders fulfilled within this many days are marked as 'Repeat'.\n"
-            "Default: 1 day (only yesterday's fulfillments)\n"
-            "Increase for longer detection window (e.g., 7 days, 30 days)"
+        section.add_row(
+            "Repeat Detection Window (days):",
+            self.repeat_days_input,
+            tooltip=(
+                "Orders fulfilled within this many days are marked as 'Repeat'.\n"
+                "Default: 1 day (only yesterday's fulfillments)\n"
+                "Increase for longer detection window (e.g., 7 days, 30 days)"
+            ),
         )
-        settings_layout.addRow(repeat_days_label, self.repeat_days_input)
 
-        main_layout.addWidget(settings_box)
+        main_layout.addWidget(section)
         main_layout.addStretch()
 
     def collect(self) -> dict:

--- a/gui/settings/mappings.py
+++ b/gui/settings/mappings.py
@@ -13,7 +13,7 @@ from PySide6.QtWidgets import (
 from gui.column_mapping_widget import ColumnMappingWidget
 from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
-from gui.theme_manager import set_button_role
+from gui.theme_manager import get_theme_manager, set_button_role
 
 
 class MappingsPage(SettingsPage):
@@ -148,7 +148,9 @@ class MappingsPage(SettingsPage):
         delete_btn = QPushButton("✕")
         set_button_role(delete_btn, "secondary")
         delete_btn.setFixedWidth(30)
-        delete_btn.setStyleSheet("color: red; font-weight: bold;")
+        theme = get_theme_manager().get_current_theme()
+        # Sets only `color`, so the secondary role's background still applies.
+        delete_btn.setStyleSheet(f"color: {theme.accent_red}; font-weight: bold;")
         delete_btn.setToolTip("Remove this courier mapping")
 
         row_layout.addWidget(code_label)

--- a/gui/settings/mappings.py
+++ b/gui/settings/mappings.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
 from gui.column_mapping_widget import ColumnMappingWidget
 from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
+from gui.theme_manager import set_button_role
 
 
 class MappingsPage(SettingsPage):
@@ -94,6 +95,7 @@ class MappingsPage(SettingsPage):
         courier_mappings_box.add_widget(self.courier_mappings_container)
 
         add_courier_btn = QPushButton("+ Add Courier Mapping")
+        set_button_role(add_courier_btn, "secondary")
         add_courier_btn.clicked.connect(lambda: self.add_courier_mapping_row())
         add_courier_btn.setMaximumWidth(200)
         courier_mappings_box.add_widget(add_courier_btn)
@@ -144,6 +146,7 @@ class MappingsPage(SettingsPage):
 
         # Delete button
         delete_btn = QPushButton("✕")
+        set_button_role(delete_btn, "secondary")
         delete_btn.setFixedWidth(30)
         delete_btn.setStyleSheet("color: red; font-weight: bold;")
         delete_btn.setToolTip("Remove this courier mapping")

--- a/gui/settings/mappings.py
+++ b/gui/settings/mappings.py
@@ -203,11 +203,9 @@ class MappingsPage(SettingsPage):
                 patterns = [p.strip() for p in patterns_str.split(',') if p.strip()]
                 new_couriers[courier_code] = {"patterns": patterns, "case_sensitive": False}
 
-        # The shell merges collect() dict values one level deep
-        # (config_data[key].update(value)) rather than replacing them, so a
-        # deleted courier code or a stale legacy column_mappings key would
-        # survive a plain new-dict return. Mutate the live dicts in place --
-        # update() against itself is then a no-op and the deletion sticks.
+        # SettingsPage's contract: the returned value replaces
+        # config_data[key], so these must be the live dicts handed to
+        # __init__ -- clear-and-refill in place, never a fresh dict.
         self.column_mappings.clear()
         self.column_mappings.update({"version": 2, "orders": orders_mappings, "stock": stock_mappings})
         self.courier_mappings.clear()

--- a/gui/settings/mappings.py
+++ b/gui/settings/mappings.py
@@ -1,8 +1,6 @@
 """Column mappings (orders/stock) and courier-name mappings."""
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
-    QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -13,8 +11,8 @@ from PySide6.QtWidgets import (
 )
 
 from gui.column_mapping_widget import ColumnMappingWidget
+from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
-from gui.theme_manager import font_css, get_theme_manager
 
 
 class MappingsPage(SettingsPage):
@@ -40,8 +38,7 @@ class MappingsPage(SettingsPage):
         # ========================================
         # COLUMN MAPPINGS - Orders
         # ========================================
-        orders_box = QGroupBox("Orders CSV Column Mapping")
-        orders_layout = QVBoxLayout(orders_box)
+        orders_box = FormSection("Orders CSV Column Mapping")
 
         # Define required and optional fields for orders
         orders_required = ["Order_Number", "SKU", "Quantity", "Shipping_Method"]
@@ -56,14 +53,13 @@ class MappingsPage(SettingsPage):
             optional_fields=orders_optional
         )
 
-        orders_layout.addWidget(self.orders_mapping_widget)
+        orders_box.add_widget(self.orders_mapping_widget)
         scroll_layout.addWidget(orders_box)
 
         # ========================================
         # COLUMN MAPPINGS - Stock
         # ========================================
-        stock_box = QGroupBox("Stock CSV Column Mapping")
-        stock_layout = QVBoxLayout(stock_box)
+        stock_box = FormSection("Stock CSV Column Mapping")
 
         # Define required and optional fields for stock
         stock_required = ["SKU", "Stock"]
@@ -78,34 +74,29 @@ class MappingsPage(SettingsPage):
             optional_fields=stock_optional
         )
 
-        stock_layout.addWidget(self.stock_mapping_widget)
+        stock_box.add_widget(self.stock_mapping_widget)
         scroll_layout.addWidget(stock_box)
 
         # ========================================
         # COURIER MAPPINGS
         # ========================================
-        courier_mappings_box = QGroupBox("Courier Mappings")
-        courier_main_layout = QVBoxLayout(courier_mappings_box)
-
-        instructions2 = QLabel(
-            "Map different shipping provider names to standardized courier codes.\n"
-            "You can specify multiple patterns (comma-separated) for each courier."
+        courier_mappings_box = FormSection(
+            "Courier Mappings",
+            "Map different shipping provider names to standardized courier codes. "
+            "You can specify multiple patterns (comma-separated) for each courier.",
         )
-        instructions2.setWordWrap(True)
-        theme = get_theme_manager().get_current_theme()
-        instructions2.setStyleSheet(f"color: {theme.text_secondary}; font-style: italic; {font_css('body')}")
-        courier_main_layout.addWidget(instructions2)
 
         # Container for courier mapping rows
         self.courier_mappings_container = QWidget()
         self.courier_mappings_layout = QVBoxLayout(self.courier_mappings_container)
         self.courier_mappings_layout.setContentsMargins(0, 0, 0, 0)
 
-        courier_main_layout.addWidget(self.courier_mappings_container)
+        courier_mappings_box.add_widget(self.courier_mappings_container)
 
         add_courier_btn = QPushButton("+ Add Courier Mapping")
         add_courier_btn.clicked.connect(lambda: self.add_courier_mapping_row())
-        courier_main_layout.addWidget(add_courier_btn, 0, Qt.AlignLeft)
+        add_courier_btn.setMaximumWidth(200)
+        courier_mappings_box.add_widget(add_courier_btn)
 
         scroll_layout.addWidget(courier_mappings_box)
         scroll_layout.addStretch()

--- a/gui/settings/packing_lists.py
+++ b/gui/settings/packing_lists.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
 
 from gui.settings.base import SettingsPage
 from gui.settings.fields import FILTER_OPERATORS, FILTERABLE_COLUMNS, add_filter_row
+from gui.theme_manager import set_button_role
 
 
 class PackingListsPage(SettingsPage):
@@ -26,6 +27,7 @@ class PackingListsPage(SettingsPage):
 
         main_layout = QVBoxLayout(self)
         add_btn = QPushButton("Add New Packing List")
+        set_button_role(add_btn, "secondary")
         add_btn.clicked.connect(self.add_packing_list_widget)
         main_layout.addWidget(add_btn, 0, Qt.AlignLeft)
         scroll_area = QScrollArea()
@@ -62,9 +64,11 @@ class PackingListsPage(SettingsPage):
         filters_rows_layout = QVBoxLayout()
         filters_layout.addLayout(filters_rows_layout)
         add_filter_btn = QPushButton("Add Filter")
+        set_button_role(add_filter_btn, "secondary")
         filters_layout.addWidget(add_filter_btn, 0, Qt.AlignLeft)
         pl_layout.addWidget(filters_box)
         delete_btn = QPushButton("Delete Packing List")
+        set_button_role(delete_btn, "secondary")
         pl_layout.addWidget(delete_btn, 0, Qt.AlignRight)
         self.packing_lists_layout.addWidget(pl_box)
         widget_refs = {

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -290,6 +290,8 @@ class RulesPage(SettingsPage):
         set_button_role(test_btn, "secondary")
         test_btn.setMaximumWidth(70)
         test_btn.setToolTip("Test this rule against current analysis data")
+        # As with Delete Rule below: the per-widget green background is
+        # deliberate and overrides the secondary role's background.
         test_btn.setStyleSheet(f"""
             QPushButton {{
                 background-color: {theme.accent_green};
@@ -311,6 +313,9 @@ class RulesPage(SettingsPage):
         header_layout.addWidget(name_edit)
         delete_rule_btn = QPushButton("Delete Rule")
         set_button_role(delete_rule_btn, "secondary")
+        # The per-widget background wins over the role on purpose: destructive
+        # red stays. The role is here so the Hub's inventory guard sees it
+        # marked, and so it picks up the secondary border/disabled treatment.
         delete_rule_btn.setStyleSheet(f"background-color: {theme.accent_red}; color: white;")
         header_layout.addWidget(delete_rule_btn)
         rule_layout.addLayout(header_layout)

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (
 
 from gui.settings.base import SettingsPage
 from gui.settings.fields import ACTION_TYPES, CONDITION_OPERATORS
-from gui.theme_manager import font_css, get_theme_manager
+from gui.theme_manager import font_css, get_theme_manager, set_button_role
 from gui.wheel_ignore_combobox import WheelIgnoreComboBox
 from shopify_tool.core import get_unique_column_values
 
@@ -46,6 +46,7 @@ class RulesPage(SettingsPage):
         # Header row with Add button and rule count label
         header_row = QHBoxLayout()
         add_rule_btn = QPushButton("Add New Rule")
+        set_button_role(add_rule_btn, "secondary")
         add_rule_btn.clicked.connect(lambda: [self.add_rule_widget(), self._update_priority_labels(), self._update_rules_count_label()])
         header_row.addWidget(add_rule_btn)
         header_row.addStretch()
@@ -272,18 +273,21 @@ class RulesPage(SettingsPage):
 
         # Up button
         up_btn = QPushButton("↑")
+        set_button_role(up_btn, "secondary")
         up_btn.setMaximumWidth(30)
         up_btn.setToolTip("Move rule up (higher priority)")
         header_layout.addWidget(up_btn)
 
         # Down button
         down_btn = QPushButton("↓")
+        set_button_role(down_btn, "secondary")
         down_btn.setMaximumWidth(30)
         down_btn.setToolTip("Move rule down (lower priority)")
         header_layout.addWidget(down_btn)
 
         # Test button
         test_btn = QPushButton("Test")
+        set_button_role(test_btn, "secondary")
         test_btn.setMaximumWidth(70)
         test_btn.setToolTip("Test this rule against current analysis data")
         test_btn.setStyleSheet(f"""
@@ -306,6 +310,7 @@ class RulesPage(SettingsPage):
         name_edit = QLineEdit(config.get("name", ""))
         header_layout.addWidget(name_edit)
         delete_rule_btn = QPushButton("Delete Rule")
+        set_button_role(delete_rule_btn, "secondary")
         delete_rule_btn.setStyleSheet(f"background-color: {theme.accent_red}; color: white;")
         header_layout.addWidget(delete_rule_btn)
         rule_layout.addLayout(header_layout)
@@ -345,6 +350,7 @@ class RulesPage(SettingsPage):
 
         # "Add Step" button
         add_step_btn = QPushButton("+ Add Step")
+        set_button_role(add_step_btn, "secondary")
         add_step_btn.setToolTip("Add a new step to this rule (narrowing: each step filters rows from previous step)")
         add_step_btn.setStyleSheet(f"color: {theme.accent_blue}; font-weight: bold;")
         rule_layout.addWidget(add_step_btn, 0, Qt.AlignLeft)
@@ -437,6 +443,7 @@ class RulesPage(SettingsPage):
         conditions_rows_layout = QVBoxLayout()
         conditions_layout.addLayout(conditions_rows_layout)
         add_condition_btn = QPushButton("Add Condition")
+        set_button_role(add_condition_btn, "secondary")
         conditions_layout.addWidget(add_condition_btn, 0, Qt.AlignLeft)
         step_layout.addWidget(conditions_box)
 
@@ -446,6 +453,7 @@ class RulesPage(SettingsPage):
         actions_rows_layout = QVBoxLayout()
         actions_layout.addLayout(actions_rows_layout)
         add_action_btn = QPushButton("Add Action")
+        set_button_role(add_action_btn, "secondary")
         actions_layout.addWidget(add_action_btn, 0, Qt.AlignLeft)
         step_layout.addWidget(actions_box)
 
@@ -453,6 +461,7 @@ class RulesPage(SettingsPage):
         delete_step_btn = None
         if step_number > 1:
             delete_step_btn = QPushButton("Delete Step")
+            set_button_role(delete_step_btn, "secondary")
             delete_step_btn.setStyleSheet(f"color: {theme.accent_red};")
             step_layout.addWidget(delete_step_btn, 0, Qt.AlignRight)
 
@@ -542,6 +551,7 @@ class RulesPage(SettingsPage):
         op_combo = WheelIgnoreComboBox()
         op_combo.addItems(CONDITION_OPERATORS)
         delete_btn = QPushButton("X")
+        set_button_role(delete_btn, "secondary")
 
         row_layout.addWidget(field_combo)
         row_layout.addWidget(op_combo)
@@ -1006,6 +1016,7 @@ class RulesPage(SettingsPage):
 
         # Delete button
         delete_btn = QPushButton("X")
+        set_button_role(delete_btn, "secondary")
 
         row_layout.addWidget(type_combo)
         # Параметри будуть вставлені динамічно

--- a/gui/settings/sets.py
+++ b/gui/settings/sets.py
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
 from gui.theme_manager import font_css, get_theme_manager
 from shopify_tool.set_decoder import export_sets_to_csv, import_sets_from_csv
@@ -40,10 +41,7 @@ class SetsPage(SettingsPage):
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(10, 10, 10, 10)
 
-        # Header
-        header_label = QLabel("Set/Bundle Definitions")
-        header_label.setStyleSheet(font_css("heading"))
-        main_layout.addWidget(header_label)
+        main_layout.addWidget(FormSection("Set/Bundle Definitions"))
 
         # Search box
         self.sets_search = QLineEdit()

--- a/gui/settings/sets.py
+++ b/gui/settings/sets.py
@@ -27,7 +27,7 @@ from PySide6.QtWidgets import (
 
 from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
-from gui.theme_manager import font_css, get_theme_manager
+from gui.theme_manager import font_css, get_theme_manager, set_button_role
 from shopify_tool.set_decoder import export_sets_to_csv, import_sets_from_csv
 
 
@@ -71,14 +71,17 @@ class SetsPage(SettingsPage):
         buttons_layout = QHBoxLayout()
 
         add_btn = QPushButton("Add Set")
+        set_button_role(add_btn, "secondary")
         add_btn.clicked.connect(self._add_set_dialog)
         buttons_layout.addWidget(add_btn)
 
         import_btn = QPushButton("Import from CSV")
+        set_button_role(import_btn, "secondary")
         import_btn.clicked.connect(self._import_sets_from_csv)
         buttons_layout.addWidget(import_btn)
 
         export_btn = QPushButton("Export to CSV")
+        set_button_role(export_btn, "secondary")
         export_btn.clicked.connect(self._export_sets_to_csv)
         buttons_layout.addWidget(export_btn)
 
@@ -136,11 +139,13 @@ class SetsPage(SettingsPage):
             actions_layout.setSpacing(5)
 
             edit_btn = QPushButton("Edit")
+            set_button_role(edit_btn, "secondary")
             edit_btn.setMaximumWidth(70)
             edit_btn.clicked.connect(lambda checked, sku=set_sku: self._edit_set_dialog(sku))
             actions_layout.addWidget(edit_btn)
 
             delete_btn = QPushButton("Delete")
+            set_button_role(delete_btn, "secondary")
             delete_btn.setMaximumWidth(70)
             delete_btn.clicked.connect(lambda checked, sku=set_sku: self._delete_set(sku))
             actions_layout.addWidget(delete_btn)
@@ -361,6 +366,7 @@ class SetEditorDialog(QDialog):
 
         # Add component button
         add_comp_btn = QPushButton("+ Add Component")
+        set_button_role(add_comp_btn, "secondary")
         # Use lambda to avoid passing 'checked' bool as first argument
         add_comp_btn.clicked.connect(lambda: self._add_component_row())
         layout.addWidget(add_comp_btn)
@@ -412,6 +418,7 @@ class SetEditorDialog(QDialog):
 
         # Remove button - використовуємо sender() щоб знайти правильний row
         remove_btn = QPushButton("Remove")
+        set_button_role(remove_btn, "secondary")
         remove_btn.setMaximumWidth(60)
         remove_btn.clicked.connect(self._remove_component_row)
         self.components_table.setCellWidget(row_idx, 2, remove_btn)

--- a/gui/settings/stock_exports.py
+++ b/gui/settings/stock_exports.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
 
 from gui.settings.base import SettingsPage
 from gui.settings.fields import FILTER_OPERATORS, FILTERABLE_COLUMNS, add_filter_row
+from gui.theme_manager import set_button_role
 
 
 class StockExportsPage(SettingsPage):
@@ -26,6 +27,7 @@ class StockExportsPage(SettingsPage):
 
         main_layout = QVBoxLayout(self)
         add_btn = QPushButton("Add New Stock Export")
+        set_button_role(add_btn, "secondary")
         add_btn.clicked.connect(self.add_stock_export_widget)
         main_layout.addWidget(add_btn, 0, Qt.AlignLeft)
         scroll_area = QScrollArea()
@@ -60,9 +62,11 @@ class StockExportsPage(SettingsPage):
         filters_rows_layout = QVBoxLayout()
         filters_layout.addLayout(filters_rows_layout)
         add_filter_btn = QPushButton("Add Filter")
+        set_button_role(add_filter_btn, "secondary")
         filters_layout.addWidget(add_filter_btn, 0, Qt.AlignLeft)
         se_layout.addWidget(filters_box)
         delete_btn = QPushButton("Delete Stock Export")
+        set_button_role(delete_btn, "secondary")
         se_layout.addWidget(delete_btn, 0, Qt.AlignRight)
         self.stock_exports_layout.addWidget(se_box)
         widget_refs = {

--- a/gui/settings/weight.py
+++ b/gui/settings/weight.py
@@ -43,6 +43,10 @@ class WeightPage(SettingsPage):
             "products": {},
             "boxes": []
         }
+        # Held by reference for collect() -- see SettingsPage's contract. Note
+        # this is weight_cfg, not weight_config: an empty config substitutes a
+        # fresh dict above, and that substitute is the one to keep.
+        self._weight_config = weight_cfg
 
         # ---- Global Settings (compact row) ----
         global_row = QHBoxLayout()
@@ -870,10 +874,9 @@ class WeightPage(SettingsPage):
                 "height_cm": _safe_float_b(row, 3),
             })
 
-        return {
-            "weight_config": {
-                "volumetric_divisor": divisor,
-                "products": products,
-                "boxes": boxes,
-            }
-        }
+        self._weight_config.update({
+            "volumetric_divisor": divisor,
+            "products": products,
+            "boxes": boxes,
+        })
+        return {"weight_config": self._weight_config}

--- a/gui/settings/weight.py
+++ b/gui/settings/weight.py
@@ -21,7 +21,7 @@ from PySide6.QtWidgets import (
 )
 
 from gui.settings.base import SettingsPage
-from gui.theme_manager import font_css, get_theme_manager
+from gui.theme_manager import font_css, get_theme_manager, set_button_role
 
 
 class WeightPage(SettingsPage):
@@ -82,21 +82,26 @@ class WeightPage(SettingsPage):
 
         prod_toolbar = QHBoxLayout()
         import_sku_btn = QPushButton("Import from Stock CSV")
+        set_button_role(import_sku_btn, "secondary")
         import_sku_btn.setToolTip("Load SKUs from the current stock CSV file")
         import_sku_btn.clicked.connect(self._weight_import_skus_from_stock_csv)
         prod_toolbar.addWidget(import_sku_btn)
         import_dims_btn = QPushButton("Import Dimensions CSV")
+        set_button_role(import_dims_btn, "secondary")
         import_dims_btn.setToolTip("Import SKU dimensions from a CSV (columns: SKU, Name, L, W, H, No Packaging)")
         import_dims_btn.clicked.connect(self._weight_import_products_from_csv)
         prod_toolbar.addWidget(import_dims_btn)
         add_prod_btn = QPushButton("Add Row")
+        set_button_role(add_prod_btn, "secondary")
         add_prod_btn.clicked.connect(self._weight_add_product_row)
         prod_toolbar.addWidget(add_prod_btn)
         export_prod_btn = QPushButton("Export CSV")
+        set_button_role(export_prod_btn, "secondary")
         export_prod_btn.setToolTip("Export all products with dimensions to a CSV file")
         export_prod_btn.clicked.connect(self._weight_export_products_to_csv)
         prod_toolbar.addWidget(export_prod_btn)
         del_prod_btn = QPushButton("Delete Selected")
+        set_button_role(del_prod_btn, "secondary")
         del_prod_btn.clicked.connect(lambda: self._weight_delete_selected(self.weight_products_table))
         prod_toolbar.addWidget(del_prod_btn)
         prod_toolbar.addStretch()
@@ -131,6 +136,7 @@ class WeightPage(SettingsPage):
         quick_add_row.addWidget(self.weight_quick_no_pkg)
 
         quick_add_btn = QPushButton("Add")
+        set_button_role(quick_add_btn, "secondary")
         quick_add_btn.setToolTip("Add this SKU and keep the form open for the next one (Enter also works)")
         quick_add_btn.clicked.connect(self._weight_quick_add_product)
         quick_add_row.addWidget(quick_add_btn)
@@ -173,17 +179,21 @@ class WeightPage(SettingsPage):
 
         box_toolbar = QHBoxLayout()
         import_box_btn = QPushButton("Import CSV")
+        set_button_role(import_box_btn, "secondary")
         import_box_btn.setToolTip("Import boxes from a CSV (columns: Name, L, W, H)")
         import_box_btn.clicked.connect(self._weight_import_boxes_from_csv)
         box_toolbar.addWidget(import_box_btn)
         add_box_btn = QPushButton("Add Box")
+        set_button_role(add_box_btn, "secondary")
         add_box_btn.clicked.connect(self._weight_add_box_row)
         box_toolbar.addWidget(add_box_btn)
         export_box_btn = QPushButton("Export CSV")
+        set_button_role(export_box_btn, "secondary")
         export_box_btn.setToolTip("Export all boxes to a CSV file")
         export_box_btn.clicked.connect(self._weight_export_boxes_to_csv)
         box_toolbar.addWidget(export_box_btn)
         del_box_btn = QPushButton("Delete Selected")
+        set_button_role(del_box_btn, "secondary")
         del_box_btn.clicked.connect(lambda: self._weight_delete_selected(self.weight_boxes_table))
         box_toolbar.addWidget(del_box_btn)
         box_toolbar.addStretch()

--- a/gui/settings/window.py
+++ b/gui/settings/window.py
@@ -230,10 +230,7 @@ class SettingsWindow(QDialog):
 
             for page in self._pages:
                 for key, value in page.collect().items():
-                    if isinstance(value, dict) and isinstance(self.config_data.get(key), dict):
-                        self.config_data[key].update(value)
-                    else:
-                        self.config_data[key] = value
+                    self.config_data[key] = value
 
             # ========================================
             # Save to server via ProfileManager (background -- avoids blocking

--- a/gui/settings/window.py
+++ b/gui/settings/window.py
@@ -26,7 +26,7 @@ from gui.settings.rules import RulesPage
 from gui.settings.sets import SetsPage
 from gui.settings.stock_exports import StockExportsPage
 from gui.settings.weight import WeightPage
-from gui.theme_manager import apply_font
+from gui.theme_manager import apply_font, set_button_role
 from gui.worker import Worker
 
 logger = logging.getLogger(__name__)
@@ -167,6 +167,8 @@ class SettingsWindow(QDialog):
 
         button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
         self.save_button = button_box.button(QDialogButtonBox.Save)
+        set_button_role(self.save_button, "primary")
+        set_button_role(button_box.button(QDialogButtonBox.Cancel), "secondary")
         button_box.accepted.connect(self.save_settings)
         button_box.rejected.connect(self.reject)
         main_layout.addWidget(button_box)
@@ -314,6 +316,18 @@ class _TagCategoriesPage(SettingsPage):
         layout.setSpacing(0)
         self.panel = TagCategoriesPanel(tag_categories, parent=self)
         layout.addWidget(self.panel)
+
+        # TagCategoriesPanel is also used standalone (its own dialog, outside
+        # the Hub) -- mark roles on this wrapped instance only, not in
+        # tag_categories_dialog.py itself, so the standalone dialog keeps its
+        # current appearance.
+        for button in (
+            self.panel.new_category_btn, self.panel.delete_category_btn,
+            self.panel.color_button, self.panel.add_tag_btn,
+            self.panel.remove_tag_btn, self.panel.add_mapping_btn,
+            self.panel.remove_mapping_btn,
+        ):
+            set_button_role(button, "secondary")
 
     def collect(self) -> dict:
         return {"tag_categories": self.panel.get_categories()}

--- a/gui/settings/window.py
+++ b/gui/settings/window.py
@@ -3,7 +3,7 @@ import logging
 from typing import ClassVar
 
 import pandas as pd
-from PySide6.QtCore import Qt, QThreadPool
+from PySide6.QtCore import QSettings, Qt, QThreadPool
 from PySide6.QtWidgets import (
     QApplication,
     QDialog,
@@ -60,6 +60,10 @@ class SettingsWindow(QDialog):
         ("Output", ["Packing Lists", "Stock Exports", "SKU Labels"]),
         ("Organization", ["Tag Categories"]),
     ]
+
+    # Stored by *name*, not row index: the nav groups have gained entries
+    # twice already and an index would silently point at a different page.
+    NAV_SETTINGS_KEY = "settings_hub/last_page"
 
     def __init__(self, client_id, client_config, profile_manager, analysis_df=None, parent=None):
         """Initializes the SettingsWindow.
@@ -120,6 +124,7 @@ class SettingsWindow(QDialog):
         main_layout.addLayout(content_layout)
 
         self._settings_nav = QListWidget()
+        self._settings_nav.setObjectName("settingsNav")
         self._settings_nav.setFixedWidth(170)
         self._settings_nav.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         content_layout.addWidget(self._settings_nav)
@@ -204,11 +209,27 @@ class SettingsWindow(QDialog):
                 item.setData(Qt.ItemDataRole.UserRole, self._page_index_by_name[page_name])
                 self._settings_nav.addItem(item)
         self._settings_nav.currentItemChanged.connect(self._on_settings_nav_changed)
-        # Select the first real (non-header) entry
+        self._restore_nav_selection()
+
+    def _first_selectable_row(self) -> int:
         for row in range(self._settings_nav.count()):
             if self._settings_nav.item(row).flags() & Qt.ItemFlag.ItemIsSelectable:
+                return row
+        return -1
+
+    def _restore_nav_selection(self) -> None:
+        """Select the last-viewed page, or the first entry if it is gone."""
+        wanted = QSettings("ShopifyFulfillmentTool", "FulfillmentApp").value(
+            self.NAV_SETTINGS_KEY
+        )
+        for row in range(self._settings_nav.count()):
+            item = self._settings_nav.item(row)
+            if item.text() == wanted and item.flags() & Qt.ItemFlag.ItemIsSelectable:
                 self._settings_nav.setCurrentRow(row)
-                break
+                return
+        row = self._first_selectable_row()
+        if row >= 0:
+            self._settings_nav.setCurrentRow(row)
 
     def _on_settings_nav_changed(self, current, _previous):
         if current is None:
@@ -216,6 +237,9 @@ class SettingsWindow(QDialog):
         index = current.data(Qt.ItemDataRole.UserRole)
         if index is not None:
             self.tab_widget.setCurrentIndex(index)
+            QSettings("ShopifyFulfillmentTool", "FulfillmentApp").setValue(
+                self.NAV_SETTINGS_KEY, current.text()
+            )
 
     def reject(self):
         if self._is_saving:

--- a/gui/settings/window.py
+++ b/gui/settings/window.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QMessageBox,
+    QPushButton,
     QStackedWidget,
     QVBoxLayout,
 )
@@ -344,13 +345,10 @@ class _TagCategoriesPage(SettingsPage):
         # TagCategoriesPanel is also used standalone (its own dialog, outside
         # the Hub) -- mark roles on this wrapped instance only, not in
         # tag_categories_dialog.py itself, so the standalone dialog keeps its
-        # current appearance.
-        for button in (
-            self.panel.new_category_btn, self.panel.delete_category_btn,
-            self.panel.color_button, self.panel.add_tag_btn,
-            self.panel.remove_tag_btn, self.panel.add_mapping_btn,
-            self.panel.remove_mapping_btn,
-        ):
+        # current appearance. findChildren rather than a list of attribute
+        # names: a rename over there would otherwise raise AttributeError in
+        # here, and a new button would fail the role guard in the wrong file.
+        for button in self.panel.findChildren(QPushButton):
             set_button_role(button, "secondary")
 
     def collect(self) -> dict:

--- a/gui/settings/window.py
+++ b/gui/settings/window.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
+from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
 from gui.settings.general import GeneralPage
 from gui.settings.mappings import MappingsPage
@@ -25,7 +26,7 @@ from gui.settings.rules import RulesPage
 from gui.settings.sets import SetsPage
 from gui.settings.stock_exports import StockExportsPage
 from gui.settings.weight import WeightPage
-from gui.theme_manager import apply_font, font_css
+from gui.theme_manager import apply_font
 from gui.worker import Worker
 
 logger = logging.getLogger(__name__)
@@ -338,21 +339,11 @@ class _ColumnConfigPage(SettingsPage):
         from gui.column_config_dialog import ColumnConfigPanel
 
         layout.setContentsMargins(10, 10, 10, 10)
-        header_label = QLabel("Column Configuration")
-        header_label.setStyleSheet(font_css("heading"))
-        layout.addWidget(header_label)
-
-        from gui.theme_manager import get_theme_manager
-        theme = get_theme_manager().get_current_theme()
-        help_text = QLabel(
+        layout.addWidget(FormSection(
+            "Column Configuration",
             "Configure which columns are visible in the analysis table, "
-            "their order, and saved views."
-        )
-        help_text.setWordWrap(True)
-        help_text.setStyleSheet(
-            f"color: {theme.text_secondary}; font-style: italic; margin-bottom: 6px;"
-        )
-        layout.addWidget(help_text)
+            "their order, and saved views.",
+        ))
 
         self.panel = ColumnConfigPanel(
             main_window.table_config_manager, main_window=main_window, parent=self

--- a/gui/theme_manager.py
+++ b/gui/theme_manager.py
@@ -200,6 +200,7 @@ def role_stylesheet(theme: ThemeTokens) -> str:
             font-weight: bold;
         }}
         QPushButton[role="primary"]:hover {{ background-color: {hover}; }}
+        QPushButton[role="primary"]:pressed {{ background-color: {hover}; }}
 
         QPushButton[role="secondary"] {{
             background-color: {theme.background_elevated};
@@ -207,6 +208,9 @@ def role_stylesheet(theme: ThemeTokens) -> str:
             border: 1px solid {theme.border};
         }}
         QPushButton[role="secondary"]:hover {{ background-color: {theme.hover}; }}
+        /* shared/theme.py presses every QPushButton to dark accent-blue, which
+           reads as primary for the fraction of a second it is held. */
+        QPushButton[role="secondary"]:pressed {{ background-color: {theme.active_background}; }}
 
         QPushButton[role="primary"]:disabled, QPushButton[role="secondary"]:disabled {{
             background-color: {theme.background};
@@ -223,6 +227,8 @@ def role_stylesheet(theme: ThemeTokens) -> str:
         QListWidget#settingsNav::item {{
             padding: 6px 10px;
             border-radius: {theme.radius}px;
+            /* matches :selected's accent bar so selecting does not shift text */
+            border-left: 2px solid transparent;
         }}
         QListWidget#settingsNav::item:hover {{ background-color: {theme.hover}; }}
         QListWidget#settingsNav::item:selected {{

--- a/gui/theme_manager.py
+++ b/gui/theme_manager.py
@@ -71,7 +71,7 @@ class ThemeManager(QObject):
             logger.warning("QApplication not found, cannot apply theme")
             return
         theme = self.get_current_theme()
-        app.setStyleSheet(build_stylesheet(theme))
+        app.setStyleSheet(build_stylesheet(theme) + role_stylesheet(theme))
         app.setPalette(build_palette(theme))
         logger.debug(f"Applied {self._current_theme_name} theme globally")
 
@@ -173,3 +173,59 @@ def apply_font(target, role: str, bold: bool | None = None) -> None:
     font.setPointSize(style.size_pt)
     font.setBold(style.bold if bold is None else bold)
     target.setFont(font)
+
+
+BUTTON_ROLES = ("primary", "secondary")
+
+
+def role_stylesheet(theme: ThemeTokens) -> str:
+    """QSS for the button hierarchy, appended after shared.theme's sheet.
+
+    shared/theme.py paints every QPushButton accent-blue and is sync-owned
+    by packing-tool, so it cannot be edited here -- these rules layer on in
+    this module, the same seam Track 1 used for the font override.
+
+    Deliberately opt-in: a button with no `role` property keeps exactly its
+    current appearance. The opposite arrangement (neutral by default, mark
+    the primaries) is fewer edits but restyles every button in the app at
+    once, and this is a Windows-only app with three tracks of visual change
+    not yet verified on Windows.
+    """
+    hover = theme.button_hover_dark if theme.name == "dark" else theme.button_hover_light
+    return f"""
+        QPushButton[role="primary"] {{
+            background-color: {theme.accent_blue};
+            color: white;
+            border: 1px solid {theme.accent_blue};
+            font-weight: bold;
+        }}
+        QPushButton[role="primary"]:hover {{ background-color: {hover}; }}
+
+        QPushButton[role="secondary"] {{
+            background-color: {theme.background_elevated};
+            color: {theme.text};
+            border: 1px solid {theme.border};
+        }}
+        QPushButton[role="secondary"]:hover {{ background-color: {theme.hover}; }}
+
+        QPushButton[role="primary"]:disabled, QPushButton[role="secondary"]:disabled {{
+            background-color: {theme.background};
+            color: {theme.text_disabled};
+            border: 1px solid {theme.border_subtle};
+        }}
+    """
+
+
+def set_button_role(button, role: str) -> None:
+    """Mark a button primary or secondary.
+
+    Qt does not restyle a widget when a dynamic property changes after the
+    stylesheet was applied -- the classic trap. Every call site here sets
+    the role at construction, where it would not matter, but unpolish/polish
+    runs unconditionally so a later live-flipping caller cannot step in it.
+    """
+    if role not in BUTTON_ROLES:
+        raise ValueError(f"Unknown button role {role!r}; expected one of {BUTTON_ROLES}")
+    button.setProperty("role", role)
+    button.style().unpolish(button)
+    button.style().polish(button)

--- a/gui/theme_manager.py
+++ b/gui/theme_manager.py
@@ -213,6 +213,27 @@ def role_stylesheet(theme: ThemeTokens) -> str:
             color: {theme.text_disabled};
             border: 1px solid {theme.border_subtle};
         }}
+
+        QListWidget#settingsNav {{
+            background-color: {theme.background};
+            border: none;
+            border-right: 1px solid {theme.border_subtle};
+            outline: none;
+        }}
+        QListWidget#settingsNav::item {{
+            padding: 6px 10px;
+            border-radius: {theme.radius}px;
+        }}
+        QListWidget#settingsNav::item:hover {{ background-color: {theme.hover}; }}
+        QListWidget#settingsNav::item:selected {{
+            background-color: {theme.active_background};
+            color: {theme.text};
+            border-left: 2px solid {theme.accent_blue};
+        }}
+        QListWidget#settingsNav::item:disabled {{
+            color: {theme.text_secondary};
+            padding-top: 10px;
+        }}
     """
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,20 @@
-"""Shared fixtures for the backend test suite.
+"""Shared fixtures for the test suite.
 
 Column names mirror the DEFAULT Shopify/Bulgarian-ERP mapping hardcoded in
 shopify_tool.analysis._clean_and_prepare_data (used when column_mappings=None),
 so fixtures exercise the exact same path production runs through.
+
+The SettingsWindow fixtures at the bottom are here rather than in a test
+module because three test files need them and `tests/` is not a package --
+conftest is the only sharing mechanism that does not depend on sys.path.
 """
+from unittest.mock import Mock
+
 import pandas as pd
 import pytest
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+from gui.settings.window import SettingsWindow
 
 
 @pytest.fixture
@@ -75,3 +84,141 @@ def simple_stock_df(stock_df_factory):
         {"Артикул": "B1", "Име": "Widget B1", "Наличност": 10},
         {"Артикул": "B2", "Име": "Widget B2", "Наличност": 10},
     ])
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def no_modals(monkeypatch):
+    """Fail loudly instead of blocking forever.
+
+    save_settings() reports validation failures through modal QMessageBox
+    calls and returns early. Under the offscreen QPA platform an unstubbed
+    modal hangs the test run, so every popup is recorded and dismissed.
+    """
+    seen = []
+    for name in ("warning", "critical", "information", "question"):
+        monkeypatch.setattr(
+            QMessageBox, name,
+            staticmethod(lambda *a, _n=name, **k: seen.append((_n, a[1:3]))),
+        )
+    return seen
+
+
+def settings_fixture_config():
+    """A config touching every section save_settings() writes."""
+    return {
+        "settings": {
+            "stock_csv_delimiter": ";",
+            "orders_csv_delimiter": ",",
+            "low_stock_threshold": 5,
+            "repeat_detection_days": 30,
+        },
+        "rules": [
+            {
+                "name": "Flag big orders",
+                "priority": 1,
+                "level": "order",
+                "steps": [
+                    {
+                        "conditions": [
+                            {"field": "item_count", "operator": "is greater than", "value": "5"}
+                        ],
+                        "match": "ALL",
+                        "actions": [{"type": "ADD_ORDER_TAG", "value": "BULK"}],
+                    }
+                ],
+            }
+        ],
+        "packing_list_configs": [
+            {
+                "name": "Main",
+                "output_filename": "main.xlsx",
+                "filters": [{"field": "SKU", "operator": "contains", "value": "AB"}],
+                "exclude_skus": ["X1", "X2"],
+            }
+        ],
+        "stock_export_configs": [
+            {
+                "name": "Daily",
+                "output_filename": "daily.csv",
+                "filters": [{"field": "Tags", "operator": "==", "value": "hot"}],
+            }
+        ],
+        # v2 mappings are {csv_column: internal_name}. Every required internal
+        # field must appear or save_settings() aborts at validation.
+        "column_mappings": {
+            "version": 2,
+            "orders": {
+                "Name": "Order_Number",
+                "Lineitem sku": "SKU",
+                "Lineitem quantity": "Quantity",
+                "Shipping Method": "Shipping_Method",
+                "Lineitem name": "Product_Name",
+            },
+            "stock": {"Article": "SKU", "Available": "Stock"},
+        },
+        "courier_mappings": {
+            "DHL": {"patterns": ["dhl", "DHL Express"], "case_sensitive": False}
+        },
+        "set_decoders": {},
+        "weight_config": {
+            "volumetric_divisor": 5000,
+            "products": {
+                "SKU1": {
+                    "name": "Widget",
+                    "length_cm": 10.0,
+                    "width_cm": 5.0,
+                    "height_cm": 2.0,
+                    "no_packaging": False,
+                }
+            },
+            "boxes": [
+                {"name": "Small", "length_cm": 20.0, "width_cm": 15.0, "height_cm": 10.0}
+            ],
+        },
+        "tag_categories": {"version": 2, "categories": {}},
+    }
+
+
+@pytest.fixture
+def make_settings_config():
+    """Factory, not a value: test_settings_nav builds two windows in one test
+    and each needs its own config to mutate."""
+    return settings_fixture_config
+
+
+@pytest.fixture
+def started_workers(monkeypatch):
+    """Intercept the background save instead of letting it run.
+
+    save_settings() hands a Worker to QThreadPool.globalInstance().start().
+    Left alone that really runs, on a real thread, racing the assertions and
+    delivering a success QMessageBox through queued signals. Capturing the
+    worker keeps the test deterministic and still proves the save was reached.
+    """
+    started = []
+    monkeypatch.setattr(
+        "gui.settings.window.QThreadPool",
+        type("Pool", (), {
+            "globalInstance": staticmethod(
+                lambda: type("P", (), {"start": staticmethod(started.append)})()
+            )
+        }),
+    )
+    return started
+
+
+@pytest.fixture
+def window(qapp, no_modals, started_workers):
+    """A real SettingsWindow with the background save intercepted."""
+    win = SettingsWindow(
+        client_id="M",
+        client_config=settings_fixture_config(),
+        profile_manager=Mock(),
+    )
+    yield win
+    win.deleteLater()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 
 import pandas as pd
 import pytest
+from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication, QMessageBox
 
 from gui.settings.window import SettingsWindow
@@ -210,6 +211,17 @@ def started_workers(monkeypatch):
         }),
     )
     return started
+
+
+@pytest.fixture(autouse=True)
+def clean_nav_setting():
+    """QSettings is process-global and writes to the real ~/.config store, so
+    any test that builds a SettingsWindow would otherwise leave the developer's
+    (and CI's) last-page setting behind and leak it into the next run."""
+    store = QSettings("ShopifyFulfillmentTool", "FulfillmentApp")
+    store.remove(SettingsWindow.NAV_SETTINGS_KEY)
+    yield
+    store.remove(SettingsWindow.NAV_SETTINGS_KEY)
 
 
 @pytest.fixture

--- a/tests/test_components_form_section.py
+++ b/tests/test_components_form_section.py
@@ -1,0 +1,71 @@
+"""Construction tests for the FormSection component. No window needed."""
+import pytest
+from PySide6.QtWidgets import QApplication, QFormLayout, QLabel, QLineEdit
+
+from gui.components.form_section import FormSection
+from gui.theme_manager import TYPE_SCALE
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _app():
+    yield QApplication.instance() or QApplication([])
+
+
+def test_title_renders_at_the_label_role():
+    section = FormSection("General Settings")
+    title = section.layout().itemAt(0).widget()
+    assert isinstance(title, QLabel)
+    assert title.text() == "General Settings"
+    assert f"font-size: {TYPE_SCALE['label'].size_pt}pt" in title.styleSheet()
+
+
+def test_description_is_omitted_when_not_given():
+    section = FormSection("General Settings")
+    # title + the form body, nothing else
+    assert section.layout().count() == 2
+
+
+def test_description_wraps_and_renders_at_caption():
+    section = FormSection("Courier Mappings", "Map provider names to codes.")
+    desc = section.layout().itemAt(1).widget()
+    assert desc.text() == "Map provider names to codes."
+    assert desc.wordWrap() is True
+    assert f"font-size: {TYPE_SCALE['caption'].size_pt}pt" in desc.styleSheet()
+
+
+def test_add_row_builds_the_label_and_puts_both_in_the_form():
+    section = FormSection("S")
+    field = QLineEdit()
+    label = section.add_row("Stock CSV Delimiter:", field)
+    form = section.form
+    assert isinstance(form, QFormLayout)
+    assert form.rowCount() == 1
+    assert form.itemAt(0, QFormLayout.LabelRole).widget() is label
+    assert form.itemAt(0, QFormLayout.FieldRole).widget() is field
+    assert label.text() == "Stock CSV Delimiter:"
+
+
+def test_add_row_tooltip_reaches_the_label_too():
+    """Hovering the label should explain the field. Today only the input
+    carries the tooltip, so the explanation is invisible to anyone reading
+    the form rather than clicking into it."""
+    section = FormSection("S")
+    field = QLineEdit()
+    label = section.add_row("Low Stock Threshold:", field, tooltip="Alert below this.")
+    assert label.toolTip() == "Alert below this."
+    assert field.toolTip() == "Alert below this."
+
+
+def test_add_row_leaves_an_existing_widget_tooltip_alone():
+    section = FormSection("S")
+    field = QLineEdit()
+    field.setToolTip("set by the caller")
+    section.add_row("X:", field)
+    assert field.toolTip() == "set by the caller"
+
+
+def test_add_widget_appends_below_the_form():
+    section = FormSection("Courier Mappings")
+    child = QLineEdit()
+    section.add_widget(child)
+    assert section.layout().indexOf(child) == section.layout().count() - 1

--- a/tests/test_settings_button_roles.py
+++ b/tests/test_settings_button_roles.py
@@ -1,10 +1,10 @@
 """Inside the Hub, Save is the only accent-filled button on screen."""
-from PySide6.QtWidgets import QPushButton
+from PySide6.QtWidgets import QDialogButtonBox, QPushButton
 
 
 def test_the_footer_marks_save_primary_and_cancel_secondary(window):
     assert window.save_button.property("role") == "primary"
-    cancel = window.save_button.parent().buttons()[1]
+    cancel = window.save_button.parent().button(QDialogButtonBox.Cancel)
     assert cancel.property("role") == "secondary"
 
 

--- a/tests/test_settings_button_roles.py
+++ b/tests/test_settings_button_roles.py
@@ -1,0 +1,19 @@
+"""Inside the Hub, Save is the only accent-filled button on screen."""
+from PySide6.QtWidgets import QPushButton
+
+
+def test_the_footer_marks_save_primary_and_cancel_secondary(window):
+    assert window.save_button.property("role") == "primary"
+    cancel = window.save_button.parent().buttons()[1]
+    assert cancel.property("role") == "secondary"
+
+
+def test_no_page_leaves_an_unmarked_button_competing_with_save(window):
+    """An unmarked button still renders accent-blue, so it would read as a
+    second primary action. Inside the Hub every in-page button is secondary."""
+    unmarked = []
+    for page in window._pages:
+        for button in page.findChildren(QPushButton):
+            if button.property("role") is None:
+                unmarked.append(f"{type(page).__name__}: {button.text()!r}")
+    assert unmarked == [], "unmarked buttons inside the Hub: " + ", ".join(unmarked)

--- a/tests/test_settings_nav.py
+++ b/tests/test_settings_nav.py
@@ -1,0 +1,74 @@
+"""The Hub remembers which page you were on.
+
+Nine pages and one QListWidget; the Weight and Rules pages are the ones
+people return to.
+
+Fixtures (qapp, no_modals, started_workers, window, make_settings_config)
+all come from conftest.py.
+"""
+from unittest.mock import Mock
+
+import pytest
+from PySide6.QtCore import QSettings, Qt
+
+from gui.settings.window import SettingsWindow
+
+
+@pytest.fixture(autouse=True)
+def clean_nav_setting():
+    """QSettings is process-global and persists to disk on this machine, so
+    a leftover value would leak between tests and between runs."""
+    store = QSettings("ShopifyFulfillmentTool", "FulfillmentApp")
+    store.remove(SettingsWindow.NAV_SETTINGS_KEY)
+    yield
+    store.remove(SettingsWindow.NAV_SETTINGS_KEY)
+
+
+def _current_page_name(win):
+    return win._settings_nav.currentItem().text()
+
+
+def test_a_fresh_profile_lands_on_the_first_entry(window):
+    assert _current_page_name(window) == "General"
+
+
+def test_the_selected_page_is_remembered_by_name(
+    qapp, no_modals, started_workers, make_settings_config
+):
+    first = SettingsWindow(client_id="M", client_config=make_settings_config(),
+                           profile_manager=Mock())
+    for row in range(first._settings_nav.count()):
+        if first._settings_nav.item(row).text() == "Weight":
+            first._settings_nav.setCurrentRow(row)
+            break
+    first.deleteLater()
+
+    second = SettingsWindow(client_id="M", client_config=make_settings_config(),
+                            profile_manager=Mock())
+    assert _current_page_name(second) == "Weight"
+    second.deleteLater()
+
+
+def test_a_page_name_that_no_longer_exists_falls_back(
+    qapp, no_modals, started_workers, make_settings_config
+):
+    """Nav groups have gained entries twice already. Storing a row index
+    would silently point at a different page; a stale *name* must degrade to
+    the first entry rather than raise or select nothing."""
+    QSettings("ShopifyFulfillmentTool", "FulfillmentApp").setValue(
+        SettingsWindow.NAV_SETTINGS_KEY, "A Page That Was Removed"
+    )
+
+    win = SettingsWindow(client_id="M", client_config=make_settings_config(),
+                         profile_manager=Mock())
+    assert _current_page_name(win) == "General"
+    win.deleteLater()
+
+
+def test_headers_are_not_selectable_and_are_never_stored(window):
+    headers = [
+        window._settings_nav.item(row)
+        for row in range(window._settings_nav.count())
+        if not window._settings_nav.item(row).flags() & Qt.ItemFlag.ItemIsSelectable
+    ]
+    assert [h.text() for h in headers] == ["DATA", "FULFILLMENT LOGIC", "OUTPUT", "ORGANIZATION"]

--- a/tests/test_settings_nav.py
+++ b/tests/test_settings_nav.py
@@ -8,20 +8,9 @@ all come from conftest.py.
 """
 from unittest.mock import Mock
 
-import pytest
 from PySide6.QtCore import QSettings, Qt
 
 from gui.settings.window import SettingsWindow
-
-
-@pytest.fixture(autouse=True)
-def clean_nav_setting():
-    """QSettings is process-global and persists to disk on this machine, so
-    a leftover value would leak between tests and between runs."""
-    store = QSettings("ShopifyFulfillmentTool", "FulfillmentApp")
-    store.remove(SettingsWindow.NAV_SETTINGS_KEY)
-    yield
-    store.remove(SettingsWindow.NAV_SETTINGS_KEY)
 
 
 def _current_page_name(win):
@@ -65,7 +54,8 @@ def test_a_page_name_that_no_longer_exists_falls_back(
     win.deleteLater()
 
 
-def test_headers_are_not_selectable_and_are_never_stored(window):
+def test_group_headers_are_not_selectable(window):
+    """Not selectable is also why one can never be the stored page name."""
     headers = [
         window._settings_nav.item(row)
         for row in range(window._settings_nav.count())

--- a/tests/test_settings_page_general.py
+++ b/tests/test_settings_page_general.py
@@ -9,15 +9,36 @@ def qapp():
     return QApplication.instance() or QApplication([])
 
 
-def test_general_page_round_trips_its_settings(qapp):
-    settings = {
+def sample_settings():
+    return {
         "stock_csv_delimiter": "|",
         "orders_csv_delimiter": ";",
         "low_stock_threshold": 12,
         "repeat_detection_days": 30,
     }
+
+
+def test_general_page_round_trips_its_settings(qapp):
+    settings = sample_settings()
+    expected = dict(settings)
     page = GeneralPage(settings)
-    assert page.collect() == {"settings": settings}
+    # Compare against a copy taken before construction: the page holds the
+    # live dict, so comparing collect() to `settings` compares an object to
+    # itself and passes for any implementation.
+    assert page.collect() == {"settings": expected}
+
+
+def test_general_page_writes_every_key_it_owns(qapp):
+    """The live-dict contract means a key the page stops writing survives in
+    the dict it was handed -- so round-trip tests cannot see the drop. Detach
+    the page from that dict and only what collect() actively writes remains."""
+    page = GeneralPage(sample_settings())
+    page._settings = {}
+
+    assert set(page.collect()["settings"]) == {
+        "stock_csv_delimiter", "orders_csv_delimiter",
+        "low_stock_threshold", "repeat_detection_days",
+    }
 
 
 def test_general_page_falls_back_to_defaults(qapp):

--- a/tests/test_settings_page_weight.py
+++ b/tests/test_settings_page_weight.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 from PySide6.QtWidgets import QApplication
 
@@ -29,8 +31,24 @@ def sample_weight_config():
 
 def test_weight_page_round_trips_its_config(qapp):
     weight_config = sample_weight_config()
+    expected = copy.deepcopy(weight_config)
     page = WeightPage(weight_config, {}, ";")
-    assert page.collect() == {"weight_config": weight_config}
+    # Compare against a copy taken before construction: the page holds the
+    # live dict, so comparing collect() to `weight_config` compares an object
+    # to itself and passes for any implementation.
+    assert page.collect() == {"weight_config": expected}
+
+
+def test_weight_page_writes_every_key_it_owns(qapp):
+    """The live-dict contract means a key the page stops writing survives in
+    the dict it was handed -- so round-trip tests cannot see the drop. Detach
+    the page from that dict and only what collect() actively writes remains."""
+    page = WeightPage(sample_weight_config(), {}, ";")
+    page._weight_config = {}
+
+    assert set(page.collect()["weight_config"]) == {
+        "volumetric_divisor", "products", "boxes"
+    }
 
 
 def test_weight_page_normalizes_an_empty_config(qapp):

--- a/tests/test_settings_roundtrip.py
+++ b/tests/test_settings_roundtrip.py
@@ -38,12 +38,15 @@ def test_save_round_trips_every_config_section(window, no_modals):
 
 
 def test_no_page_silently_drops_a_field(window):
-    """Round-tripping through save_settings() alone cannot see a dropped key.
+    """Compare each page's collect() output against the config it was built
+    from, section by section.
 
-    The shell merges dict-valued sections with `config_data[key].update(...)`,
-    so a key the fixture already holds survives even if collect() stopped
-    producing it. Compare each page's collect() output directly instead --
-    every page owns disjoint top-level keys, so no merge is needed here.
+    Blind spot to know about: General and Weight hold the *live* sub-dict
+    (see gui/settings/base.py), so for those two this compares an object to
+    a deepcopy of itself and a dropped key still shows up. Their key coverage
+    lives in test_settings_page_{general,weight}.py, which detach the page
+    from the live dict first. Every other page builds a fresh dict, so this
+    still bites for them.
     """
     before = copy.deepcopy(window.config_data)
 

--- a/tests/test_settings_roundtrip.py
+++ b/tests/test_settings_roundtrip.py
@@ -210,3 +210,20 @@ def test_save_reaches_the_background_write(window, started_workers):
     window.save_settings()
     assert len(started_workers) == 1
     assert window._is_saving is True
+
+
+def test_a_key_no_page_renders_survives_a_save(qapp, no_modals, started_workers):
+    """Live client configs on the server can carry keys this build's UI does
+    not know about -- profile_migrations.py exists because that has happened.
+    A page returning a fresh dict would drop them on every save."""
+    config = settings_fixture_config()
+    config["settings"]["legacy_key_no_page_renders"] = "keep me"
+    config["weight_config"]["legacy_weight_key"] = 123
+
+    win = SettingsWindow(client_id="M", client_config=config, profile_manager=Mock())
+    win.save_settings()
+
+    assert no_modals == [], f"save_settings() reported a problem: {no_modals}"
+    assert win.config_data["settings"]["legacy_key_no_page_renders"] == "keep me"
+    assert win.config_data["weight_config"]["legacy_weight_key"] == 123
+    win.deleteLater()

--- a/tests/test_settings_roundtrip.py
+++ b/tests/test_settings_roundtrip.py
@@ -6,145 +6,15 @@ config. If a page extraction drops or renames a field, this fails.
 
 Kept deliberately blunt -- it asserts on whole config sections rather than
 individual widgets, so it keeps working as the pages move into gui/settings/.
+
+Fixtures (qapp, no_modals, started_workers, window, make_settings_config)
+all come from conftest.py -- tests/ is not a package, so cross-file fixture
+imports do not work.
 """
 import copy
 from unittest.mock import Mock
 
-import pytest
-from PySide6.QtWidgets import QApplication, QMessageBox
-
 from gui.settings.window import SettingsWindow
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    return QApplication.instance() or QApplication([])
-
-
-@pytest.fixture
-def no_modals(monkeypatch):
-    """Fail loudly instead of blocking forever.
-
-    save_settings() reports validation failures through modal QMessageBox
-    calls and returns early. Under the offscreen QPA platform an unstubbed
-    modal hangs the test run, so every popup is recorded and dismissed.
-    """
-    seen = []
-    for name in ("warning", "critical", "information", "question"):
-        monkeypatch.setattr(
-            QMessageBox, name,
-            staticmethod(lambda *a, _n=name, **k: seen.append((_n, a[1:3]))),
-        )
-    return seen
-
-
-def settings_fixture_config():
-    """A config touching every section save_settings() writes."""
-    return {
-        "settings": {
-            "stock_csv_delimiter": ";",
-            "orders_csv_delimiter": ",",
-            "low_stock_threshold": 5,
-            "repeat_detection_days": 30,
-        },
-        "rules": [
-            {
-                "name": "Flag big orders",
-                "priority": 1,
-                "level": "order",
-                "steps": [
-                    {
-                        "conditions": [
-                            {"field": "item_count", "operator": "is greater than", "value": "5"}
-                        ],
-                        "match": "ALL",
-                        "actions": [{"type": "ADD_ORDER_TAG", "value": "BULK"}],
-                    }
-                ],
-            }
-        ],
-        "packing_list_configs": [
-            {
-                "name": "Main",
-                "output_filename": "main.xlsx",
-                "filters": [{"field": "SKU", "operator": "contains", "value": "AB"}],
-                "exclude_skus": ["X1", "X2"],
-            }
-        ],
-        "stock_export_configs": [
-            {
-                "name": "Daily",
-                "output_filename": "daily.csv",
-                "filters": [{"field": "Tags", "operator": "==", "value": "hot"}],
-            }
-        ],
-        # v2 mappings are {csv_column: internal_name}. Every required internal
-        # field must appear or save_settings() aborts at validation.
-        "column_mappings": {
-            "version": 2,
-            "orders": {
-                "Name": "Order_Number",
-                "Lineitem sku": "SKU",
-                "Lineitem quantity": "Quantity",
-                "Shipping Method": "Shipping_Method",
-                "Lineitem name": "Product_Name",
-            },
-            "stock": {"Article": "SKU", "Available": "Stock"},
-        },
-        "courier_mappings": {
-            "DHL": {"patterns": ["dhl", "DHL Express"], "case_sensitive": False}
-        },
-        "set_decoders": {},
-        "weight_config": {
-            "volumetric_divisor": 5000,
-            "products": {
-                "SKU1": {
-                    "name": "Widget",
-                    "length_cm": 10.0,
-                    "width_cm": 5.0,
-                    "height_cm": 2.0,
-                    "no_packaging": False,
-                }
-            },
-            "boxes": [
-                {"name": "Small", "length_cm": 20.0, "width_cm": 15.0, "height_cm": 10.0}
-            ],
-        },
-        "tag_categories": {"version": 2, "categories": {}},
-    }
-
-
-@pytest.fixture
-def started_workers(monkeypatch):
-    """Intercept the background save instead of letting it run.
-
-    save_settings() hands a Worker to QThreadPool.globalInstance().start().
-    Left alone that really runs, on a real thread, racing the assertions and
-    delivering a success QMessageBox through queued signals. Capturing the
-    worker keeps the test deterministic and still proves the save was reached.
-    """
-    started = []
-    monkeypatch.setattr(
-        "gui.settings.window.QThreadPool",
-        type("Pool", (), {
-            "globalInstance": staticmethod(
-                lambda: type("P", (), {"start": staticmethod(started.append)})()
-            )
-        }),
-    )
-    return started
-
-
-@pytest.fixture
-def window(qapp, no_modals, started_workers):
-    """A real SettingsWindow with the background save intercepted."""
-    win = SettingsWindow(
-        client_id="M",
-        client_config=settings_fixture_config(),
-        profile_manager=Mock(),
-    )
-    yield win
-    win.deleteLater()
 
 
 def test_window_registers_every_page(window):
@@ -212,11 +82,13 @@ def test_save_reaches_the_background_write(window, started_workers):
     assert window._is_saving is True
 
 
-def test_a_key_no_page_renders_survives_a_save(qapp, no_modals, started_workers):
+def test_a_key_no_page_renders_survives_a_save(
+    qapp, no_modals, started_workers, make_settings_config
+):
     """Live client configs on the server can carry keys this build's UI does
     not know about -- profile_migrations.py exists because that has happened.
     A page returning a fresh dict would drop them on every save."""
-    config = settings_fixture_config()
+    config = make_settings_config()
     config["settings"]["legacy_key_no_page_renders"] = "keep me"
     config["weight_config"]["legacy_weight_key"] = 123
 

--- a/tests/test_theme_button_roles.py
+++ b/tests/test_theme_button_roles.py
@@ -4,6 +4,8 @@ shared/theme.py paints every QPushButton accent-blue, and it is sync-owned
 by packing-tool so it cannot be edited here. These rules are layered on in
 gui/theme_manager.py, the repo-owned seam.
 """
+import re
+
 import pytest
 from PySide6.QtWidgets import QApplication, QPushButton
 
@@ -14,6 +16,15 @@ from shared.theme import get_theme
 @pytest.fixture(scope="module", autouse=True)
 def _app():
     yield QApplication.instance() or QApplication([])
+
+
+def _background_color(qss: str, role: str) -> str:
+    """The resolved colour of the role's base rule -- comparing whole QSS
+    blocks instead would pass on `font-weight: bold` alone."""
+    block = qss.split(f'QPushButton[role="{role}"]')[1].split("}")[0]
+    match = re.search(r"background-color:\s*([^;]+);", block)
+    assert match, f"no background-color in the {role} rule"
+    return match.group(1).strip()
 
 
 @pytest.mark.parametrize("theme_name", ["light", "dark"])
@@ -28,13 +39,10 @@ def test_the_two_roles_do_not_render_the_same(theme_name):
     """A token that happens to resolve to the same colour in one theme is
     invisible on Linux and only shows up on the Windows machines that run
     this app."""
-    theme = get_theme(theme_name)
-    qss = role_stylesheet(theme)
-    primary = qss.split('QPushButton[role="primary"]')[1].split("}")[0]
-    secondary = qss.split('QPushButton[role="secondary"]')[1].split("}")[0]
-    assert "background-color" in primary
-    assert "background-color" in secondary
-    assert primary != secondary
+    qss = role_stylesheet(get_theme(theme_name))
+    primary = _background_color(qss, "primary")
+    secondary = _background_color(qss, "secondary")
+    assert primary != secondary, f"both roles render {primary} in the {theme_name} theme"
 
 
 def test_set_button_role_sets_the_property():

--- a/tests/test_theme_button_roles.py
+++ b/tests/test_theme_button_roles.py
@@ -56,3 +56,10 @@ def test_the_suffix_is_actually_applied_to_the_app():
 
     get_theme_manager().apply_theme()
     assert 'QPushButton[role="primary"]' in QApplication.instance().styleSheet()
+
+
+@pytest.mark.parametrize("theme_name", ["light", "dark"])
+def test_the_settings_nav_is_styled_as_a_sidebar(theme_name):
+    qss = role_stylesheet(get_theme(theme_name))
+    assert "QListWidget#settingsNav" in qss
+    assert "QListWidget#settingsNav::item:selected" in qss

--- a/tests/test_theme_button_roles.py
+++ b/tests/test_theme_button_roles.py
@@ -1,0 +1,58 @@
+"""The primary/secondary button hierarchy Track 3 said had to be built.
+
+shared/theme.py paints every QPushButton accent-blue, and it is sync-owned
+by packing-tool so it cannot be edited here. These rules are layered on in
+gui/theme_manager.py, the repo-owned seam.
+"""
+import pytest
+from PySide6.QtWidgets import QApplication, QPushButton
+
+from gui.theme_manager import role_stylesheet, set_button_role
+from shared.theme import get_theme
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _app():
+    yield QApplication.instance() or QApplication([])
+
+
+@pytest.mark.parametrize("theme_name", ["light", "dark"])
+def test_both_roles_have_a_rule(theme_name):
+    qss = role_stylesheet(get_theme(theme_name))
+    assert 'QPushButton[role="primary"]' in qss
+    assert 'QPushButton[role="secondary"]' in qss
+
+
+@pytest.mark.parametrize("theme_name", ["light", "dark"])
+def test_the_two_roles_do_not_render_the_same(theme_name):
+    """A token that happens to resolve to the same colour in one theme is
+    invisible on Linux and only shows up on the Windows machines that run
+    this app."""
+    theme = get_theme(theme_name)
+    qss = role_stylesheet(theme)
+    primary = qss.split('QPushButton[role="primary"]')[1].split("}")[0]
+    secondary = qss.split('QPushButton[role="secondary"]')[1].split("}")[0]
+    assert "background-color" in primary
+    assert "background-color" in secondary
+    assert primary != secondary
+
+
+def test_set_button_role_sets_the_property():
+    button = QPushButton("Save")
+    set_button_role(button, "primary")
+    assert button.property("role") == "primary"
+
+
+def test_set_button_role_rejects_an_unknown_role():
+    """Same rule Tracks 1-3 set for the type scale: a typo fails in
+    development rather than silently rendering as an unstyled button."""
+    button = QPushButton("Save")
+    with pytest.raises(ValueError):
+        set_button_role(button, "tertiary")
+
+
+def test_the_suffix_is_actually_applied_to_the_app():
+    from gui.theme_manager import get_theme_manager
+
+    get_theme_manager().apply_theme()
+    assert 'QPushButton[role="primary"]' in QApplication.instance().styleSheet()


### PR DESCRIPTION
## What

UI Design System **Track 4 — Settings Hub**. Turns the freshly-split `gui/settings/` package (Track C, #272) into a coherent hub: one visual language for section headers, a single primary action, and a sidebar nav that remembers where you were.

- Design: `docs/superpowers/specs/2026-08-13-settings-hub-design.md`
- Plan: `docs/superpowers/plans/2026-08-13-settings-hub-plan.md`

## The bug fix that came first

`gui/settings/window.py` merged each page's `collect()` result into the existing config with `dict.update()`. That masked a real hazard: a page that renders only *some* of a settings sub-dict would silently drop the keys it never rendered, and the merge papered over it inconsistently.

Now `collect()` **replaces**, and `GeneralPage` / `WeightPage` hold the *live* dict rather than a snapshot — so keys no page renders survive a save intact. A guard test pins this.

## Changes

| # | Commit | What |
|---|---|---|
| 1 | `fix(settings)` | `collect()` replaces instead of merging (above) |
| 2 | `feat(components)` | New `FormSection` — the section-header primitive deferred from Track 3 |
| 3 | `refactor(settings)` | General + Mappings: 4 `QGroupBox` sites → `FormSection` |
| 4 | `refactor(settings)` | Sets + Column Config: hand-rolled heading labels → `FormSection` |
| 5 | `feat(theme)` | Opt-in `role_stylesheet()` / `set_button_role()` in `theme_manager` |
| 6 | `feat(settings)` | Save is the Hub's only primary button; every in-page button marked secondary |
| 7 | `feat(settings)` | Sidebar-styled nav that remembers the last page |
| 8 | `fix(settings)` | Review-pass fixes (see below) |

Button roles are **opt-in** — nothing outside `gui/settings/` changes appearance.

## Tests

**523 pass** (498 baseline + 25), `ruff check . --exclude shared` clean.

New: `test_components_form_section.py`, `test_theme_button_roles.py`, `test_settings_button_roles.py`, `test_settings_nav.py`. Shared settings fixtures moved into `tests/conftest.py` (`tests/` is not a package — the only cross-file sharing mechanism available).

## Review pass (commit 8)

A code review caught that the live-dict change had **silently disabled the drop-detection guard it was supposed to strengthen**: once `collect()` returns the live dict, comparing its output to a deepcopy of the config it was built from compares an object to itself, so `WeightPage` could stop writing a top-level `weight_config` key with zero coverage. Fixed by detaching the page from the live dict before `collect()`:

```python
page = WeightPage(sample_weight_config(), {}, ";")
page._weight_config = {}          # only what collect() actively writes remains
assert set(page.collect()["weight_config"]) == {"volumetric_divisor", "products", "boxes"}
```

Verified by mutation — dropping `volumetric_divisor` (or `repeat_detection_days` in General) now fails these tests and nothing else. Two per-page round-trip tests that had become tautologies were fixed the same way.

Also in that commit: `_TagCategoriesPage` now marks buttons via `findChildren` instead of seven hand-listed attribute names (a rename in `tag_categories_dialog.py` would otherwise raise `AttributeError` while *opening* the settings window); a `:pressed` rule for secondary buttons (`shared/theme.py` presses every `QPushButton` to dark accent-blue, which reads as primary while held); a transparent left border on nav items so selection no longer shifts text 2px; QSettings nav cleanup moved to `conftest` as autouse — the `window` fixture was writing `settings_hub/last_page` into the real `~/.config` on every run.

**`TagCategoriesPanel` scope.** `_TagCategoriesPage` wraps `TagCategoriesPanel` from `gui/tag_categories_dialog.py`, which a standalone dialog also uses. Rather than edit that shared file, roles are applied to the wrapped instance from inside `_TagCategoriesPage.__init__` — so only the Hub instance is marked and the standalone dialog is untouched.

**Two buttons keep their own background on purpose.** Rules' *Delete Rule* (red) and *Test* (green) carry per-widget stylesheets that beat the secondary role's background. The role is still set so the Hub's inventory guard sees them marked; a comment at each site says so.

## Open questions (carried forward, not resolved here)

1. **Should Client Profile move into the Hub?** This design says no, and no is the reversible choice. If the vision doc genuinely meant one window for everything client-related, it becomes its own task — the Hub would need to accept a client independent of the active one.
2. **Windows visual check is still outstanding.** Tracks 1–3, Track C's relabels, and this track's button hierarchy + nav styling are now five stacked layers of visual change with no screenshot on the target OS. One pass covering all of them is the standing recommendation — this track adds to the stack, it doesn't create it.
3. **Phase 5 `column_order`** — unanswered since #267 merged; documented in a docstring on `_get_config_from_ui`. Waiting on a user report.
