### PR TITLE
Phase 6 — Mappings UI: split Orders/Stock pages, expose lot fields, fix save-deletes-mappings

### DIFF
--- a/docs/superpowers/plans/2026-08-13-mappings-ui-plan.md
+++ b/docs/superpowers/plans/2026-08-13-mappings-ui-plan.md
@@ -1,0 +1,1172 @@
+# Mappings UI + Stock Lot-Column Mapping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Stock CSV mapping able to hold `Expiry_Date` and `Batch` without a Save destroying them, and rebuild the mapping UI as two focused nav pages whose column inputs can be filled from a real CSV's headers.
+
+**Architecture:** Seven tasks, defect-first. Tasks 1-4 are data-integrity and backend work that can be verified without looking at a pixel; tasks 5-7 rebuild the UI on top. The widget keeps its class name and public API throughout so each task leaves the suite green.
+
+**Tech Stack:** PySide6, pandas, pytest. Windows-only in production, developed on Linux with `QT_QPA_PLATFORM=offscreen`.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-mappings-ui-design.md`
+
+## Global Constraints
+
+- **Run the gate before finishing:** `QT_QPA_PLATFORM=offscreen python -m pytest` and `ruff check . --exclude shared`. Baseline on this branch is **523 tests passing**.
+- **Use `.venv/bin/python`**, never bare `python` or `python3` — neither is on PATH on this machine. `./scripts/setup_venv.sh` if `.venv` is missing.
+- **Never hand-edit `shared/`.** Nothing in this plan touches it.
+- **No hardcoded colors** in stylesheets — use `get_theme_manager().get_current_theme()` tokens. This change *removes* a `color: red`; it must not add one.
+- **No UI calls from background threads.** Nothing in this plan is threaded.
+- `Position` is **out of scope** by explicit user decision. Do not add it.
+- Keep `_LOT_COLUMN_DEFAULTS` in `shopify_tool/analysis.py`. It is the back-compat path for configs that already lost their mapping.
+- Internal field names are exact strings and are load-bearing: `Expiry_Date` and `Batch` are what `_build_fifo_lots()` looks for (`shopify_tool/analysis.py:96-97`). Not `Lot`, not `Expiry`.
+
+---
+
+### Task 1: `read_csv_headers()` in csv_utils
+
+Backend helper the header-loading button (Task 7) needs. No Qt, so it is tested directly.
+
+**Files:**
+- Modify: `shopify_tool/csv_utils.py` (add after `detect_csv_delimiter`, which ends at line 121)
+- Test: `tests/test_csv_utils.py`
+
+**Interfaces:**
+- Consumes: `detect_csv_delimiter(file_path, encoding) -> tuple[str, str]`, already in this module at line 30.
+- Produces: `read_csv_headers(file_path: str, encoding: str = "utf-8-sig") -> list[str]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_csv_utils.py`:
+
+```python
+def test_read_csv_headers_semicolon_delimited(tmp_path):
+    csv = tmp_path / "stock.csv"
+    csv.write_text(
+        "Артикул;Наличност;Годност;Партида\nSKU1;10;261230;L42\n",
+        encoding="utf-8",
+    )
+    assert read_csv_headers(str(csv)) == ["Артикул", "Наличност", "Годност", "Партида"]
+
+
+def test_read_csv_headers_comma_delimited(tmp_path):
+    csv = tmp_path / "orders.csv"
+    csv.write_text("Name,Lineitem sku,Lineitem quantity\n#1001,ABC,2\n", encoding="utf-8")
+    assert read_csv_headers(str(csv)) == ["Name", "Lineitem sku", "Lineitem quantity"]
+
+
+def test_read_csv_headers_does_not_read_rows(tmp_path):
+    """nrows=0 keeps this cheap on a large stock export over a network share."""
+    csv = tmp_path / "big.csv"
+    rows = "\n".join(f"SKU{i};{i}" for i in range(5000))
+    csv.write_text(f"Артикул;Наличност\n{rows}\n", encoding="utf-8")
+    assert read_csv_headers(str(csv)) == ["Артикул", "Наличност"]
+```
+
+Add `read_csv_headers` to the existing import of `shopify_tool.csv_utils` at the top of the file.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_csv_utils.py -k read_csv_headers -v`
+Expected: FAIL — `ImportError: cannot import name 'read_csv_headers'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `shopify_tool/csv_utils.py`, directly after `detect_csv_delimiter`:
+
+```python
+def read_csv_headers(file_path: str, encoding: str = 'utf-8-sig') -> list[str]:
+    """Return a CSV's column names without loading any of its rows.
+
+    Delimiter comes from detect_csv_delimiter's fallback chain rather than a
+    configured value, so the settings pages that call this need no delimiter
+    plumbing. nrows=0 reads the header line only, which matters on a large
+    stock export sitting on a network share.
+
+    Args:
+        file_path: Path to the CSV file.
+        encoding: File encoding (default: utf-8-sig).
+
+    Returns:
+        List of column names, in file order.
+    """
+    delimiter, _method = detect_csv_delimiter(file_path, encoding)
+    return list(
+        pd.read_csv(file_path, sep=delimiter, encoding=encoding, nrows=0).columns
+    )
+```
+
+`pandas` is already imported in this module.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_csv_utils.py -v`
+Expected: PASS, including the pre-existing cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shopify_tool/csv_utils.py tests/test_csv_utils.py
+git commit -m "feat(csv): read_csv_headers() reads a CSV's header row only"
+```
+
+---
+
+### Task 2: Stop dropping mappings the widget has no row for
+
+The defect. `get_mappings()` can only emit internal names in `required_fields + optional_fields`, so anything else in the client's config is erased on Save.
+
+**Files:**
+- Modify: `gui/column_mapping_widget.py:170-188` (`get_mappings`)
+- Modify: `tests/conftest.py:163` (fixture stock mapping)
+- Test: `tests/test_settings_page_mappings.py`
+
+**Interfaces:**
+- Produces: `ColumnMappingWidget.get_mappings() -> dict` — unchanged signature, changed contract: entries whose internal name is not managed by this widget are carried through untouched.
+
+- [ ] **Step 1: Widen the shared fixture so the existing guard can see the bug**
+
+In `tests/conftest.py`, change line 163 from:
+
+```python
+            "stock": {"Article": "SKU", "Available": "Stock"},
+```
+
+to:
+
+```python
+            "stock": {
+                "Article": "SKU",
+                "Available": "Stock",
+                "Годност": "Expiry_Date",
+                "Партида": "Batch",
+            },
+```
+
+`test_no_page_silently_drops_a_field` (`tests/test_settings_roundtrip.py:40`) already
+compares each page's `collect()` to a pre-collect deepcopy. It never caught this because
+the fixture had nothing droppable in it.
+
+- [ ] **Step 2: Write the failing unit test**
+
+Append to `tests/test_settings_page_mappings.py`:
+
+```python
+def test_get_mappings_preserves_an_internal_name_it_has_no_row_for(qapp):
+    """A field missing from required/optional must not delete the client's
+    mapping for it. Regression: stock_optional listed only Product_Name, so
+    one Save destroyed the Expiry_Date and Batch mappings the default config
+    ships with -- and with them, FIFO lot allocation."""
+    widget = ColumnMappingWidget(
+        mapping_type="stock",
+        current_mappings={"Article": "SKU", "Available": "Stock", "Годност": "Expiry_Date"},
+        required_fields=["SKU", "Stock"],
+        optional_fields=[],  # deliberately does not manage Expiry_Date
+    )
+    assert widget.get_mappings() == {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Годност": "Expiry_Date",
+    }
+
+
+def test_get_mappings_still_removes_a_cleared_managed_field(qapp):
+    """Carrying unmanaged entries through must not resurrect a field the user
+    deliberately cleared."""
+    widget = ColumnMappingWidget(
+        mapping_type="stock",
+        current_mappings={"Article": "SKU", "Name": "Product_Name"},
+        required_fields=["SKU"],
+        optional_fields=["Product_Name"],
+    )
+    widget.csv_column_inputs["Product_Name"].setText("")
+    assert widget.get_mappings() == {"Article": "SKU"}
+```
+
+Add to the imports at the top of the file:
+
+```python
+from gui.column_mapping_widget import ColumnMappingWidget
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py tests/test_settings_roundtrip.py -v`
+Expected: `test_get_mappings_preserves_an_internal_name_it_has_no_row_for` FAILS (`Годност` missing from the result) and `test_no_page_silently_drops_a_field` FAILS on section `column_mappings`. `test_get_mappings_still_removes_a_cleared_managed_field` passes already — it is the guard against over-correcting in Step 4.
+
+- [ ] **Step 4: Write the implementation**
+
+Replace `get_mappings` in `gui/column_mapping_widget.py`:
+
+```python
+    def get_mappings(self):
+        """Get current mappings from UI.
+
+        Entries for internal names this widget has no row for are carried
+        through untouched. Without that, a field missing from
+        required_fields/optional_fields is silently deleted from the client's
+        config on every save -- which is exactly what happened to the
+        Expiry_Date and Batch mappings that drive FIFO lot allocation.
+
+        A *managed* field left blank is still removed: its old entry was
+        never carried over, so clearing a box does delete the mapping.
+
+        Returns:
+            dict: Dictionary of {csv_column_name: internal_name}
+        """
+        managed = set(self.required_fields) | set(self.optional_fields)
+        mappings = {
+            csv_column: internal_name
+            for csv_column, internal_name in self.current_mappings.items()
+            if internal_name not in managed
+        }
+
+        for internal_name in self.required_fields + self.optional_fields:
+            input_widget = self.csv_column_inputs.get(internal_name)
+            if input_widget:
+                csv_column = input_widget.text().strip()
+                if csv_column:  # Only add non-empty mappings
+                    mappings[csv_column] = internal_name
+
+        return mappings
+```
+
+Note for Task 5: `.text()` becomes `.currentText()` when the inputs become editable
+combo boxes. Left correct for the widget as it exists right now.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py tests/test_settings_roundtrip.py -v`
+Expected: PASS, all of them.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest`
+Expected: 525 passed (523 baseline + 2 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/column_mapping_widget.py tests/conftest.py tests/test_settings_page_mappings.py
+git commit -m "fix(settings): saving no longer deletes stock mappings the UI has no row for"
+```
+
+---
+
+### Task 3: Expiry_Date and Batch become editable rows
+
+Task 2 stops them being destroyed. This makes them editable, which is the ticket.
+
+**Files:**
+- Modify: `gui/settings/mappings.py:66-67` (`stock_required` / `stock_optional`)
+- Test: `tests/test_settings_page_mappings.py`
+
+**Interfaces:**
+- Consumes: `ColumnMappingWidget(mapping_type, current_mappings, required_fields, optional_fields)` and its `csv_column_inputs: dict[str, QWidget]`.
+- Produces: `MappingsPage.stock_mapping_widget` now has inputs keyed `"Expiry_Date"` and `"Batch"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_settings_page_mappings.py`:
+
+```python
+def test_stock_page_offers_rows_for_the_lot_tracking_fields(qapp):
+    """Expiry_Date and Batch drive _build_fifo_lots(); before this they were
+    in the default client config with no way to see or edit them."""
+    page = MappingsPage(valid_column_mappings(), {})
+    inputs = page.stock_mapping_widget.csv_column_inputs
+    assert "Expiry_Date" in inputs
+    assert "Batch" in inputs
+
+
+def test_stock_lot_mappings_round_trip_through_the_page(qapp):
+    column_mappings = valid_column_mappings()
+    column_mappings["stock"] = {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Exp date": "Expiry_Date",
+        "Lot": "Batch",
+    }
+    page = MappingsPage(column_mappings, {})
+
+    assert page.collect()["column_mappings"]["stock"] == {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Exp date": "Expiry_Date",
+        "Lot": "Batch",
+    }
+```
+
+The second test is the one that matters: `"Exp date"`/`"Lot"` are *not* the Bulgarian
+headers `_LOT_COLUMN_DEFAULTS` rescues, so this is the case that was permanently broken.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py -v`
+Expected: `test_stock_page_offers_rows_for_the_lot_tracking_fields` FAILS with `assert 'Expiry_Date' in {...}`. `test_stock_lot_mappings_round_trip_through_the_page` PASSES already, courtesy of Task 2 — it stays as the guard that the fields survive both mechanisms.
+
+- [ ] **Step 3: Write the implementation**
+
+In `gui/settings/mappings.py`, replace lines 65-67:
+
+```python
+        # Define required and optional fields for stock
+        stock_required = ["SKU", "Stock"]
+        stock_optional = ["Product_Name"]
+```
+
+with:
+
+```python
+        # Define required and optional fields for stock.
+        # Expiry_Date and Batch are the exact internal names _build_fifo_lots()
+        # looks for (shopify_tool/analysis.py:96-97) -- renaming them here
+        # silently turns FIFO lot allocation off.
+        stock_required = ["SKU", "Stock"]
+        stock_optional = ["Product_Name", "Expiry_Date", "Batch"]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/settings/mappings.py tests/test_settings_page_mappings.py
+git commit -m "feat(settings): expose Expiry_Date and Batch in the Stock CSV mapping"
+```
+
+---
+
+### Task 4: Don't inject a lot default for an internal name already mapped
+
+`analysis.py` back-fills `Годност`/`Партида` whenever those *CSV header keys* are absent.
+Now that a client can map `Exp date → Expiry_Date` in the UI, that test is wrong: it
+injects a second CSV header claiming the same internal name.
+
+**Files:**
+- Modify: `shopify_tool/analysis.py:216-221`
+- Test: `tests/test_analysis.py`
+
+**Interfaces:**
+- Consumes: `_LOT_COLUMN_DEFAULTS` (module constant, `analysis.py:14`).
+- Produces: no signature change; behavioural change inside `_clean_and_prepare_data`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_analysis.py`:
+
+```python
+def test_lot_defaults_are_not_injected_when_the_internal_name_is_already_mapped():
+    """A client who maps their own expiry header in Settings must not also get
+    the Bulgarian default injected -- that is two CSV headers claiming one
+    internal name."""
+    from shopify_tool.analysis import _LOT_COLUMN_DEFAULTS, _resolve_stock_mappings
+
+    resolved = _resolve_stock_mappings({"Article": "SKU", "Exp date": "Expiry_Date"})
+
+    assert resolved["Exp date"] == "Expiry_Date"
+    assert "Годност" not in resolved
+    # Batch is still unmapped, so its default is still injected.
+    assert resolved["Партида"] == "Batch"
+    assert _LOT_COLUMN_DEFAULTS == {"Годност": "Expiry_Date", "Партида": "Batch"}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_analysis.py -k lot_defaults -v`
+Expected: FAIL — `ImportError: cannot import name '_resolve_stock_mappings'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `shopify_tool/analysis.py`, add after `_LOT_COLUMN_DEFAULTS` (line 14):
+
+```python
+def _resolve_stock_mappings(stock_mappings: dict[str, str]) -> dict[str, str]:
+    """Back-fill lot column defaults that the config does not already cover.
+
+    Lot tracking works for clients whose configs pre-date the Stock mapping UI
+    without a config migration. A default is skipped when its CSV header is
+    already mapped, or when its *internal* name is -- otherwise a client who
+    maps "Exp date" -> Expiry_Date also gets "Годност" -> Expiry_Date, i.e.
+    two CSV headers claiming one internal field.
+
+    ponytail: this back-fill is only needed until existing configs have been
+    re-saved through the fixed Mappings UI -- drop it, and the constant, once
+    that has happened.
+    """
+    mapped_internals = set(stock_mappings.values())
+    missing = {
+        csv_col: internal
+        for csv_col, internal in _LOT_COLUMN_DEFAULTS.items()
+        if csv_col not in stock_mappings and internal not in mapped_internals
+    }
+    return {**stock_mappings, **missing} if missing else stock_mappings
+```
+
+Then replace lines 216-221 (the inline injection):
+
+```python
+    # Inject lot column defaults for any keys not already in the config mapping.
+    # This ensures lot tracking works for existing clients whose configs pre-date
+    # this feature without requiring a config migration or UI change.
+    missing = {k: v for k, v in _LOT_COLUMN_DEFAULTS.items() if k not in stock_mappings}
+    if missing:
+        stock_mappings = {**stock_mappings, **missing}
+```
+
+with:
+
+```python
+    stock_mappings = _resolve_stock_mappings(stock_mappings)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_analysis.py -v`
+Expected: PASS, including the existing lot-tracking cases — the extraction is behaviour-preserving for every input where no internal name is doubly mapped.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shopify_tool/analysis.py tests/test_analysis.py
+git commit -m "fix(analysis): skip a lot default whose internal name is already mapped"
+```
+
+---
+
+### Task 5: Rebuild the mapping row
+
+Everything so far is invisible. This is the "better UI" half: drop the twelve repeated
+`"Your CSV Column:"` labels, the `→` arrows, the trailing `*` column and the inner
+`QScrollArea` that gives the page its second scrollbar.
+
+**Files:**
+- Modify: `gui/column_mapping_widget.py` (replace `_setup_ui` and `_create_mapping_row`; update `get_mappings`, `validate_mappings`, `set_mappings` for the new input type)
+- Test: `tests/test_settings_page_mappings.py`
+
+**Interfaces:**
+- Consumes: `FormSection(title, description="")` with `.add_row(label, widget, tooltip="") -> QLabel` and `.add_widget(widget)` from `gui/components/form_section.py`.
+- Produces:
+  - `ColumnMappingWidget.csv_column_inputs: dict[str, QComboBox]` — was `dict[str, QLineEdit]`. Editable combo boxes; read with `.currentText()`, write with `.setCurrentText()`.
+  - `ColumnMappingWidget.set_available_headers(headers: list[str]) -> None` — new, used by Task 7.
+  - `get_mappings()`, `validate_mappings()`, `set_mappings()`, `mappings_changed` unchanged in name and signature.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_settings_page_mappings.py`:
+
+```python
+from PySide6.QtWidgets import QComboBox, QScrollArea
+
+
+def test_mapping_inputs_are_editable_combo_boxes(qapp):
+    page = MappingsPage(valid_column_mappings(), {})
+    sku_input = page.orders_mapping_widget.csv_column_inputs["SKU"]
+    assert isinstance(sku_input, QComboBox)
+    assert sku_input.isEditable()
+    assert sku_input.currentText() == "Lineitem sku"
+
+
+def test_set_available_headers_offers_them_on_every_row_without_losing_text(qapp):
+    page = MappingsPage(valid_column_mappings(), {})
+    widget = page.orders_mapping_widget
+
+    widget.set_available_headers(["Name", "Lineitem sku", "Some other column"])
+
+    sku_input = widget.csv_column_inputs["SKU"]
+    assert [sku_input.itemText(i) for i in range(sku_input.count())] == [
+        "Name",
+        "Lineitem sku",
+        "Some other column",
+    ]
+    assert sku_input.currentText() == "Lineitem sku", "typed/configured text must survive"
+
+
+def test_the_widget_has_no_scroll_area_of_its_own(qapp):
+    """The page already scrolls. A second QScrollArea inside it clips the
+    Stock block to a few rows and produces two scrollbars side by side."""
+    page = MappingsPage(valid_column_mappings(), {})
+    assert page.orders_mapping_widget.findChildren(QScrollArea) == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py -v`
+Expected: all three FAIL — the inputs are `QLineEdit`, `set_available_headers` does not exist, and the widget holds a `QScrollArea`.
+
+- [ ] **Step 3: Rewrite the widget's UI half**
+
+In `gui/column_mapping_widget.py`, replace the imports:
+
+```python
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QComboBox, QVBoxLayout, QWidget
+
+from gui.components.form_section import FormSection
+```
+
+`Qt`, `QGroupBox`, `QHBoxLayout`, `QLabel`, `QLineEdit`, `QScrollArea`, `font_css` and
+`get_theme_manager` all become unused — remove them, `ruff` will fail otherwise.
+
+Replace `_setup_ui` and `_create_mapping_row` with:
+
+```python
+    def _setup_ui(self):
+        """Setup the UI layout.
+
+        No QScrollArea here: the settings page already scrolls, and nesting a
+        second one clips this widget to a few rows. One FormSection per group;
+        the internal field name is the row label, so the per-row
+        "Your CSV Column:" label and the -> arrow both go.
+        """
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        if self.required_fields:
+            required_section = FormSection("Required")
+            for internal_name in self.required_fields:
+                self._add_mapping_row(required_section, internal_name, required=True)
+            layout.addWidget(required_section)
+
+        if self.optional_fields:
+            optional_section = FormSection("Optional")
+            for internal_name in self.optional_fields:
+                self._add_mapping_row(optional_section, internal_name, required=False)
+            layout.addWidget(optional_section)
+
+    def _add_mapping_row(self, section, internal_name, required=False):
+        """Add one internal-field row to `section`.
+
+        Args:
+            section (FormSection): The section to append the row to.
+            internal_name (str): The internal field name (e.g. "Order_Number").
+            required (bool): Whether this field is required.
+        """
+        csv_input = QComboBox()
+        csv_input.setEditable(True)
+        csv_input.setInsertPolicy(QComboBox.NoInsert)
+        csv_input.lineEdit().setPlaceholderText("Enter column name...")
+        csv_input.setCurrentText(self.internal_to_csv.get(internal_name, ""))
+        csv_input.currentTextChanged.connect(lambda: self.mappings_changed.emit())
+
+        self.csv_column_inputs[internal_name] = csv_input
+        section.add_row(
+            f"{internal_name} *" if required else internal_name,
+            csv_input,
+            tooltip=self.FIELD_TOOLTIPS.get(
+                internal_name,
+                "Required — the save is blocked until this is mapped."
+                if required
+                else "",
+            ),
+        )
+```
+
+Add the tooltip table as a class attribute, directly under `mappings_changed`:
+
+```python
+    # Only fields whose effect is not obvious from the name. A warehouse
+    # operator setting up lot tracking has no other way to learn what these do.
+    FIELD_TOOLTIPS: ClassVar[dict[str, str]] = {
+        "Expiry_Date": (
+            "Optional. When mapped, stock is allocated oldest-expiry-first (FIFO) "
+            "and each packing list row shows the lot it came from.\n"
+            "Understood formats: YYMMDD, YYYYMMDD, DDMMYY, MMYY."
+        ),
+        "Batch": (
+            "Optional. Lot or batch number. Shown per lot on packing lists, and "
+            "used to keep separate deliveries of the same SKU apart."
+        ),
+    }
+```
+
+with `from typing import ClassVar` at the top.
+
+- [ ] **Step 4: Switch the three readers to the combo box API**
+
+In the same file, `get_mappings` (rewritten in Task 2) — change:
+
+```python
+                csv_column = input_widget.text().strip()
+```
+
+to:
+
+```python
+                csv_column = input_widget.currentText().strip()
+```
+
+In `validate_mappings`, change:
+
+```python
+            csv_column = self.csv_column_inputs[internal_name].text().strip()
+```
+
+to:
+
+```python
+            csv_column = self.csv_column_inputs[internal_name].currentText().strip()
+```
+
+In `set_mappings`, change:
+
+```python
+            input_widget.setText(csv_column)
+```
+
+to:
+
+```python
+            input_widget.setCurrentText(csv_column)
+```
+
+- [ ] **Step 5: Add `set_available_headers`**
+
+Append to the class:
+
+```python
+    def set_available_headers(self, headers):
+        """Offer `headers` as dropdown options on every row.
+
+        The text already in each box is preserved -- a configured mapping
+        whose column is absent from the file the user just picked must not be
+        wiped by looking at that file. A header already used by another row is
+        still offered; validate_mappings() catches the duplicate on Save,
+        which is where that error belongs.
+
+        Args:
+            headers (list): Column names read from a CSV.
+        """
+        for input_widget in self.csv_column_inputs.values():
+            current = input_widget.currentText()
+            input_widget.clear()
+            input_widget.addItems(headers)
+            input_widget.setCurrentText(current)
+```
+
+`clear()` on an editable `QComboBox` also clears its line edit, which is why `current` is
+read first and restored after.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py tests/test_settings_roundtrip.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full suite and the linter**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest && .venv/bin/ruff check . --exclude shared`
+Expected: all pass, ruff clean. If ruff reports unused imports in `column_mapping_widget.py`, Step 3's import cleanup was incomplete.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add gui/column_mapping_widget.py tests/test_settings_page_mappings.py
+git commit -m "refactor(settings): rebuild mapping rows on FormSection, drop the nested scroll area"
+```
+
+---
+
+### Task 6: Split Mappings into Orders and Stock nav pages
+
+**Files:**
+- Modify: `gui/settings/mappings.py` (whole file — `MappingsPage` becomes two classes)
+- Modify: `gui/settings/window.py:59` (nav group) and `:150-156` (page registration)
+- Test: `tests/test_settings_page_mappings.py`, `tests/test_settings_roundtrip.py`
+
+**Interfaces:**
+- Consumes: `SettingsPage` (`gui/settings/base.py`), `ColumnMappingWidget` incl. `set_available_headers` from Task 5.
+- Produces:
+  - `OrdersMappingPage(column_mappings: dict, courier_mappings: dict, parent=None)` — attributes `orders_mapping_widget`, `courier_mapping_widgets`, method `add_courier_mapping_row`, `_delete_courier_row`. `collect()` returns `{"column_mappings": ..., "courier_mappings": ...}`.
+  - `StockMappingPage(column_mappings: dict, parent=None)` — attribute `stock_mapping_widget`. `collect()` returns `{"column_mappings": ...}`.
+  - `MappingsPage` is **gone**. Both classes live in `gui/settings/mappings.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Rewrite `tests/test_settings_page_mappings.py`'s imports and add these; every existing
+`MappingsPage(...)` call in the file becomes the matching new class (the courier tests
+move to `OrdersMappingPage`, the stock tests to `StockMappingPage`, and
+`test_mappings_page_round_trips_valid_mappings` splits in two).
+
+```python
+def test_both_pages_collect_into_one_live_column_mappings_dict(qapp):
+    """Two pages now own one config key. Each must write only its own sub-key
+    in place -- a clear() or a freshly built dict in either one wipes the
+    other's work, and _pages order decides who loses."""
+    column_mappings = valid_column_mappings()
+    orders_page = OrdersMappingPage(column_mappings, {})
+    stock_page = StockMappingPage(column_mappings)
+
+    stock_page.collect()
+    orders_page.collect()
+
+    assert column_mappings["orders"]["Lineitem sku"] == "SKU"
+    assert column_mappings["stock"]["Article"] == "SKU"
+    assert column_mappings["version"] == 2
+
+
+def test_collect_order_does_not_matter(qapp):
+    column_mappings = valid_column_mappings()
+    orders_page = OrdersMappingPage(column_mappings, {})
+    stock_page = StockMappingPage(column_mappings)
+
+    orders_page.collect()
+    result = stock_page.collect()["column_mappings"]
+
+    assert set(result) == {"version", "orders", "stock"}
+    assert result["orders"] and result["stock"]
+
+
+def test_stock_page_collect_emits_every_stock_key_it_was_built_with(qapp):
+    """Key coverage for the live-dict blind spot: collect() returns the same
+    object the page was constructed with, so the roundtrip guard in
+    test_settings_roundtrip.py cannot see a dropped sub-key here. Detach
+    first, then assert on what collect() actively writes."""
+    column_mappings = valid_column_mappings()
+    column_mappings["stock"] = {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Name": "Product_Name",
+        "Exp date": "Expiry_Date",
+        "Lot": "Batch",
+    }
+    page = StockMappingPage(column_mappings)
+
+    page.column_mappings = {}  # detach from the live dict
+    written = page.collect()["column_mappings"]["stock"]
+
+    assert set(written.values()) == {"SKU", "Stock", "Product_Name", "Expiry_Date", "Batch"}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py -v`
+Expected: FAIL — `ImportError: cannot import name 'OrdersMappingPage'`
+
+- [ ] **Step 3: Split the page**
+
+Rewrite `gui/settings/mappings.py`. `OrdersMappingPage` keeps the courier block verbatim
+(`add_courier_mapping_row`, `_delete_courier_row` and their imports move with it);
+`StockMappingPage` is the stock half.
+
+```python
+"""Column mappings, split one page per CSV: orders (plus courier name
+mappings, which resolve an orders column) and stock."""
+
+from typing import ClassVar
+
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from gui.column_mapping_widget import ColumnMappingWidget
+from gui.components.form_section import FormSection
+from gui.settings.base import SettingsPage
+from gui.theme_manager import get_theme_manager, set_button_role
+
+
+class _MappingPageBase(SettingsPage):
+    """Shared scaffolding: one scroll area, one column-mapping widget.
+
+    Both pages hold the SAME live config_data["column_mappings"] dict and
+    write only their own sub-key into it, in place. Never clear() it and
+    never rebuild it -- whichever page collect()s second would wipe the
+    other's sub-key, and _pages order would silently decide which.
+    """
+
+    MAPPING_TYPE = ""
+    TITLE = ""
+    DESCRIPTION = ""
+    # ClassVar, not a bare annotation: ruff's RUF012 rejects a mutable class
+    # attribute without it, and window.py already uses this for the same reason.
+    REQUIRED_FIELDS: ClassVar[list[str]] = []
+    OPTIONAL_FIELDS: ClassVar[list[str]] = []
+
+    def __init__(self, column_mappings: dict, parent=None):
+        super().__init__(parent)
+        self.column_mappings = column_mappings
+
+        main_layout = QVBoxLayout(self)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll_widget = QWidget()
+        self.scroll_layout = QVBoxLayout(scroll_widget)
+
+        box = FormSection(self.TITLE, self.DESCRIPTION)
+        self.mapping_widget = ColumnMappingWidget(
+            mapping_type=self.MAPPING_TYPE,
+            current_mappings=column_mappings.get(self.MAPPING_TYPE, {}),
+            required_fields=self.REQUIRED_FIELDS,
+            optional_fields=self.OPTIONAL_FIELDS,
+        )
+        box.add_widget(self.mapping_widget)
+        self.scroll_layout.addWidget(box)
+
+        scroll.setWidget(scroll_widget)
+        main_layout.addWidget(scroll)
+
+    def validate(self) -> tuple[bool, list[str]]:
+        ok, error = self.mapping_widget.validate_mappings()
+        if not ok:
+            return False, [f"{self.TITLE} is invalid:\n{error}"]
+        return True, []
+
+    def _collect_column_mappings(self) -> dict:
+        """Write this page's sub-key into the live dict and return it."""
+        self.column_mappings["version"] = 2
+        self.column_mappings[self.MAPPING_TYPE] = self.mapping_widget.get_mappings()
+        return self.column_mappings
+
+
+class OrdersMappingPage(_MappingPageBase):
+    """Orders CSV columns, plus the courier name mappings that resolve the
+    Shipping_Method values those columns carry."""
+
+    MAPPING_TYPE = "orders"
+    TITLE = "Orders CSV Column Mapping"
+    DESCRIPTION = "Map your CSV column names to internal fields for the ORDERS file."
+    REQUIRED_FIELDS: ClassVar[list[str]] = [
+        "Order_Number", "SKU", "Quantity", "Shipping_Method",
+    ]
+    OPTIONAL_FIELDS: ClassVar[list[str]] = [
+        "Product_Name", "Shipping_Country", "Tags", "Notes", "Total_Price", "Subtotal",
+    ]
+
+    def __init__(self, column_mappings: dict, courier_mappings: dict, parent=None):
+        super().__init__(column_mappings, parent)
+        self.courier_mappings = courier_mappings
+        self.courier_mapping_widgets = []
+        self.orders_mapping_widget = self.mapping_widget  # name used by tests/callers
+
+        courier_box = FormSection(
+            "Courier Mappings",
+            "Map different shipping provider names to standardized courier codes. "
+            "You can specify multiple patterns (comma-separated) for each courier.",
+        )
+        self.courier_mappings_container = QWidget()
+        self.courier_mappings_layout = QVBoxLayout(self.courier_mappings_container)
+        self.courier_mappings_layout.setContentsMargins(0, 0, 0, 0)
+        courier_box.add_widget(self.courier_mappings_container)
+
+        add_courier_btn = QPushButton("+ Add Courier Mapping")
+        set_button_role(add_courier_btn, "secondary")
+        add_courier_btn.clicked.connect(lambda: self.add_courier_mapping_row())
+        add_courier_btn.setMaximumWidth(200)
+        courier_box.add_widget(add_courier_btn)
+
+        self.scroll_layout.addWidget(courier_box)
+        self.scroll_layout.addStretch()
+
+        if isinstance(courier_mappings, dict):
+            for courier_code, mapping_data in courier_mappings.items():
+                if isinstance(mapping_data, dict):
+                    patterns = mapping_data.get("patterns", [])
+                    self.add_courier_mapping_row(courier_code, ", ".join(patterns) if patterns else "")
+
+        if not courier_mappings:
+            self.add_courier_mapping_row()
+
+    def collect(self) -> dict:
+        new_couriers = {}
+        for row_refs in self.courier_mapping_widgets:
+            courier_code = row_refs["courier_code"].text().strip()
+            patterns_str = row_refs["patterns"].text().strip()
+            if courier_code and patterns_str:
+                patterns = [p.strip() for p in patterns_str.split(',') if p.strip()]
+                new_couriers[courier_code] = {"patterns": patterns, "case_sensitive": False}
+
+        # Same live-dict contract as column_mappings: clear-and-refill in
+        # place so a deleted courier code does not survive the shell's merge.
+        self.courier_mappings.clear()
+        self.courier_mappings.update(new_couriers)
+
+        return {
+            "column_mappings": self._collect_column_mappings(),
+            "courier_mappings": self.courier_mappings,
+        }
+```
+
+`add_courier_mapping_row` and `_delete_courier_row` move onto `OrdersMappingPage`
+**unchanged** from `mappings.py:121-176` — copy them verbatim, including the
+`accent_red` stylesheet and its comment.
+
+```python
+class StockMappingPage(_MappingPageBase):
+    """Stock CSV columns, including the two that drive FIFO lot allocation."""
+
+    MAPPING_TYPE = "stock"
+    TITLE = "Stock CSV Column Mapping"
+    DESCRIPTION = "Map your CSV column names to internal fields for the STOCK file."
+    REQUIRED_FIELDS: ClassVar[list[str]] = ["SKU", "Stock"]
+    # Expiry_Date and Batch are the exact internal names _build_fifo_lots()
+    # looks for (shopify_tool/analysis.py:96-97) -- renaming them here
+    # silently turns FIFO lot allocation off.
+    OPTIONAL_FIELDS: ClassVar[list[str]] = ["Product_Name", "Expiry_Date", "Batch"]
+
+    def __init__(self, column_mappings: dict, parent=None):
+        super().__init__(column_mappings, parent)
+        self.stock_mapping_widget = self.mapping_widget  # name used by tests/callers
+        self.scroll_layout.addStretch()
+
+    def collect(self) -> dict:
+        return {"column_mappings": self._collect_column_mappings()}
+```
+
+- [ ] **Step 4: Register both pages in the window**
+
+In `gui/settings/window.py`, change the import at line 24:
+
+```python
+from gui.settings.mappings import OrdersMappingPage, StockMappingPage
+```
+
+Change the nav group at line 59:
+
+```python
+        ("Data", ["General", "Orders Mapping", "Stock Mapping", "Column Config"]),
+```
+
+Replace the registration at lines 150-156:
+
+```python
+        self._add_page(
+            OrdersMappingPage(
+                self.config_data.get("column_mappings", {}),
+                self.config_data.get("courier_mappings", {}),
+            ),
+            "Orders Mapping",
+        )
+        self._add_page(
+            StockMappingPage(self.config_data.get("column_mappings", {})),
+            "Stock Mapping",
+        )
+```
+
+No nav migration is needed: `_restore_nav_selection` matches by name and falls back to
+the first selectable row when the stored name is gone (`window.py:221-233`), so a user
+whose last page was `"Mappings"` lands on General.
+
+- [ ] **Step 5: Update the roundtrip test's page-count expectation**
+
+`test_window_registers_every_page` (`tests/test_settings_roundtrip.py:18`) asserts on the
+registration order. Replace its list:
+
+```python
+def test_window_registers_every_page(window):
+    assert list(window._page_index_by_name) == [
+        "General", "Rules", "Packing Lists", "Stock Exports",
+        "Orders Mapping", "Stock Mapping",
+        "Sets", "Weight", "Tag Categories", "Column Config",
+    ]
+```
+
+The order is registration order, not nav order — `OrdersMappingPage` and
+`StockMappingPage` are registered where the single `MappingsPage` call used to be.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py tests/test_settings_roundtrip.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Verify the key-coverage test actually bites**
+
+Temporarily change `StockMappingPage.OPTIONAL_FIELDS` to `["Product_Name"]` and run:
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py -k emits_every_stock_key -v`
+Expected: FAIL. If it passes, the test is not detached from the live dict and is comparing an object to itself — fix it before continuing. **Revert the temporary change.**
+
+- [ ] **Step 8: Run the full suite and the linter**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest && .venv/bin/ruff check . --exclude shared`
+Expected: all pass, ruff clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add gui/settings/mappings.py gui/settings/window.py tests/
+git commit -m "refactor(settings): split Mappings into Orders and Stock nav pages"
+```
+
+---
+
+### Task 7: "Load headers from CSV…"
+
+**Files:**
+- Modify: `gui/settings/mappings.py` (`_MappingPageBase`)
+- Test: `tests/test_settings_page_mappings.py`
+
+**Interfaces:**
+- Consumes: `read_csv_headers(file_path, encoding="utf-8-sig") -> list[str]` (Task 1); `ColumnMappingWidget.set_available_headers(headers)` (Task 5).
+- Produces: `_MappingPageBase._load_headers_from_csv()` on both pages, plus a `load_headers_btn` attribute.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_settings_page_mappings.py`:
+
+```python
+def test_load_headers_fills_every_row_from_the_chosen_file(qapp, tmp_path, monkeypatch):
+    csv = tmp_path / "stock.csv"
+    csv.write_text("Article;Available;Exp date;Lot\nA1;5;261230;L7\n", encoding="utf-8")
+
+    page = StockMappingPage(valid_column_mappings())
+    monkeypatch.setattr(
+        "gui.settings.mappings.QFileDialog.getOpenFileName",
+        lambda *a, **k: (str(csv), ""),
+    )
+
+    page._load_headers_from_csv()
+
+    sku_input = page.stock_mapping_widget.csv_column_inputs["SKU"]
+    assert [sku_input.itemText(i) for i in range(sku_input.count())] == [
+        "Article", "Available", "Exp date", "Lot",
+    ]
+    assert sku_input.currentText() == "Article", "the configured mapping must survive"
+
+
+def test_load_headers_cancelled_leaves_the_inputs_alone(qapp, monkeypatch):
+    page = StockMappingPage(valid_column_mappings())
+    monkeypatch.setattr(
+        "gui.settings.mappings.QFileDialog.getOpenFileName", lambda *a, **k: ("", "")
+    )
+
+    page._load_headers_from_csv()
+
+    sku_input = page.stock_mapping_widget.csv_column_inputs["SKU"]
+    assert sku_input.count() == 0
+    assert sku_input.currentText() == "Article"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py -k load_headers -v`
+Expected: FAIL — `AttributeError: 'StockMappingPage' object has no attribute '_load_headers_from_csv'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `gui/settings/mappings.py`, extend the imports:
+
+```python
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from shopify_tool.csv_utils import read_csv_headers
+```
+
+In `_MappingPageBase.__init__`, immediately after `box = FormSection(...)` and before
+`box.add_widget(self.mapping_widget)`:
+
+```python
+        self.load_headers_btn = QPushButton("Load headers from CSV...")
+        set_button_role(self.load_headers_btn, "secondary")
+        self.load_headers_btn.setMaximumWidth(220)
+        self.load_headers_btn.setToolTip(
+            "Pick your CSV to fill each field's dropdown with its real column "
+            "names. Nothing you have already typed is changed."
+        )
+        self.load_headers_btn.clicked.connect(self._load_headers_from_csv)
+        box.add_widget(self.load_headers_btn)
+```
+
+Add the handler to `_MappingPageBase`:
+
+```python
+    def _load_headers_from_csv(self):
+        """Offer a chosen CSV's column names as dropdown options on every row.
+
+        Reads the header line only, and detects the delimiter itself, so this
+        does not depend on the delimiter the General page currently shows --
+        which may hold an edit the user has not saved yet.
+        """
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            f"Select {self.MAPPING_TYPE.capitalize()} CSV",
+            "",
+            "CSV Files (*.csv);;All Files (*)",
+        )
+        if not file_path:
+            return
+
+        try:
+            headers = read_csv_headers(file_path)
+        except Exception as e:
+            QMessageBox.warning(
+                self,
+                "Could Not Read CSV",
+                f"Failed to read column names from this file:\n\n{e!s}",
+            )
+            return
+
+        if not headers:
+            QMessageBox.warning(
+                self, "No Columns Found", "That file has no column headers."
+            )
+            return
+
+        self.mapping_widget.set_available_headers(headers)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_settings_page_mappings.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full gate**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest && .venv/bin/ruff check . --exclude shared`
+Expected: full suite green, ruff clean.
+
+- [ ] **Step 6: Refresh the knowledge graph**
+
+Run: `graphify update .`
+
+Per this repo's `CLAUDE.md` — a stale graph silently returns wrong answers about
+`shared/` ownership and theme delegation. `graphify-out/` is gitignored; nothing to
+commit from this step.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/settings/mappings.py tests/test_settings_page_mappings.py
+git commit -m "feat(settings): load real CSV headers into the mapping dropdowns"
+```
+
+---
+
+## Notes for the implementer
+
+**Task ordering is deliberate.** Tasks 2-4 fix the defect and can ship on their own if the
+UI work stalls; tasks 5-7 are the visible half. Do not reorder — Task 5 changes the input
+widget type that Tasks 2 and 3 write tests against, and it updates those call sites as
+part of its own step list.
+
+**One churn point, accepted:** Task 2 writes `.text()` and Task 5 changes it to
+`.currentText()`. That is the price of landing the data-loss fix before the UI rewrite,
+and it is one line in each of three methods.
+
+**The live-dict contract is the trap in this change.** Two pages now own
+`config_data["column_mappings"]`. `test_no_page_silently_drops_a_field` cannot see a
+dropped sub-key when `collect()` returns the same object the page was built from — that
+is why Task 6 Step 7 mutation-checks the key-coverage test by hand. This is the same
+blind spot the Settings Hub review found in `GeneralPage` and `WeightPage`; do not skip
+the check.
+
+**Windows visual verification is not possible here.** Development is on Linux; the app is
+Windows-only in production. The screenshots this design was built from came from the user.
+Leave the visual check to them and say so in the PR.

--- a/docs/superpowers/specs/2026-08-13-mappings-ui-design.md
+++ b/docs/superpowers/specs/2026-08-13-mappings-ui-design.md
@@ -1,0 +1,318 @@
+# Mappings: better UI, expiry/lot fields in the Stock CSV mapping
+
+Date: 2026-08-13
+Todoist: Phase 6 subtask `6h8v4Vm8RGcFw2H3`
+Branch: `worktree-mappings-ui`
+
+## Why this is not only a UI ticket
+
+The ticket reads as a redesign plus two new fields. Reading the code first turned up a
+data-loss defect underneath it, which changes what the work has to be.
+
+`ColumnMappingWidget.get_mappings()` builds its result by walking
+`required_fields + optional_fields` and reading the matching input box
+(`gui/column_mapping_widget.py:179-188`). Anything mapped in the client config whose
+internal name is not in those two lists cannot be represented, so it is not returned.
+`MappingsPage.collect()` then writes that result in as the whole `stock` sub-dict
+(`gui/settings/mappings.py:206`).
+
+`MappingsPage` declares `stock_optional = ["Product_Name"]` (`mappings.py:67`). The
+default client config ships five stock mappings, two of which drive lot tracking
+(`shopify_tool/profile_manager.py:386-391`):
+
+```
+"stock": {"Артикул": "SKU", "Име": "Product_Name",
+          "Наличност": "Stock", "Годност": "Expiry_Date", "Партида": "Batch"}
+```
+
+So opening Settings and pressing Save destroys the `Expiry_Date` and `Batch` mappings.
+Measured on this branch's base:
+
+```
+$ QT_QPA_PLATFORM=offscreen python -c "...MappingsPage(cm, {}).collect()..."
+stock after save: {'Артикул': 'SKU', 'Наличност': 'Stock', 'Име': 'Product_Name'}
+```
+
+In production this is masked. `shopify_tool/analysis.py:219` re-injects the two
+Bulgarian header names whenever they are absent from the mapping:
+
+```python
+missing = {k: v for k, v in _LOT_COLUMN_DEFAULTS.items() if k not in stock_mappings}
+```
+
+The mask only covers clients whose stock CSV uses the literal headers `Годност` and
+`Партида`. A client who maps `Expiry` or `Exp date` loses FIFO lot allocation
+permanently on the first Save, with no error — `_build_fifo_lots()` returns `None` the
+moment neither column survives the rename (`analysis.py:96-99`), and the run silently
+falls back to the legacy no-lot path.
+
+Two reasons the existing guard test did not catch it. `test_no_page_silently_drops_a_field`
+(`tests/test_settings_roundtrip.py:40`) compares each page's `collect()` output to a
+pre-collect deepcopy, and it does bite for `MappingsPage` — but the fixture's stock
+mapping is `{"Article": "SKU", "Available": "Stock"}` (`tests/conftest.py:163`), which
+contains nothing droppable. And `tests/test_settings_page_mappings.py` round-trips only
+mappings the widget already knows about.
+
+This is also why the ticket exists in the shape it does: the 2026-07-29 lot data-model
+spec explicitly deferred the mapping UI here, on the grounds that "the backend mapping
+mechanism already supports this today" (`2026-07-29-tags-lot-data-model-design.md:117-122`).
+It does support it. The settings window is what takes it away.
+
+## What the Windows screenshots show
+
+The user's 2026-08-13 Windows build screenshots (Todoist, epic `6hG88Vx9CgRHVgG3`) give
+the visual half:
+
+- **Two scrollbars.** `ColumnMappingWidget` wraps its rows in a `QScrollArea`
+  (`column_mapping_widget.py:73`) and `MappingsPage` wraps the whole page in another
+  (`mappings.py:34`). The inner one clips the Stock block to a few rows inside an
+  already-scrolling page.
+- **`"Your CSV Column:"` twelve times.** One fixed-width label per row
+  (`column_mapping_widget.py:120`) saying the same thing the section title says once.
+- **The `→` arrow and a right-hand `*` column** spend a third of the row width on
+  decoration, pushing the actual inputs into the left half of a 1626px window.
+- **Headers are typed from memory.** Nothing in the dialog can tell you what the CSV
+  actually contains, so a typo produces a mapping that silently does not apply — the
+  rename map skips columns not present in the DataFrame (`analysis.py:234-238`).
+
+## Decisions taken with the user
+
+| Question | Answer |
+|---|---|
+| CSV-column input | Free text, plus a **"Load headers from CSV…"** button per page. The picker reads the file and turns the row inputs into dropdowns of its real headers. |
+| `Position` field | **Left out.** Nothing in the codebase reads one; it goes in the day a feature needs it. |
+| UI scope | Rebuild the rows **and** split Orders and Stock into separate nav pages. |
+
+## Design
+
+### 1. Preserve unmanaged mappings (the defect fix)
+
+`get_mappings()` starts from the mappings it was constructed with and replaces only the
+internal names it manages:
+
+```python
+def get_mappings(self) -> dict:
+    managed = set(self.required_fields) | set(self.optional_fields)
+    # Entries for internal names this widget has no row for are carried through
+    # untouched -- a field missing from the two lists must not silently delete
+    # the client's mapping for it.
+    mappings = {csv: internal for csv, internal
+                in self.current_mappings.items() if internal not in managed}
+    for internal_name in self.required_fields + self.optional_fields:
+        csv_column = self.csv_column_inputs[internal_name].currentText().strip()
+        if csv_column:
+            mappings[csv_column] = internal_name
+    return mappings
+```
+
+`currentText()`, not `text()`: the inputs become editable `QComboBox`es in §6.
+`validate_mappings()` reads the same inputs (`column_mapping_widget.py:200`) and changes
+with them, as does the `mappings_changed` wiring — `currentTextChanged` in place of
+`textChanged` (`column_mapping_widget.py:133`).
+
+Clearing a box still removes that mapping — the field is managed, so its old entry was
+never carried over. Only genuinely unknown internal names survive.
+
+This is the root-cause fix and it is deliberately independent of the field list below.
+Adding `Expiry_Date`/`Batch` to `stock_optional` fixes the two fields we know about;
+this fixes the class. Both land.
+
+### 2. Expiry and Batch become real rows
+
+```python
+stock_optional = ["Product_Name", "Expiry_Date", "Batch"]
+```
+
+Nothing else is needed to make them work: `_build_fifo_lots()` already keys off the
+internal names `Expiry_Date` and `Batch` (`analysis.py:96-97`), the default config
+already maps them, and packing lists already expand per lot
+(`shopify_tool/packing_lists.py:13-20`). The only missing piece was the GUI, exactly as
+the lot spec predicted.
+
+Both rows get tooltips explaining what the backend does with them — FIFO ordering by
+expiry, batch shown per lot on the packing list — because a warehouse operator setting
+this up has no other way to learn that.
+
+### 3. `_LOT_COLUMN_DEFAULTS` stays, with one correction
+
+The injection at `analysis.py:216-221` is kept. Every client who has ever opened Settings
+and saved already has the mapping stripped from their stored config; removing the
+fallback in the same change would break lot tracking for all of them at once.
+
+It gains one condition — skip a default whose *internal name* is already mapped:
+
+```python
+mapped_internals = set(stock_mappings.values())
+missing = {k: v for k, v in _LOT_COLUMN_DEFAULTS.items()
+           if k not in stock_mappings and v not in mapped_internals}
+```
+
+Without this, a client who maps `Exp date → Expiry_Date` in the new UI also gets
+`Годност → Expiry_Date` injected. Harmless today (the rename skips absent columns) but it
+is two CSV headers claiming one internal name, which the widget's own duplicate check
+would reject if it ever saw it.
+
+The fallback becomes removable once configs have been re-saved through the fixed UI.
+Marked with a `ponytail:` comment naming that, not scheduled here.
+
+### 4. The page split
+
+`MappingsPage` becomes two pages in `gui/settings/mappings.py`:
+
+| Page | Nav entry | Owns |
+|---|---|---|
+| `OrdersMappingPage` | Data → Orders Mapping | `column_mappings["orders"]`, `courier_mappings` |
+| `StockMappingPage` | Data → Stock Mapping | `column_mappings["stock"]` |
+
+Courier mappings go with Orders because they resolve `Shipping_Method` values, which is
+an orders column. A fifth nav entry for one small block is not worth the sidebar row.
+
+**Both pages hold the same live `column_mappings` dict** and mutate only their own
+sub-key in place:
+
+```python
+def collect(self) -> dict:
+    self.column_mappings["version"] = 2
+    self.column_mappings["orders"] = self.orders_mapping_widget.get_mappings()
+    return {"column_mappings": self.column_mappings, "courier_mappings": ...}
+```
+
+No `clear()`. The current code clears and refills because one page owned the whole dict;
+with two owners a `clear()` in the second page to run would wipe the first one's work.
+In-place per-key assignment makes the result independent of `_pages` order, and both
+pages returning the same object under the same key means the shell's
+`config_data[key] = value` loop (`window.py:259-261`) is a no-op for the second one.
+
+This is the live-dict contract `SettingsPage` already documents, and it carries the known
+cost: `test_no_page_silently_drops_a_field` compares `collect()`'s value to a pre-collect
+deepcopy, and the sub-dicts are rebuilt fresh inside a live parent, so it still bites at
+the `column_mappings` level. Per-page key coverage is added anyway (§6) — the Settings Hub
+review established that every page on this contract needs it.
+
+Nav group becomes:
+
+```python
+("Data", ["General", "Orders Mapping", "Stock Mapping", "Column Config"]),
+```
+
+`_restore_nav_selection()` looks pages up by name and falls back to the first entry when
+the stored name is gone (`window.py:221-233`), so a user whose last page was `"Mappings"`
+lands on General instead of crashing. No migration needed.
+
+### 5. The rebuilt row
+
+`ColumnMappingWidget` keeps its class name and public API (`get_mappings`,
+`validate_mappings`, `set_mappings`, `mappings_changed`) so `mappings.py` and the existing
+tests keep working. `_setup_ui` and `_create_mapping_row` are replaced:
+
+- Rows are built with `FormSection.add_row(label, widget, tooltip)` — the internal field
+  name is the row label, the input is the widget. The `"Your CSV Column:"` label, the `→`
+  arrow and the trailing `*` column all go.
+- Required is marked on the label itself (`Order_Number *`) with the tooltip
+  `FormSection.add_row` already propagates to both label and input.
+- Two `FormSection`s per widget, `"Required"` and `"Optional"`, replacing the two
+  `QGroupBox`es. The page keeps one outer `QScrollArea`; the widget's inner one is
+  removed.
+
+```
+┌ Orders CSV Column Mapping ──────────────────────────┐
+│ Map your CSV column names to internal fields.       │
+│                            [ Load headers from CSV… ]│
+│ Required                                            │
+│   Order_Number *      [ Name                      ▾ ]│
+│   SKU          *      [ Lineitem sku              ▾ ]│
+│   Quantity     *      [ Lineitem quantity         ▾ ]│
+│   Shipping_Method *   [ Shipping Method           ▾ ]│
+│ Optional                                            │
+│   Product_Name        [ Lineitem name             ▾ ]│
+└─────────────────────────────────────────────────────┘
+```
+
+The `color: red` at `column_mapping_widget.py:153` disappears with the `*` column it
+styled — one of the two hardcoded colours the Settings Hub review flagged as still
+outstanding.
+
+### 6. Loading headers
+
+One button per page, above the sections. It opens a file picker, reads the header row and
+hands the names to every input on that page.
+
+New helper in `shopify_tool/csv_utils.py`, next to the delimiter detection it reuses:
+
+```python
+def read_csv_headers(file_path: str, encoding: str = "utf-8-sig") -> list[str]:
+    """Return the column names of a CSV without loading its rows."""
+    delimiter, _ = detect_csv_delimiter(file_path, encoding)
+    return list(pd.read_csv(file_path, sep=delimiter, encoding=encoding, nrows=0).columns)
+```
+
+`detect_csv_delimiter` already exists and already has a three-method fallback chain
+(`csv_utils.py:30`), so the page needs no delimiter plumbing and no dependency on which
+delimiter the General page is currently showing. `nrows=0` reads the header line only —
+this stays fast on a large stock export over a network share.
+
+Backend, not GUI, so it is testable without Qt.
+
+The row inputs are **editable `QComboBox`es from the start**, empty until headers are
+loaded, with the current mapping as their text and `"Enter column name…"` as placeholder.
+One widget type and one code path beats swapping `QLineEdit` for `QComboBox` at runtime
+and re-wiring every signal. `setInsertPolicy(NoInsert)` so typing does not append to the
+list. Typed text survives loading headers — `addItems` does not disturb the line edit.
+
+A header that is already used by another row is still offered; the existing duplicate
+checks in `validate_mappings()` (`column_mapping_widget.py:204-214`) catch it on Save,
+which is where the error belongs.
+
+If the file cannot be read the page shows a `QMessageBox.warning` with the exception text
+and leaves the inputs as they are. `WeightPage._import_skus_from_csv` sets this pattern
+(`gui/settings/weight.py:425-455`) — a file picker, a read, a warning box on failure.
+
+### 7. Testing
+
+| Test | Bites when |
+|---|---|
+| `tests/conftest.py`: fixture stock mapping gains `Годност`/`Партида` | The existing `test_no_page_silently_drops_a_field` fails on today's code — this alone is the regression test for the defect |
+| `get_mappings()` carries through an unmanaged internal name | The §1 fix is reverted or a field is dropped from the lists |
+| `StockMappingPage.collect()` emits every key of `column_mappings["stock"]` it was built with, after detaching the page from the live dict | A field vanishes from `stock_optional`; covers the live-dict blind spot §4 names |
+| `OrdersMappingPage` and `StockMappingPage` collect in either order without losing the other's sub-key | Someone reintroduces `clear()` or rebuilds `column_mappings` fresh |
+| `read_csv_headers()` on a `;`-delimited and a `,`-delimited fixture | Delimiter detection or the `nrows=0` read regresses |
+| Loading headers populates every combo and preserves typed text | The header wiring breaks |
+| `_LOT_COLUMN_DEFAULTS` is not injected when `Expiry_Date` is already mapped to another header | The §3 condition is dropped |
+
+Existing `tests/test_settings_page_mappings.py` is updated for the two new classes; its
+three cases stay meaningful.
+
+## Non-goals
+
+- **`Position`.** Excluded by decision. Nothing reads it; add it with the feature.
+- **A per-client expiry date format setting.** The `ponytail:` comment at
+  `analysis.py:32-35` already tracks it; no evidence yet of real ambiguity.
+- **Removing `_LOT_COLUMN_DEFAULTS`.** Kept as the back-compat path (§3).
+- **Touching the standalone Column Config dialog, or `shared/`.**
+- **The other three Phase 6 panels.** Rules, Tag Categories and Packing List/Stock Export
+  each keep their own ticket. This change does not move them into the pattern; it
+  establishes it.
+
+## Files
+
+| File | Change |
+|---|---|
+| `gui/column_mapping_widget.py` | `get_mappings()` preserves unmanaged entries; rows rebuilt on `FormSection`; inner `QScrollArea` and the `*` column removed; `set_available_headers()` added |
+| `gui/settings/mappings.py` | `MappingsPage` → `OrdersMappingPage` + `StockMappingPage`; lot fields; per-key in-place collect; header button |
+| `gui/settings/window.py` | Two `_add_page` calls; nav group updated |
+| `shopify_tool/csv_utils.py` | `read_csv_headers()` |
+| `shopify_tool/analysis.py` | Injection skips already-mapped internal names |
+| `tests/conftest.py` | Fixture stock mapping gains the lot columns |
+| `tests/test_settings_page_mappings.py` | Updated for the split; new coverage per §7 |
+| `tests/test_csv_utils.py` | `read_csv_headers()` |
+
+## Open question for the user
+
+The Windows screenshots are the first look at Tracks 1-4 on the real platform and they
+answer the visual-check question that PR #273 left open. One thing they surface that is
+outside this ticket: in **Column Config**, both in the Hub and in the standalone "Manage
+Table Columns" dialog, the *Columns* list and the *Additional CSV Columns* list are each
+collapsed to about two visible rows while the page has vertical space to spare. That is a
+stretch-factor problem in `ColumnConfigPanel`, not in the Mappings page, and it looks like
+its own small ticket rather than something to fold in here. Flagging it rather than fixing
+it.

--- a/gui/column_mapping_widget.py
+++ b/gui/column_mapping_widget.py
@@ -5,19 +5,12 @@ Users can see the relationship between their CSV columns and the internal proces
 """
 
 import logging
+from typing import ClassVar
 
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtWidgets import (
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QScrollArea,
-    QVBoxLayout,
-    QWidget,
-)
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QComboBox, QVBoxLayout, QWidget
 
-from gui.theme_manager import font_css, get_theme_manager
+from gui.components.form_section import FormSection
 
 logger = logging.getLogger("ShopifyToolLogger")
 
@@ -39,6 +32,20 @@ class ColumnMappingWidget(QWidget):
 
     mappings_changed = Signal()
 
+    # Only fields whose effect is not obvious from the name. A warehouse
+    # operator setting up lot tracking has no other way to learn what these do.
+    FIELD_TOOLTIPS: ClassVar[dict[str, str]] = {
+        "Expiry_Date": (
+            "Optional. When mapped, stock is allocated oldest-expiry-first (FIFO) "
+            "and each packing list row shows the lot it came from.\n"
+            "Understood formats: YYMMDD, YYYYMMDD, DDMMYY, MMYY."
+        ),
+        "Batch": (
+            "Optional. Lot or batch number. Shown per lot on packing lists, and "
+            "used to keep separate deliveries of the same SKU apart."
+        ),
+    }
+
     def __init__(self, mapping_type, current_mappings=None, required_fields=None, optional_fields=None):
         super().__init__()
         self.mapping_type = mapping_type
@@ -55,117 +62,54 @@ class ColumnMappingWidget(QWidget):
         self._setup_ui()
 
     def _setup_ui(self):
-        """Setup the UI layout."""
+        """Setup the UI layout.
+
+        No QScrollArea here: the settings page already scrolls, and nesting a
+        second one clips this widget to a few rows. One FormSection per group;
+        the internal field name is the row label, so the per-row
+        "Your CSV Column:" label and the -> arrow both go.
+        """
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Instructions
-        instructions = QLabel(
-            f"Map your CSV column names to internal fields for {self.mapping_type.upper()} file.\n"
-            f"Fields marked with * are required."
-        )
-        instructions.setWordWrap(True)
-        theme = get_theme_manager().get_current_theme()
-        instructions.setStyleSheet(f"color: {theme.text_secondary}; font-style: italic; padding: 5px;")
-        layout.addWidget(instructions)
-
-        # Scroll area for mappings
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll_widget = QWidget()
-        scroll_layout = QVBoxLayout(scroll_widget)
-
-        # Required fields section
         if self.required_fields:
-            required_group = QGroupBox("Required Fields *")
-            required_group.setStyleSheet("QGroupBox { font-weight: bold; }")
-            required_layout = QVBoxLayout(required_group)
-
+            required_section = FormSection("Required")
             for internal_name in self.required_fields:
-                row_widget = self._create_mapping_row(internal_name, required=True)
-                required_layout.addWidget(row_widget)
+                self._add_mapping_row(required_section, internal_name, required=True)
+            layout.addWidget(required_section)
 
-            scroll_layout.addWidget(required_group)
-
-        # Optional fields section
         if self.optional_fields:
-            optional_group = QGroupBox("Optional Fields")
-            optional_layout = QVBoxLayout(optional_group)
-
+            optional_section = FormSection("Optional")
             for internal_name in self.optional_fields:
-                row_widget = self._create_mapping_row(internal_name, required=False)
-                optional_layout.addWidget(row_widget)
+                self._add_mapping_row(optional_section, internal_name, required=False)
+            layout.addWidget(optional_section)
 
-            scroll_layout.addWidget(optional_group)
-
-        scroll_layout.addStretch()
-        scroll.setWidget(scroll_widget)
-        layout.addWidget(scroll)
-
-    def _create_mapping_row(self, internal_name, required=False):
-        """Create a single mapping row.
+    def _add_mapping_row(self, section, internal_name, required=False):
+        """Add one internal-field row to `section`.
 
         Args:
-            internal_name (str): The internal field name (e.g., "Order_Number")
-            required (bool): Whether this field is required
-
-        Returns:
-            QWidget: Widget containing the mapping row
+            section (FormSection): The section to append the row to.
+            internal_name (str): The internal field name (e.g. "Order_Number").
+            required (bool): Whether this field is required.
         """
-        row_widget = QWidget()
-        row_layout = QHBoxLayout(row_widget)
-        row_layout.setContentsMargins(5, 3, 5, 3)
+        csv_input = QComboBox()
+        csv_input.setEditable(True)
+        csv_input.setInsertPolicy(QComboBox.NoInsert)
+        csv_input.lineEdit().setPlaceholderText("Enter column name...")
+        csv_input.setCurrentText(self.internal_to_csv.get(internal_name, ""))
+        csv_input.currentTextChanged.connect(lambda: self.mappings_changed.emit())
 
-        # CSV Column input (left side)
-        csv_label = QLabel("Your CSV Column:")
-        csv_label.setFixedWidth(120)
-
-        csv_input = QLineEdit()
-        csv_input.setPlaceholderText("Enter column name...")
-        csv_input.setMinimumWidth(200)
-
-        # Set current value if exists
-        current_csv_name = self.internal_to_csv.get(internal_name, "")
-        if current_csv_name:
-            csv_input.setText(current_csv_name)
-
-        # Connect change signal
-        csv_input.textChanged.connect(lambda: self.mappings_changed.emit())
-
-        # Store for later access
         self.csv_column_inputs[internal_name] = csv_input
-
-        # Arrow
-        arrow_label = QLabel("→")
-        arrow_label.setStyleSheet(font_css("heading"))
-        arrow_label.setFixedWidth(30)
-        arrow_label.setAlignment(Qt.AlignCenter)
-
-        # Internal name label (right side)
-        internal_label = QLabel(internal_name)
-        internal_label.setStyleSheet("font-family: monospace; font-weight: bold;")
-        internal_label.setFixedWidth(150)
-
-        # Required indicator
-        if required:
-            required_indicator = QLabel("*")
-            # Track 3 moves the literal red onto a theme token; only the size is in scope here.
-            required_indicator.setStyleSheet(f"color: red; {font_css('heading')}")
-            required_indicator.setFixedWidth(15)
-            required_indicator.setToolTip("This field is required")
-        else:
-            required_indicator = QLabel("")
-            required_indicator.setFixedWidth(15)
-
-        # Add to layout
-        row_layout.addWidget(csv_label)
-        row_layout.addWidget(csv_input, 1)
-        row_layout.addWidget(arrow_label)
-        row_layout.addWidget(internal_label)
-        row_layout.addWidget(required_indicator)
-        row_layout.addStretch()
-
-        return row_widget
+        section.add_row(
+            f"{internal_name} *" if required else internal_name,
+            csv_input,
+            tooltip=self.FIELD_TOOLTIPS.get(
+                internal_name,
+                "Required — the save is blocked until this is mapped."
+                if required
+                else "",
+            ),
+        )
 
     def get_mappings(self):
         """Get current mappings from UI.
@@ -192,7 +136,7 @@ class ColumnMappingWidget(QWidget):
         for internal_name in self.required_fields + self.optional_fields:
             input_widget = self.csv_column_inputs.get(internal_name)
             if input_widget:
-                csv_column = input_widget.text().strip()
+                csv_column = input_widget.currentText().strip()
                 if csv_column:  # Only add non-empty mappings
                     mappings[csv_column] = internal_name
 
@@ -208,7 +152,7 @@ class ColumnMappingWidget(QWidget):
 
         # Check that all required fields are mapped
         for internal_name in self.required_fields:
-            csv_column = self.csv_column_inputs[internal_name].text().strip()
+            csv_column = self.csv_column_inputs[internal_name].currentText().strip()
             if not csv_column:
                 return False, f"Required field '{internal_name}' must be mapped to a CSV column"
 
@@ -238,4 +182,22 @@ class ColumnMappingWidget(QWidget):
         # Update all input widgets
         for internal_name, input_widget in self.csv_column_inputs.items():
             csv_column = self.internal_to_csv.get(internal_name, "")
-            input_widget.setText(csv_column)
+            input_widget.setCurrentText(csv_column)
+
+    def set_available_headers(self, headers):
+        """Offer `headers` as dropdown options on every row.
+
+        The text already in each box is preserved -- a configured mapping
+        whose column is absent from the file the user just picked must not be
+        wiped by looking at that file. A header already used by another row is
+        still offered; validate_mappings() catches the duplicate on Save,
+        which is where that error belongs.
+
+        Args:
+            headers (list): Column names read from a CSV.
+        """
+        for input_widget in self.csv_column_inputs.values():
+            current = input_widget.currentText()
+            input_widget.clear()
+            input_widget.addItems(headers)
+            input_widget.setCurrentText(current)

--- a/gui/column_mapping_widget.py
+++ b/gui/column_mapping_widget.py
@@ -156,11 +156,22 @@ class ColumnMappingWidget(QWidget):
             if not csv_column:
                 return False, f"Required field '{internal_name}' must be mapped to a CSV column"
 
-        # Check for duplicate CSV column names
-        csv_columns = list(mappings.keys())
+        # Check for duplicate CSV column names.
+        #
+        # Read the boxes, not get_mappings() -- that returns a dict keyed by CSV
+        # column, so two rows sharing a column have already collapsed into one
+        # entry by then and the duplicate is invisible. Picking the same header
+        # twice from the dropdowns is easy, and the row that loses would be
+        # saved with no mapping at all.
+        csv_columns = [
+            self.csv_column_inputs[internal_name].currentText().strip()
+            for internal_name in self.required_fields + self.optional_fields
+            if internal_name in self.csv_column_inputs
+        ]
+        csv_columns = [col for col in csv_columns if col]
         if len(csv_columns) != len(set(csv_columns)):
-            duplicates = [col for col in csv_columns if csv_columns.count(col) > 1]
-            return False, f"Duplicate CSV column names: {', '.join(set(duplicates))}"
+            duplicates = {col for col in csv_columns if csv_columns.count(col) > 1}
+            return False, f"Duplicate CSV column names: {', '.join(sorted(duplicates))}"
 
         # Check that no two CSV columns map to the same internal name
         internal_names = list(mappings.values())

--- a/gui/column_mapping_widget.py
+++ b/gui/column_mapping_widget.py
@@ -170,15 +170,26 @@ class ColumnMappingWidget(QWidget):
     def get_mappings(self):
         """Get current mappings from UI.
 
+        Entries for internal names this widget has no row for are carried
+        through untouched. Without that, a field missing from
+        required_fields/optional_fields is silently deleted from the client's
+        config on every save -- which is exactly what happened to the
+        Expiry_Date and Batch mappings that drive FIFO lot allocation.
+
+        A *managed* field left blank is still removed: its old entry was
+        never carried over, so clearing a box does delete the mapping.
+
         Returns:
             dict: Dictionary of {csv_column_name: internal_name}
         """
-        mappings = {}
+        managed = set(self.required_fields) | set(self.optional_fields)
+        mappings = {
+            csv_column: internal_name
+            for csv_column, internal_name in self.current_mappings.items()
+            if internal_name not in managed
+        }
 
-        # Combine required and optional fields
-        all_fields = self.required_fields + self.optional_fields
-
-        for internal_name in all_fields:
+        for internal_name in self.required_fields + self.optional_fields:
             input_widget = self.csv_column_inputs.get(internal_name)
             if input_widget:
                 csv_column = input_widget.text().strip()

--- a/gui/settings/mappings.py
+++ b/gui/settings/mappings.py
@@ -4,9 +4,11 @@ mappings, which resolve an orders column) and stock."""
 from typing import ClassVar
 
 from PySide6.QtWidgets import (
+    QFileDialog,
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QMessageBox,
     QPushButton,
     QScrollArea,
     QVBoxLayout,
@@ -17,6 +19,7 @@ from gui.column_mapping_widget import ColumnMappingWidget
 from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
 from gui.theme_manager import get_theme_manager, set_button_role
+from shopify_tool.csv_utils import read_csv_headers
 
 
 class _MappingPageBase(SettingsPage):
@@ -47,6 +50,16 @@ class _MappingPageBase(SettingsPage):
         self.scroll_layout = QVBoxLayout(scroll_widget)
 
         box = FormSection(self.TITLE, self.DESCRIPTION)
+        self.load_headers_btn = QPushButton("Load headers from CSV...")
+        set_button_role(self.load_headers_btn, "secondary")
+        self.load_headers_btn.setMaximumWidth(220)
+        self.load_headers_btn.setToolTip(
+            "Pick your CSV to fill each field's dropdown with its real column "
+            "names. Nothing you have already typed is changed."
+        )
+        self.load_headers_btn.clicked.connect(self._load_headers_from_csv)
+        box.add_widget(self.load_headers_btn)
+
         self.mapping_widget = ColumnMappingWidget(
             mapping_type=self.MAPPING_TYPE,
             current_mappings=column_mappings.get(self.MAPPING_TYPE, {}),
@@ -70,6 +83,40 @@ class _MappingPageBase(SettingsPage):
         self.column_mappings["version"] = 2
         self.column_mappings[self.MAPPING_TYPE] = self.mapping_widget.get_mappings()
         return self.column_mappings
+
+    def _load_headers_from_csv(self):
+        """Offer a chosen CSV's column names as dropdown options on every row.
+
+        Reads the header line only, and detects the delimiter itself, so this
+        does not depend on the delimiter the General page currently shows --
+        which may hold an edit the user has not saved yet.
+        """
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            f"Select {self.MAPPING_TYPE.capitalize()} CSV",
+            "",
+            "CSV Files (*.csv);;All Files (*)",
+        )
+        if not file_path:
+            return
+
+        try:
+            headers = read_csv_headers(file_path)
+        except Exception as e:
+            QMessageBox.warning(
+                self,
+                "Could Not Read CSV",
+                f"Failed to read column names from this file:\n\n{e!s}",
+            )
+            return
+
+        if not headers:
+            QMessageBox.warning(
+                self, "No Columns Found", "That file has no column headers."
+            )
+            return
+
+        self.mapping_widget.set_available_headers(headers)
 
 
 class OrdersMappingPage(_MappingPageBase):

--- a/gui/settings/mappings.py
+++ b/gui/settings/mappings.py
@@ -62,9 +62,12 @@ class MappingsPage(SettingsPage):
         # ========================================
         stock_box = FormSection("Stock CSV Column Mapping")
 
-        # Define required and optional fields for stock
+        # Define required and optional fields for stock.
+        # Expiry_Date and Batch are the exact internal names _build_fifo_lots()
+        # looks for (shopify_tool/analysis.py:96-97) -- renaming them here
+        # silently turns FIFO lot allocation off.
         stock_required = ["SKU", "Stock"]
-        stock_optional = ["Product_Name"]
+        stock_optional = ["Product_Name", "Expiry_Date", "Batch"]
 
         stock_mappings = column_mappings.get("stock", {})
 

--- a/gui/settings/mappings.py
+++ b/gui/settings/mappings.py
@@ -1,4 +1,7 @@
-"""Column mappings (orders/stock) and courier-name mappings."""
+"""Column mappings, split one page per CSV: orders (plus courier name
+mappings, which resolve an orders column) and stock."""
+
+from typing import ClassVar
 
 from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -16,108 +19,104 @@ from gui.settings.base import SettingsPage
 from gui.theme_manager import get_theme_manager, set_button_role
 
 
-class MappingsPage(SettingsPage):
-    """Column and courier mappings, stored under config_data["column_mappings"]
-    and config_data["courier_mappings"]."""
+class _MappingPageBase(SettingsPage):
+    """Shared scaffolding: one scroll area, one column-mapping widget.
 
-    def __init__(self, column_mappings: dict, courier_mappings: dict, parent=None):
+    Both pages hold the SAME live config_data["column_mappings"] dict and
+    write only their own sub-key into it, in place. Never clear() it and
+    never rebuild it -- whichever page collect()s second would wipe the
+    other's sub-key, and _pages order would silently decide which.
+    """
+
+    MAPPING_TYPE = ""
+    TITLE = ""
+    DESCRIPTION = ""
+    # ClassVar, not a bare annotation: ruff's RUF012 rejects a mutable class
+    # attribute without it, and window.py already uses this for the same reason.
+    REQUIRED_FIELDS: ClassVar[list[str]] = []
+    OPTIONAL_FIELDS: ClassVar[list[str]] = []
+
+    def __init__(self, column_mappings: dict, parent=None):
         super().__init__(parent)
-        # Held by reference (not copied) so collect() can mutate them in place --
-        # see the comment on collect() for why that matters.
         self.column_mappings = column_mappings
-        self.courier_mappings = courier_mappings
-        self.courier_mapping_widgets = []
 
         main_layout = QVBoxLayout(self)
-
-        # Add scroll area for the entire tab
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll_widget = QWidget()
-        scroll_layout = QVBoxLayout(scroll_widget)
+        self.scroll_layout = QVBoxLayout(scroll_widget)
 
-        # ========================================
-        # COLUMN MAPPINGS - Orders
-        # ========================================
-        orders_box = FormSection("Orders CSV Column Mapping")
-
-        # Define required and optional fields for orders
-        orders_required = ["Order_Number", "SKU", "Quantity", "Shipping_Method"]
-        orders_optional = ["Product_Name", "Shipping_Country", "Tags", "Notes", "Total_Price", "Subtotal"]
-
-        orders_mappings = column_mappings.get("orders", {})
-
-        self.orders_mapping_widget = ColumnMappingWidget(
-            mapping_type="orders",
-            current_mappings=orders_mappings,
-            required_fields=orders_required,
-            optional_fields=orders_optional
+        box = FormSection(self.TITLE, self.DESCRIPTION)
+        self.mapping_widget = ColumnMappingWidget(
+            mapping_type=self.MAPPING_TYPE,
+            current_mappings=column_mappings.get(self.MAPPING_TYPE, {}),
+            required_fields=self.REQUIRED_FIELDS,
+            optional_fields=self.OPTIONAL_FIELDS,
         )
+        box.add_widget(self.mapping_widget)
+        self.scroll_layout.addWidget(box)
 
-        orders_box.add_widget(self.orders_mapping_widget)
-        scroll_layout.addWidget(orders_box)
+        scroll.setWidget(scroll_widget)
+        main_layout.addWidget(scroll)
 
-        # ========================================
-        # COLUMN MAPPINGS - Stock
-        # ========================================
-        stock_box = FormSection("Stock CSV Column Mapping")
+    def validate(self) -> tuple[bool, list[str]]:
+        ok, error = self.mapping_widget.validate_mappings()
+        if not ok:
+            return False, [f"{self.TITLE} is invalid:\n{error}"]
+        return True, []
 
-        # Define required and optional fields for stock.
-        # Expiry_Date and Batch are the exact internal names _build_fifo_lots()
-        # looks for (shopify_tool/analysis.py:96-97) -- renaming them here
-        # silently turns FIFO lot allocation off.
-        stock_required = ["SKU", "Stock"]
-        stock_optional = ["Product_Name", "Expiry_Date", "Batch"]
+    def _collect_column_mappings(self) -> dict:
+        """Write this page's sub-key into the live dict and return it."""
+        self.column_mappings["version"] = 2
+        self.column_mappings[self.MAPPING_TYPE] = self.mapping_widget.get_mappings()
+        return self.column_mappings
 
-        stock_mappings = column_mappings.get("stock", {})
 
-        self.stock_mapping_widget = ColumnMappingWidget(
-            mapping_type="stock",
-            current_mappings=stock_mappings,
-            required_fields=stock_required,
-            optional_fields=stock_optional
-        )
+class OrdersMappingPage(_MappingPageBase):
+    """Orders CSV columns, plus the courier name mappings that resolve the
+    Shipping_Method values those columns carry."""
 
-        stock_box.add_widget(self.stock_mapping_widget)
-        scroll_layout.addWidget(stock_box)
+    MAPPING_TYPE = "orders"
+    TITLE = "Orders CSV Column Mapping"
+    DESCRIPTION = "Map your CSV column names to internal fields for the ORDERS file."
+    REQUIRED_FIELDS: ClassVar[list[str]] = [
+        "Order_Number", "SKU", "Quantity", "Shipping_Method",
+    ]
+    OPTIONAL_FIELDS: ClassVar[list[str]] = [
+        "Product_Name", "Shipping_Country", "Tags", "Notes", "Total_Price", "Subtotal",
+    ]
 
-        # ========================================
-        # COURIER MAPPINGS
-        # ========================================
-        courier_mappings_box = FormSection(
+    def __init__(self, column_mappings: dict, courier_mappings: dict, parent=None):
+        super().__init__(column_mappings, parent)
+        self.courier_mappings = courier_mappings
+        self.courier_mapping_widgets = []
+        self.orders_mapping_widget = self.mapping_widget  # name used by tests/callers
+
+        courier_box = FormSection(
             "Courier Mappings",
             "Map different shipping provider names to standardized courier codes. "
             "You can specify multiple patterns (comma-separated) for each courier.",
         )
-
-        # Container for courier mapping rows
         self.courier_mappings_container = QWidget()
         self.courier_mappings_layout = QVBoxLayout(self.courier_mappings_container)
         self.courier_mappings_layout.setContentsMargins(0, 0, 0, 0)
-
-        courier_mappings_box.add_widget(self.courier_mappings_container)
+        courier_box.add_widget(self.courier_mappings_container)
 
         add_courier_btn = QPushButton("+ Add Courier Mapping")
         set_button_role(add_courier_btn, "secondary")
         add_courier_btn.clicked.connect(lambda: self.add_courier_mapping_row())
         add_courier_btn.setMaximumWidth(200)
-        courier_mappings_box.add_widget(add_courier_btn)
+        courier_box.add_widget(add_courier_btn)
 
-        scroll_layout.addWidget(courier_mappings_box)
-        scroll_layout.addStretch()
+        self.scroll_layout.addWidget(courier_box)
+        self.scroll_layout.addStretch()
 
-        scroll.setWidget(scroll_widget)
-        main_layout.addWidget(scroll)
-
-        # Populate existing courier mappings
         if isinstance(courier_mappings, dict):
             for courier_code, mapping_data in courier_mappings.items():
                 if isinstance(mapping_data, dict):
                     patterns = mapping_data.get("patterns", [])
-                    patterns_str = ", ".join(patterns) if patterns else ""
-                    self.add_courier_mapping_row(courier_code, patterns_str)
+                    self.add_courier_mapping_row(courier_code, ", ".join(patterns) if patterns else "")
 
-        # Add at least one empty row if no mappings exist
         if not courier_mappings:
             self.add_courier_mapping_row()
 
@@ -178,39 +177,42 @@ class MappingsPage(SettingsPage):
         row_refs["widget"].deleteLater()
         self.courier_mapping_widgets.remove(row_refs)
 
-    def validate(self) -> tuple[bool, list[str]]:
-        orders_valid, orders_error = self.orders_mapping_widget.validate_mappings()
-        if not orders_valid:
-            return False, [f"Orders column mapping is invalid:\n{orders_error}"]
-
-        stock_valid, stock_error = self.stock_mapping_widget.validate_mappings()
-        if not stock_valid:
-            return False, [f"Stock column mapping is invalid:\n{stock_error}"]
-
-        return True, []
-
     def collect(self) -> dict:
-        orders_mappings = self.orders_mapping_widget.get_mappings()
-        stock_mappings = self.stock_mapping_widget.get_mappings()
-
         new_couriers = {}
         for row_refs in self.courier_mapping_widgets:
             courier_code = row_refs["courier_code"].text().strip()
             patterns_str = row_refs["patterns"].text().strip()
-
             if courier_code and patterns_str:
                 patterns = [p.strip() for p in patterns_str.split(',') if p.strip()]
                 new_couriers[courier_code] = {"patterns": patterns, "case_sensitive": False}
 
-        # SettingsPage's contract: the returned value replaces
-        # config_data[key], so these must be the live dicts handed to
-        # __init__ -- clear-and-refill in place, never a fresh dict.
-        self.column_mappings.clear()
-        self.column_mappings.update({"version": 2, "orders": orders_mappings, "stock": stock_mappings})
+        # Same live-dict contract as column_mappings: clear-and-refill in
+        # place so a deleted courier code does not survive the shell's merge.
         self.courier_mappings.clear()
         self.courier_mappings.update(new_couriers)
 
         return {
-            "column_mappings": self.column_mappings,
+            "column_mappings": self._collect_column_mappings(),
             "courier_mappings": self.courier_mappings,
         }
+
+
+class StockMappingPage(_MappingPageBase):
+    """Stock CSV columns, including the two that drive FIFO lot allocation."""
+
+    MAPPING_TYPE = "stock"
+    TITLE = "Stock CSV Column Mapping"
+    DESCRIPTION = "Map your CSV column names to internal fields for the STOCK file."
+    REQUIRED_FIELDS: ClassVar[list[str]] = ["SKU", "Stock"]
+    # Expiry_Date and Batch are the exact internal names _build_fifo_lots()
+    # looks for (shopify_tool/analysis.py:96-97) -- renaming them here
+    # silently turns FIFO lot allocation off.
+    OPTIONAL_FIELDS: ClassVar[list[str]] = ["Product_Name", "Expiry_Date", "Batch"]
+
+    def __init__(self, column_mappings: dict, parent=None):
+        super().__init__(column_mappings, parent)
+        self.stock_mapping_widget = self.mapping_widget  # name used by tests/callers
+        self.scroll_layout.addStretch()
+
+    def collect(self) -> dict:
+        return {"column_mappings": self._collect_column_mappings()}

--- a/gui/settings/weight.py
+++ b/gui/settings/weight.py
@@ -450,7 +450,7 @@ class WeightPage(SettingsPage):
                         break
 
             if not sku_col:
-                QMessageBox.warning(self, "Warning", "Could not find SKU column in CSV.\nCheck column mappings in Settings → Mappings tab.")
+                QMessageBox.warning(self, "Warning", "Could not find SKU column in CSV.\nCheck column mappings in Settings → Stock Mapping.")
                 return
 
             skus_in_csv = df[sku_col].dropna().astype(str).str.strip().unique().tolist()

--- a/gui/settings/window.py
+++ b/gui/settings/window.py
@@ -21,7 +21,7 @@ from PySide6.QtWidgets import (
 from gui.components.form_section import FormSection
 from gui.settings.base import SettingsPage
 from gui.settings.general import GeneralPage
-from gui.settings.mappings import MappingsPage
+from gui.settings.mappings import OrdersMappingPage, StockMappingPage
 from gui.settings.packing_lists import PackingListsPage
 from gui.settings.rules import RulesPage
 from gui.settings.sets import SetsPage
@@ -56,7 +56,7 @@ class SettingsWindow(QDialog):
     # Grouped left-nav replacing the old 10-tab horizontal QTabWidget strip.
     # Group/order chosen to mirror VS Code's own Settings UI grouping.
     SETTINGS_NAV_GROUPS: ClassVar[list[tuple[str, list[str]]]] = [
-        ("Data", ["General", "Mappings", "Column Config"]),
+        ("Data", ["General", "Orders Mapping", "Stock Mapping", "Column Config"]),
         ("Fulfillment Logic", ["Rules", "Sets", "Weight"]),
         ("Output", ["Packing Lists", "Stock Exports", "SKU Labels"]),
         ("Organization", ["Tag Categories"]),
@@ -148,11 +148,15 @@ class SettingsWindow(QDialog):
             "Stock Exports",
         )
         self._add_page(
-            MappingsPage(
+            OrdersMappingPage(
                 self.config_data.get("column_mappings", {}),
                 self.config_data.get("courier_mappings", {}),
             ),
-            "Mappings",
+            "Orders Mapping",
+        )
+        self._add_page(
+            StockMappingPage(self.config_data.get("column_mappings", {})),
+            "Stock Mapping",
         )
         self._add_page(SetsPage(self.config_data.get("set_decoders", {})), "Sets")
         self._add_page(

--- a/shopify_tool/analysis.py
+++ b/shopify_tool/analysis.py
@@ -14,6 +14,28 @@ logger = logging.getLogger(__name__)
 _LOT_COLUMN_DEFAULTS: dict[str, str] = {"Годност": "Expiry_Date", "Партида": "Batch"}
 
 
+def _resolve_stock_mappings(stock_mappings: dict[str, str]) -> dict[str, str]:
+    """Back-fill lot column defaults that the config does not already cover.
+
+    Lot tracking works for clients whose configs pre-date the Stock mapping UI
+    without a config migration. A default is skipped when its CSV header is
+    already mapped, or when its *internal* name is -- otherwise a client who
+    maps "Exp date" -> Expiry_Date also gets "Годност" -> Expiry_Date, i.e.
+    two CSV headers claiming one internal field.
+
+    ponytail: this back-fill is only needed until existing configs have been
+    re-saved through the fixed Mappings UI -- drop it, and the constant, once
+    that has happened.
+    """
+    mapped_internals = set(stock_mappings.values())
+    missing = {
+        csv_col: internal
+        for csv_col, internal in _LOT_COLUMN_DEFAULTS.items()
+        if csv_col not in stock_mappings and internal not in mapped_internals
+    }
+    return {**stock_mappings, **missing} if missing else stock_mappings
+
+
 def _parse_expiry_date(raw) -> date | None:
     """Parse a raw expiry string from the stock CSV to a comparable date object.
 
@@ -213,12 +235,7 @@ def _clean_and_prepare_data(
     orders_mappings = column_mappings.get("orders", {})
     stock_mappings = column_mappings.get("stock", {})
 
-    # Inject lot column defaults for any keys not already in the config mapping.
-    # This ensures lot tracking works for existing clients whose configs pre-date
-    # this feature without requiring a config migration or UI change.
-    missing = {k: v for k, v in _LOT_COLUMN_DEFAULTS.items() if k not in stock_mappings}
-    if missing:
-        stock_mappings = {**stock_mappings, **missing}
+    stock_mappings = _resolve_stock_mappings(stock_mappings)
 
     # Apply mappings to orders DataFrame
     # Only rename columns that exist in the DataFrame AND are different from internal names

--- a/shopify_tool/csv_utils.py
+++ b/shopify_tool/csv_utils.py
@@ -119,6 +119,27 @@ def detect_csv_delimiter(file_path: str, encoding: str = 'utf-8-sig') -> tuple[s
     return ',', 'default'
 
 
+def read_csv_headers(file_path: str, encoding: str = 'utf-8-sig') -> list[str]:
+    """Return a CSV's column names without loading any of its rows.
+
+    Delimiter comes from detect_csv_delimiter's fallback chain rather than a
+    configured value, so the settings pages that call this need no delimiter
+    plumbing. nrows=0 reads the header line only, which matters on a large
+    stock export sitting on a network share.
+
+    Args:
+        file_path: Path to the CSV file.
+        encoding: File encoding (default: utf-8-sig).
+
+    Returns:
+        List of column names, in file order.
+    """
+    delimiter, _method = detect_csv_delimiter(file_path, encoding)
+    return list(
+        pd.read_csv(file_path, sep=delimiter, encoding=encoding, nrows=0).columns
+    )
+
+
 def validate_delimiter(file_path: str, delimiter: str, encoding: str = 'utf-8-sig') -> bool:
     """
     Validate that a delimiter works for a CSV file.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,7 +160,12 @@ def settings_fixture_config():
                 "Shipping Method": "Shipping_Method",
                 "Lineitem name": "Product_Name",
             },
-            "stock": {"Article": "SKU", "Available": "Stock"},
+            "stock": {
+                "Article": "SKU",
+                "Available": "Stock",
+                "Годност": "Expiry_Date",
+                "Партида": "Batch",
+            },
         },
         "courier_mappings": {
             "DHL": {"patterns": ["dhl", "DHL Express"], "case_sensitive": False}

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -444,3 +444,18 @@ class TestQuantityRobustness:
         stock = _stock([{"Артикул": "A1", "Наличност": 10}])
         final_df, *_ = _run(orders, stock)
         assert final_df.iloc[0]["Order_Fulfillment_Status"] == "Not Fulfillable"
+
+
+def test_lot_defaults_are_not_injected_when_the_internal_name_is_already_mapped():
+    """A client who maps their own expiry header in Settings must not also get
+    the Bulgarian default injected -- that is two CSV headers claiming one
+    internal name."""
+    from shopify_tool.analysis import _LOT_COLUMN_DEFAULTS, _resolve_stock_mappings
+
+    resolved = _resolve_stock_mappings({"Article": "SKU", "Exp date": "Expiry_Date"})
+
+    assert resolved["Exp date"] == "Expiry_Date"
+    assert "Годност" not in resolved
+    # Batch is still unmapped, so its default is still injected.
+    assert resolved["Партида"] == "Batch"
+    assert _LOT_COLUMN_DEFAULTS == {"Годност": "Expiry_Date", "Партида": "Batch"}

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -8,6 +8,7 @@ from shopify_tool.csv_utils import (
     normalize_sku,
     normalize_sku_for_matching,
     order_number_sort_key,
+    read_csv_headers,
 )
 
 
@@ -139,3 +140,26 @@ class TestMergeCsvFiles:
     def test_empty_file_list_raises(self):
         with pytest.raises(ValueError):
             merge_csv_files([], delimiter=",")
+
+
+def test_read_csv_headers_semicolon_delimited(tmp_path):
+    csv = tmp_path / "stock.csv"
+    csv.write_text(
+        "Артикул;Наличност;Годност;Партида\nSKU1;10;261230;L42\n",
+        encoding="utf-8",
+    )
+    assert read_csv_headers(str(csv)) == ["Артикул", "Наличност", "Годност", "Партида"]
+
+
+def test_read_csv_headers_comma_delimited(tmp_path):
+    csv = tmp_path / "orders.csv"
+    csv.write_text("Name,Lineitem sku,Lineitem quantity\n#1001,ABC,2\n", encoding="utf-8")
+    assert read_csv_headers(str(csv)) == ["Name", "Lineitem sku", "Lineitem quantity"]
+
+
+def test_read_csv_headers_does_not_read_rows(tmp_path):
+    """nrows=0 keeps this cheap on a large stock export over a network share."""
+    csv = tmp_path / "big.csv"
+    rows = "\n".join(f"SKU{i};{i}" for i in range(5000))
+    csv.write_text(f"Артикул;Наличност\n{rows}\n", encoding="utf-8")
+    assert read_csv_headers(str(csv)) == ["Артикул", "Наличност"]

--- a/tests/test_settings_page_mappings.py
+++ b/tests/test_settings_page_mappings.py
@@ -1,6 +1,7 @@
 import pytest
 from PySide6.QtWidgets import QApplication
 
+from gui.column_mapping_widget import ColumnMappingWidget
 from gui.settings.mappings import MappingsPage
 
 
@@ -62,3 +63,34 @@ def test_mappings_page_validate_reports_invalid_orders_mapping(qapp):
     ok, errors = page.validate()
     assert ok is False
     assert errors and "Orders column mapping is invalid" in errors[0]
+
+
+def test_get_mappings_preserves_an_internal_name_it_has_no_row_for(qapp):
+    """A field missing from required/optional must not delete the client's
+    mapping for it. Regression: stock_optional listed only Product_Name, so
+    one Save destroyed the Expiry_Date and Batch mappings the default config
+    ships with -- and with them, FIFO lot allocation."""
+    widget = ColumnMappingWidget(
+        mapping_type="stock",
+        current_mappings={"Article": "SKU", "Available": "Stock", "Годност": "Expiry_Date"},
+        required_fields=["SKU", "Stock"],
+        optional_fields=[],  # deliberately does not manage Expiry_Date
+    )
+    assert widget.get_mappings() == {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Годност": "Expiry_Date",
+    }
+
+
+def test_get_mappings_still_removes_a_cleared_managed_field(qapp):
+    """Carrying unmanaged entries through must not resurrect a field the user
+    deliberately cleared."""
+    widget = ColumnMappingWidget(
+        mapping_type="stock",
+        current_mappings={"Article": "SKU", "Name": "Product_Name"},
+        required_fields=["SKU"],
+        optional_fields=["Product_Name"],
+    )
+    widget.csv_column_inputs["Product_Name"].setText("")
+    assert widget.get_mappings() == {"Article": "SKU"}

--- a/tests/test_settings_page_mappings.py
+++ b/tests/test_settings_page_mappings.py
@@ -1,8 +1,8 @@
 import pytest
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QComboBox, QScrollArea
 
 from gui.column_mapping_widget import ColumnMappingWidget
-from gui.settings.mappings import MappingsPage
+from gui.settings.mappings import OrdersMappingPage, StockMappingPage
 
 
 @pytest.fixture(scope="module")
@@ -23,10 +23,10 @@ def valid_column_mappings():
     }
 
 
-def test_mappings_page_round_trips_valid_mappings(qapp):
+def test_orders_page_round_trips_valid_mappings(qapp):
     column_mappings = valid_column_mappings()
     courier_mappings = {"DHL": {"patterns": ["dhl", "DHL Express"], "case_sensitive": False}}
-    page = MappingsPage(column_mappings, courier_mappings)
+    page = OrdersMappingPage(column_mappings, courier_mappings)
 
     ok, errors = page.validate()
     assert (ok, errors) == (True, [])
@@ -36,13 +36,22 @@ def test_mappings_page_round_trips_valid_mappings(qapp):
     }
 
 
-def test_mappings_page_deleting_a_courier_row_removes_it_on_save(qapp):
+def test_stock_page_round_trips_valid_mappings(qapp):
+    column_mappings = valid_column_mappings()
+    page = StockMappingPage(column_mappings)
+
+    ok, errors = page.validate()
+    assert (ok, errors) == (True, [])
+    assert page.collect() == {"column_mappings": column_mappings}
+
+
+def test_orders_page_deleting_a_courier_row_removes_it_on_save(qapp):
     """Regression: the shell merges collect() dict values one level deep, which
     would silently un-delete a removed courier code if collect() didn't mutate
     the live dict in place."""
     column_mappings = valid_column_mappings()
     courier_mappings = {"DHL": {"patterns": ["dhl"], "case_sensitive": False}}
-    page = MappingsPage(column_mappings, courier_mappings)
+    page = OrdersMappingPage(column_mappings, courier_mappings)
 
     # Simulate deleting the only courier row.
     row_refs = page.courier_mapping_widgets[0]
@@ -53,16 +62,16 @@ def test_mappings_page_deleting_a_courier_row_removes_it_on_save(qapp):
     assert courier_mappings == {}, "the live dict passed in must be mutated in place"
 
 
-def test_mappings_page_validate_reports_invalid_orders_mapping(qapp):
+def test_orders_page_validate_reports_invalid_orders_mapping(qapp):
     column_mappings = {
         "version": 2,
         "orders": {},  # missing every required field
         "stock": {"Article": "SKU", "Available": "Stock"},
     }
-    page = MappingsPage(column_mappings, {})
+    page = OrdersMappingPage(column_mappings, {})
     ok, errors = page.validate()
     assert ok is False
-    assert errors and "Orders column mapping is invalid" in errors[0]
+    assert errors and "Orders CSV Column Mapping is invalid" in errors[0]
 
 
 def test_get_mappings_preserves_an_internal_name_it_has_no_row_for(qapp):
@@ -99,7 +108,7 @@ def test_get_mappings_still_removes_a_cleared_managed_field(qapp):
 def test_stock_page_offers_rows_for_the_lot_tracking_fields(qapp):
     """Expiry_Date and Batch drive _build_fifo_lots(); before this they were
     in the default client config with no way to see or edit them."""
-    page = MappingsPage(valid_column_mappings(), {})
+    page = StockMappingPage(valid_column_mappings())
     inputs = page.stock_mapping_widget.csv_column_inputs
     assert "Expiry_Date" in inputs
     assert "Batch" in inputs
@@ -113,7 +122,7 @@ def test_stock_lot_mappings_round_trip_through_the_page(qapp):
         "Exp date": "Expiry_Date",
         "Lot": "Batch",
     }
-    page = MappingsPage(column_mappings, {})
+    page = StockMappingPage(column_mappings)
 
     assert page.collect()["column_mappings"]["stock"] == {
         "Article": "SKU",
@@ -123,11 +132,8 @@ def test_stock_lot_mappings_round_trip_through_the_page(qapp):
     }
 
 
-from PySide6.QtWidgets import QComboBox, QScrollArea
-
-
 def test_mapping_inputs_are_editable_combo_boxes(qapp):
-    page = MappingsPage(valid_column_mappings(), {})
+    page = OrdersMappingPage(valid_column_mappings(), {})
     sku_input = page.orders_mapping_widget.csv_column_inputs["SKU"]
     assert isinstance(sku_input, QComboBox)
     assert sku_input.isEditable()
@@ -135,7 +141,7 @@ def test_mapping_inputs_are_editable_combo_boxes(qapp):
 
 
 def test_set_available_headers_offers_them_on_every_row_without_losing_text(qapp):
-    page = MappingsPage(valid_column_mappings(), {})
+    page = OrdersMappingPage(valid_column_mappings(), {})
     widget = page.orders_mapping_widget
 
     widget.set_available_headers(["Name", "Lineitem sku", "Some other column"])
@@ -152,5 +158,54 @@ def test_set_available_headers_offers_them_on_every_row_without_losing_text(qapp
 def test_the_widget_has_no_scroll_area_of_its_own(qapp):
     """The page already scrolls. A second QScrollArea inside it clips the
     Stock block to a few rows and produces two scrollbars side by side."""
-    page = MappingsPage(valid_column_mappings(), {})
+    page = OrdersMappingPage(valid_column_mappings(), {})
     assert page.orders_mapping_widget.findChildren(QScrollArea) == []
+
+
+def test_both_pages_collect_into_one_live_column_mappings_dict(qapp):
+    """Two pages now own one config key. Each must write only its own sub-key
+    in place -- a clear() or a freshly built dict in either one wipes the
+    other's work, and _pages order decides who loses."""
+    column_mappings = valid_column_mappings()
+    orders_page = OrdersMappingPage(column_mappings, {})
+    stock_page = StockMappingPage(column_mappings)
+
+    stock_page.collect()
+    orders_page.collect()
+
+    assert column_mappings["orders"]["Lineitem sku"] == "SKU"
+    assert column_mappings["stock"]["Article"] == "SKU"
+    assert column_mappings["version"] == 2
+
+
+def test_collect_order_does_not_matter(qapp):
+    column_mappings = valid_column_mappings()
+    orders_page = OrdersMappingPage(column_mappings, {})
+    stock_page = StockMappingPage(column_mappings)
+
+    orders_page.collect()
+    result = stock_page.collect()["column_mappings"]
+
+    assert set(result) == {"version", "orders", "stock"}
+    assert result["orders"] and result["stock"]
+
+
+def test_stock_page_collect_emits_every_stock_key_it_was_built_with(qapp):
+    """Key coverage for the live-dict blind spot: collect() returns the same
+    object the page was constructed with, so the roundtrip guard in
+    test_settings_roundtrip.py cannot see a dropped sub-key here. Detach
+    first, then assert on what collect() actively writes."""
+    column_mappings = valid_column_mappings()
+    column_mappings["stock"] = {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Name": "Product_Name",
+        "Exp date": "Expiry_Date",
+        "Lot": "Batch",
+    }
+    page = StockMappingPage(column_mappings)
+
+    page.column_mappings = {}  # detach from the live dict
+    written = page.collect()["column_mappings"]["stock"]
+
+    assert set(written.values()) == {"SKU", "Stock", "Product_Name", "Expiry_Date", "Batch"}

--- a/tests/test_settings_page_mappings.py
+++ b/tests/test_settings_page_mappings.py
@@ -105,6 +105,24 @@ def test_get_mappings_still_removes_a_cleared_managed_field(qapp):
     assert widget.get_mappings() == {"Article": "SKU"}
 
 
+def test_validate_rejects_two_rows_sharing_one_csv_column(qapp):
+    """Regression: the duplicate check read get_mappings(), which is keyed by
+    CSV column -- so the duplicate had already collapsed and the check could
+    never fire. Save then succeeded with the losing row unmapped. Now that the
+    inputs are dropdowns, picking one header twice is a click away."""
+    widget = ColumnMappingWidget(
+        mapping_type="orders",
+        current_mappings={"Name": "Order_Number", "Tags": "Tags"},
+        required_fields=["Order_Number"],
+        optional_fields=["Tags"],
+    )
+    widget.csv_column_inputs["Tags"].setCurrentText("Name")
+
+    ok, error = widget.validate_mappings()
+    assert ok is False
+    assert "Name" in error
+
+
 def test_stock_page_offers_rows_for_the_lot_tracking_fields(qapp):
     """Expiry_Date and Batch drive _build_fifo_lots(); before this they were
     in the default client config with no way to see or edit them."""
@@ -194,7 +212,12 @@ def test_stock_page_collect_emits_every_stock_key_it_was_built_with(qapp):
     """Key coverage for the live-dict blind spot: collect() returns the same
     object the page was constructed with, so the roundtrip guard in
     test_settings_roundtrip.py cannot see a dropped sub-key here. Detach
-    first, then assert on what collect() actively writes."""
+    first, then assert on what collect() actively writes.
+
+    This pins the write, not the field list -- get_mappings() carries an
+    unmanaged internal name through from current_mappings, so a field dropped
+    from OPTIONAL_FIELDS still lands here. The field list is guarded by
+    test_stock_page_offers_rows_for_the_lot_tracking_fields."""
     column_mappings = valid_column_mappings()
     column_mappings["stock"] = {
         "Article": "SKU",
@@ -208,7 +231,13 @@ def test_stock_page_collect_emits_every_stock_key_it_was_built_with(qapp):
     page.column_mappings = {}  # detach from the live dict
     written = page.collect()["column_mappings"]["stock"]
 
-    assert set(written.values()) == {"SKU", "Stock", "Product_Name", "Expiry_Date", "Batch"}
+    assert written == {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Name": "Product_Name",
+        "Exp date": "Expiry_Date",
+        "Lot": "Batch",
+    }
 
 
 def test_load_headers_fills_every_row_from_the_chosen_file(qapp, tmp_path, monkeypatch):

--- a/tests/test_settings_page_mappings.py
+++ b/tests/test_settings_page_mappings.py
@@ -94,3 +94,30 @@ def test_get_mappings_still_removes_a_cleared_managed_field(qapp):
     )
     widget.csv_column_inputs["Product_Name"].setText("")
     assert widget.get_mappings() == {"Article": "SKU"}
+
+
+def test_stock_page_offers_rows_for_the_lot_tracking_fields(qapp):
+    """Expiry_Date and Batch drive _build_fifo_lots(); before this they were
+    in the default client config with no way to see or edit them."""
+    page = MappingsPage(valid_column_mappings(), {})
+    inputs = page.stock_mapping_widget.csv_column_inputs
+    assert "Expiry_Date" in inputs
+    assert "Batch" in inputs
+
+
+def test_stock_lot_mappings_round_trip_through_the_page(qapp):
+    column_mappings = valid_column_mappings()
+    column_mappings["stock"] = {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Exp date": "Expiry_Date",
+        "Lot": "Batch",
+    }
+    page = MappingsPage(column_mappings, {})
+
+    assert page.collect()["column_mappings"]["stock"] == {
+        "Article": "SKU",
+        "Available": "Stock",
+        "Exp date": "Expiry_Date",
+        "Lot": "Batch",
+    }

--- a/tests/test_settings_page_mappings.py
+++ b/tests/test_settings_page_mappings.py
@@ -209,3 +209,35 @@ def test_stock_page_collect_emits_every_stock_key_it_was_built_with(qapp):
     written = page.collect()["column_mappings"]["stock"]
 
     assert set(written.values()) == {"SKU", "Stock", "Product_Name", "Expiry_Date", "Batch"}
+
+
+def test_load_headers_fills_every_row_from_the_chosen_file(qapp, tmp_path, monkeypatch):
+    csv = tmp_path / "stock.csv"
+    csv.write_text("Article;Available;Exp date;Lot\nA1;5;261230;L7\n", encoding="utf-8")
+
+    page = StockMappingPage(valid_column_mappings())
+    monkeypatch.setattr(
+        "gui.settings.mappings.QFileDialog.getOpenFileName",
+        lambda *a, **k: (str(csv), ""),
+    )
+
+    page._load_headers_from_csv()
+
+    sku_input = page.stock_mapping_widget.csv_column_inputs["SKU"]
+    assert [sku_input.itemText(i) for i in range(sku_input.count())] == [
+        "Article", "Available", "Exp date", "Lot",
+    ]
+    assert sku_input.currentText() == "Article", "the configured mapping must survive"
+
+
+def test_load_headers_cancelled_leaves_the_inputs_alone(qapp, monkeypatch):
+    page = StockMappingPage(valid_column_mappings())
+    monkeypatch.setattr(
+        "gui.settings.mappings.QFileDialog.getOpenFileName", lambda *a, **k: ("", "")
+    )
+
+    page._load_headers_from_csv()
+
+    sku_input = page.stock_mapping_widget.csv_column_inputs["SKU"]
+    assert sku_input.count() == 0
+    assert sku_input.currentText() == "Article"

--- a/tests/test_settings_page_mappings.py
+++ b/tests/test_settings_page_mappings.py
@@ -92,7 +92,7 @@ def test_get_mappings_still_removes_a_cleared_managed_field(qapp):
         required_fields=["SKU"],
         optional_fields=["Product_Name"],
     )
-    widget.csv_column_inputs["Product_Name"].setText("")
+    widget.csv_column_inputs["Product_Name"].setCurrentText("")
     assert widget.get_mappings() == {"Article": "SKU"}
 
 
@@ -121,3 +121,36 @@ def test_stock_lot_mappings_round_trip_through_the_page(qapp):
         "Exp date": "Expiry_Date",
         "Lot": "Batch",
     }
+
+
+from PySide6.QtWidgets import QComboBox, QScrollArea
+
+
+def test_mapping_inputs_are_editable_combo_boxes(qapp):
+    page = MappingsPage(valid_column_mappings(), {})
+    sku_input = page.orders_mapping_widget.csv_column_inputs["SKU"]
+    assert isinstance(sku_input, QComboBox)
+    assert sku_input.isEditable()
+    assert sku_input.currentText() == "Lineitem sku"
+
+
+def test_set_available_headers_offers_them_on_every_row_without_losing_text(qapp):
+    page = MappingsPage(valid_column_mappings(), {})
+    widget = page.orders_mapping_widget
+
+    widget.set_available_headers(["Name", "Lineitem sku", "Some other column"])
+
+    sku_input = widget.csv_column_inputs["SKU"]
+    assert [sku_input.itemText(i) for i in range(sku_input.count())] == [
+        "Name",
+        "Lineitem sku",
+        "Some other column",
+    ]
+    assert sku_input.currentText() == "Lineitem sku", "typed/configured text must survive"
+
+
+def test_the_widget_has_no_scroll_area_of_its_own(qapp):
+    """The page already scrolls. A second QScrollArea inside it clips the
+    Stock block to a few rows and produces two scrollbars side by side."""
+    page = MappingsPage(valid_column_mappings(), {})
+    assert page.orders_mapping_widget.findChildren(QScrollArea) == []

--- a/tests/test_settings_roundtrip.py
+++ b/tests/test_settings_roundtrip.py
@@ -19,7 +19,8 @@ from gui.settings.window import SettingsWindow
 
 def test_window_registers_every_page(window):
     assert list(window._page_index_by_name) == [
-        "General", "Rules", "Packing Lists", "Stock Exports", "Mappings",
+        "General", "Rules", "Packing Lists", "Stock Exports",
+        "Orders Mapping", "Stock Mapping",
         "Sets", "Weight", "Tag Categories", "Column Config",
     ]
 
@@ -59,15 +60,15 @@ def test_no_page_silently_drops_a_field(window):
 
 
 def test_deleting_a_courier_row_survives_the_save_merge(window, no_modals):
-    """Guards the live-reference contract MappingsPage depends on.
+    """Guards the live-reference contract OrdersMappingPage depends on.
 
     `courier_mappings` holds a variable set of keys, and the shell's merge is
-    `dict.update()`, which never drops one. MappingsPage only gets away with
-    this because window.py hands it the *live* sub-dict, which it clears and
-    refills in place. Hand it a copy instead and this test fails while every
-    page-level test stays green.
+    `dict.update()`, which never drops one. OrdersMappingPage only gets away
+    with this because window.py hands it the *live* sub-dict, which it clears
+    and refills in place. Hand it a copy instead and this test fails while
+    every page-level test stays green.
     """
-    mappings = window._pages[window._page_index_by_name["Mappings"]]
+    mappings = window._pages[window._page_index_by_name["Orders Mapping"]]
     for row_refs in list(mappings.courier_mapping_widgets):
         mappings._delete_courier_row(row_refs)
 


### PR DESCRIPTION
Phase 6 — **Mappings: better UI, add expiry/lot fields to Stock CSV mapping**.

Design: `docs/superpowers/specs/2026-08-13-mappings-ui-design.md`
Plan: `docs/superpowers/plans/2026-08-13-mappings-ui-plan.md` (7/7 tasks)

## The data-loss defect this fixes

`MappingsPage` only listed `Product_Name` as a stock optional field, but the
shipped default config also maps `Expiry_Date` and `Batch`. `get_mappings()`
rebuilt the dict from its rows only — so **opening Settings and pressing Save
deleted both mappings**, and with them FIFO lot allocation, silently.

The regression test is the widened `tests/conftest.py` fixture: with it applied
to `main`, the existing `test_no_page_silently_drops_a_field` guard fails. The
fix carries unmanaged internal names through, while still removing a *managed*
field the user deliberately cleared.

## What else changed

- **Expiry_Date and Batch are now editable** in the Stock mapping (they existed
  in config with no UI).
- **Mappings split into two nav pages**, Orders Mapping and Stock Mapping. Both
  write the same `column_mappings` key, mutating one live dict per-key and never
  clearing it, so page order can't decide whose mappings survive a save.
- **Rows rebuilt on `FormSection`**, nested scroll area dropped.
- **"Load headers from CSV…"** file-picker fills every row's dropdown with the
  real column names from a chosen file. Free-text entry still works — a
  configured column absent from the picked file is not wiped.
- `analysis.py` no longer injects a lot default whose internal name is already
  mapped. The `_LOT_COLUMN_DEFAULTS` back-compat injection itself stays (removing
  it would break lot tracking for every existing client at once); there's a
  `ponytail:` comment naming the removal condition.

## Review

`superpowers:requesting-code-review` ran on `97a5bf3..fa8d030`. It verified the
two-page live-dict contract end-to-end (real `SettingsWindow`, edits on both
pages, `save_settings()` — both survive) and against three mutations, and
confirmed the defect regression test fails on base.

One substantive finding, fixed in `55bfd4a`: the duplicate-CSV-column check in
`validate_mappings()` was structurally dead — it read `get_mappings()`, which is
keyed by CSV column, so duplicates had already collapsed. Pre-existing on `main`,
but the dropdowns make it far easier to hit and the design doc names it as the
safety net. Now reads the boxes directly, with a test.

Also noted and confirmed by the reviewer: plan Task 6 Step 7's mutation check
(narrow `StockMappingPage.OPTIONAL_FIELDS`) no longer reproduces a failure in the
key-coverage test, because the carry-through fix protects unmapped-but-configured
names independently of `OPTIONAL_FIELDS`. That's a stronger guarantee than the
plan assumed, not a gap — narrowing the list fails
`test_stock_page_offers_rows_for_the_lot_tracking_fields` instead, which is the
right guard for a UI-visibility regression. Docstrings updated to say so.

Deferred, not blocking: clearing a lot field can't express "turn lot tracking
off" (the back-fill re-injects it); `read_csv_headers` is fixed at `utf-8-sig`,
matching `core.py`.

## Verification

541 tests pass (523 baseline + 18 new), `ruff check . --exclude shared` clean.

**Windows visual check is on you** — this was developed on Linux and the layout
work came from your screenshots (Todoist epic `6hG88Vx9CgRHVgG3`). Worth a look
at both new nav pages at a small window size.

Separately, from the same screenshots: in **Column Config** (both the Hub and the
standalone dialog) the *Columns* and *Additional CSV Columns* lists collapse to
~2 visible rows with vertical space to spare — a stretch-factor bug in
`ColumnConfigPanel`. Out of scope here; worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCzVnUfYdD2ZnF7JApPpRf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split mapping settings into separate **Orders Mapping** and **Stock Mapping** pages.
  * Added editable dropdowns for selecting CSV columns, including automatic header loading.
  * Added support for expiry date and batch mappings.
* **Bug Fixes**
  * Preserved unmanaged mappings when saving settings.
  * Prevented conflicting duplicate lot-tracking mappings.
  * Improved CSV header parsing and related error handling.
* **Tests**
  * Added coverage for mapping validation, round trips, header loading, and lot-tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->