### PR TITLE
Phase 6 — Rule engine: conditions fail closed, and a level-aware rule editor

### DIFF
--- a/docs/superpowers/plans/2026-08-13-rule-engine-ui-plan.md
+++ b/docs/superpowers/plans/2026-08-13-rule-engine-ui-plan.md
@@ -1,0 +1,1546 @@
+# Rule Engine & Rule UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **This repo's runner declines subagent-driven-development** — Stage B runs
+> in-session with `superpowers:executing-plans`. See the runner prompt.
+
+**Goal:** Make rule conditions fail closed instead of silently widening a rule's
+match, cut order-level rule evaluation from O(orders x rules x steps x rows) to
+O(orders x rules x steps x order-size), and give the rule editor an overview
+(collapse, summary, filter) plus level-aware field lists that stop producing the
+broken conditions in the first place.
+
+**Architecture:** Two phases in one PR. Phase 1 is `shopify_tool/rules.py` only:
+a shared condition-resolution helper used by both evaluation paths, and a
+positional-index rewrite of the order-rule loop. Phase 2 is
+`gui/settings/rules.py`: a collapsible card per rule, a filter box, level-aware
+field dropdowns sourced from the engine's own `ORDER_LEVEL_FIELDS`, and a field
+validity indicator reusing the existing validation-feedback machinery.
+
+**Tech Stack:** Python 3.11+, pandas, PySide6, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-rule-engine-ui-design.md`
+
+## Global Constraints
+
+- Windows 10/11 is the production target; development is on Ubuntu Linux. Do not
+  add platform-specific code.
+- `python` is not on PATH. Use `.venv/bin/python` or the `scripts/` wrappers.
+- Never hand-edit anything under `shared/` — it is one-way synced from
+  `../packing-tool`.
+- Never hardcode colors in stylesheets. Use
+  `get_theme_manager().get_current_theme()` tokens (`theme.accent_red`,
+  `theme.text_secondary`, `theme.border`, …).
+- No UI calls from background threads.
+- Gate before finishing: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest`
+  and `.venv/bin/ruff check . --exclude shared` must both be clean.
+- No direct commits to `main`. This work is on `worktree-rule-engine-ui`.
+- Run `graphify update .` after the code changes land.
+- Do not bump the version string — this is not a release.
+
+---
+
+### Task 1: Shared condition resolution, failing closed
+
+Closes F1 and F2's engine half. This is the behaviour change the user approved:
+an unresolvable condition evaluates to `False` instead of being dropped from the
+match.
+
+**Files:**
+- Modify: `shopify_tool/rules.py:918-997` (`_get_matching_rows`)
+- Modify: `shopify_tool/rules.py:1246-1310` (`_evaluate_order_conditions`)
+- Test: `tests/test_rules.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `RuleEngine._resolve_condition(self, cond, columns, allow_order_fields)`
+  returning `tuple[str | None, str | None, object, str | None]` —
+  `(field, operator, value, error)`. `error` is `None` when the condition is
+  usable; otherwise it is a human-readable reason string and the first three
+  values must not be used. Task 2 calls this from the rewritten order loop.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_rules.py`:
+
+```python
+class TestUnresolvableConditionsFailClosed:
+    """An unresolvable condition evaluates to False, it is not dropped.
+
+    Before this change _get_matching_rows skipped conditions it could not
+    resolve, so an ALL-match rule fired on its surviving conditions alone and
+    tagged more rows than the rule was written to tag.
+    """
+
+    def test_all_match_with_unknown_field_does_not_fire(self):
+        df = _df({"Order_Type": ["Single", "Single", "Multi"]})
+        rules = [_rule(
+            [{"field": "Order_Type", "operator": "equals", "value": "Single"},
+             {"field": "item_count", "operator": "is greater than", "value": 3}],
+            [{"type": "ADD_TAG", "value": "NOPE"}],
+            match="ALL",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", "", ""]
+
+    def test_any_match_with_unknown_field_still_fires_on_valid_condition(self):
+        df = _df({"Order_Type": ["Single", "Multi"]})
+        rules = [_rule(
+            [{"field": "Order_Type", "operator": "equals", "value": "Single"},
+             {"field": "no_such_column", "operator": "equals", "value": "x"}],
+            [{"type": "ADD_TAG", "value": "YES"}],
+            match="ANY",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["YES", ""]
+
+    def test_unknown_operator_fails_closed(self):
+        df = _df({"Order_Type": ["Single", "Multi"]})
+        rules = [_rule(
+            [{"field": "Order_Type", "operator": "sounds like", "value": "Single"}],
+            [{"type": "ADD_TAG", "value": "NOPE"}],
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", ""]
+
+    def test_separator_field_fails_closed(self):
+        df = _df({"Order_Type": ["Single", "Multi"]})
+        rules = [_rule(
+            [{"field": "Order_Type", "operator": "equals", "value": "Single"},
+             {"field": "--- ORDER-LEVEL FIELDS ---", "operator": "equals", "value": ""}],
+            [{"type": "ADD_TAG", "value": "NOPE"}],
+            match="ALL",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", ""]
+
+    def test_order_level_rule_agrees_on_unknown_field(self):
+        df = _df({
+            "Order_Number": ["A", "A"],
+            "Quantity": [1, 2],
+        })
+        rules = [_rule(
+            [{"field": "item_count", "operator": "equals", "value": 2},
+             {"field": "no_such_column", "operator": "equals", "value": "x"}],
+            [{"type": "ADD_TAG", "value": "NOPE"}],
+            match="ALL", level="order",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", ""]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules.py::TestUnresolvableConditionsFailClosed -v`
+
+Expected: `test_all_match_with_unknown_field_does_not_fire`,
+`test_unknown_operator_fails_closed` and `test_separator_field_fails_closed` FAIL
+with `assert ['NOPE', 'NOPE', ''] == ['', '', '']` or similar — the rule fires
+because the bad condition was dropped. `test_any_match_...` and
+`test_order_level_rule_agrees_on_unknown_field` should already PASS (the order
+path already fails closed, and ANY is unaffected by dropping); they are
+regression guards, not new behaviour. If `test_order_level_...` fails, stop and
+re-read `_evaluate_order_conditions` before continuing.
+
+- [ ] **Step 3: Add the shared resolver**
+
+Insert this method on `RuleEngine`, immediately above `_get_matching_rows`:
+
+```python
+    def _resolve_condition(self, cond, columns, allow_order_fields):
+        """Resolves a condition to (field, operator, value, error).
+
+        A condition the engine cannot evaluate is an error, not something to
+        skip. Skipping one drops it out of an ALL-match, which makes the rule
+        fire on its remaining conditions and match more rows than written.
+
+        Args:
+            cond (dict): The condition, with 'field', 'operator' and 'value'.
+            columns: The DataFrame columns available to this condition.
+            allow_order_fields (bool): True on the order-level path, where
+                ORDER_LEVEL_FIELDS names are computed rather than looked up.
+
+        Returns:
+            tuple: (field, operator, value, error). error is None when the
+                condition is usable; otherwise it explains why not and the
+                other three values must not be used.
+        """
+        field = cond.get("field")
+        operator = cond.get("operator")
+        value = cond.get("value")
+
+        if not field:
+            return None, None, None, "condition has no field"
+        if field.startswith("---"):
+            return None, None, None, f"'{field}' is a dropdown separator, not a field"
+        if not operator:
+            return None, None, None, f"condition on '{field}' has no operator"
+        if operator not in OPERATOR_MAP:
+            return None, None, None, f"unknown operator '{operator}'"
+
+        if allow_order_fields and field in self.ORDER_LEVEL_FIELDS:
+            return field, operator, value, None
+        if field not in columns:
+            hint = "" if allow_order_fields else " (order-level fields need level: order)"
+            return None, None, None, f"field '{field}' is not a column{hint}"
+
+        return field, operator, value, None
+```
+
+- [ ] **Step 4: Use it in the article path**
+
+In `_get_matching_rows`, replace the whole per-condition validation block
+(rules.py:946-985, from `for cond in conditions:` down to
+`condition_results.append(result)`) with:
+
+```python
+        for cond in conditions:
+            field, operator, value, error = self._resolve_condition(
+                cond, df.columns, allow_order_fields=False
+            )
+            if error:
+                logger.warning(
+                    f"[RULE ENGINE] Condition cannot be evaluated and is treated "
+                    f"as no-match: {error}"
+                )
+                condition_results.append(pd.Series(False, index=df.index))
+                continue
+
+            op_func = globals()[OPERATOR_MAP[operator]]
+            logger.debug(
+                f"[RULE ENGINE] {field} {operator} {value!r} "
+                f"(dtype {df[field].dtype})"
+            )
+            result = op_func(df[field], value)
+            condition_results.append(result)
+```
+
+`globals()[OPERATOR_MAP[operator]]` is the form the rest of the file uses today —
+match it here. Task 4 replaces every occurrence at once, or is dropped and they
+all stay as they are. Do not introduce a second form in this task.
+
+The `logger.info` lines dumping dtype, value repr and five sample values are
+deleted, not demoted individually — the single `logger.debug` above replaces
+them all.
+
+- [ ] **Step 5: Use it in the order path**
+
+In `_evaluate_order_conditions`, replace the block from `field = condition.get("field")`
+through the `if not all([field, operator]): continue` / separator checks
+(rules.py:1261-1270) with:
+
+```python
+            field, operator, value, error = self._resolve_condition(
+                condition, order_df.columns, allow_order_fields=True
+            )
+            if error:
+                logger.warning(
+                    f"[RULE ENGINE] Order condition cannot be evaluated and is "
+                    f"treated as no-match: {error}"
+                )
+                results.append(False)
+                continue
+```
+
+`_evaluate_order_conditions` has no module-level logger in scope — add
+`import logging; logger = logging.getLogger(__name__)` at the top of the method,
+matching the existing style used by `apply` and `_get_matching_rows`.
+
+Then delete the now-unreachable `if field not in order_df.columns or operator not in OPERATOR_MAP:`
+guard at the old rules.py:1294, replacing that `if/else` with just the `else`
+body — the resolver has already guaranteed both.
+
+- [ ] **Step 6: Run the new tests, then the whole rule suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules.py -v`
+
+Expected: all PASS, including the five new ones.
+
+If a *pre-existing* test now fails, do not weaken it — read it first. A
+pre-existing test that depended on a condition being dropped is documenting the
+bug, and its expectation should change with a comment saying so.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shopify_tool/rules.py tests/test_rules.py
+git commit -m "fix(rules): unresolvable conditions fail closed instead of widening the match"
+```
+
+---
+
+### Task 2: Rewrite the order-rule loop with positional indexing
+
+Closes F3, F4 and F5. No behaviour change is intended here — this task is pure
+performance plus the removal of dead code, and Step 1's equivalence test is what
+proves it.
+
+**Files:**
+- Modify: `shopify_tool/rules.py:820-874` (the order-rule block inside `apply`)
+- Test: `tests/test_rules.py`
+
+**Interfaces:**
+- Consumes: `_resolve_condition` from Task 1 (already wired into
+  `_evaluate_order_conditions`; this task does not call it directly).
+- Produces: no new public names. `_execute_actions(self, df, matches, actions)`
+  keeps its signature — `matches` stays a boolean `pd.Series` indexed like `df`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_rules.py`:
+
+```python
+class TestOrderRuleLoopRewrite:
+    """Order-level rules: same results, without O(rows) slicing per step."""
+
+    def test_multi_order_multi_rule_output_unchanged(self):
+        df = _df({
+            "Order_Number": ["A", "A", "B", "C", "C", "C"],
+            "Quantity": [1, 2, 5, 1, 1, 1],
+            "SKU": ["x", "y", "z", "x", "x", "y"],
+        })
+        rules = [
+            _rule([{"field": "item_count", "operator": "is greater than", "value": 2}],
+                  [{"type": "ADD_TAG", "value": "BIG"}],
+                  level="order", priority=1, name="big"),
+            _rule([{"field": "total_quantity", "operator": "is greater than or equal", "value": 5}],
+                  [{"type": "ADD_TAG", "value": "HEAVY"}],
+                  level="order", priority=2, name="heavy"),
+        ]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == [
+            "", "", "HEAVY", "BIG", "BIG", "BIG",
+        ]
+
+    def test_later_step_sees_earlier_step_action_writes(self):
+        """Guards the deliberate re-slice: order_df is re-taken every step."""
+        df = _df({
+            "Order_Number": ["A", "A"],
+            "Quantity": [1, 1],
+        })
+        rules = [{
+            "name": "two-step", "level": "order", "priority": 1,
+            "steps": [
+                {"conditions": [{"field": "item_count", "operator": "equals", "value": 2}],
+                 "match": "ALL",
+                 "actions": [{"type": "ADD_TAG", "value": "FIRST"}]},
+                {"conditions": [{"field": "Status_Note", "operator": "contains", "value": "FIRST"}],
+                 "match": "ALL",
+                 "actions": [{"type": "ADD_TAG", "value": "SECOND"}]},
+            ],
+        }]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["FIRST, SECOND", "FIRST, SECOND"]
+
+    def test_first_row_action_targets_one_row_with_duplicate_index_labels(self):
+        df = pd.DataFrame(
+            {"Order_Number": ["A", "A"], "Quantity": [1, 1]},
+            index=[0, 0],
+        )
+        rules = [_rule([{"field": "item_count", "operator": "equals", "value": 2}],
+                       [{"type": "ADD_ORDER_TAG", "value": "ONCE"}],
+                       level="order")]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["ONCE", "ONCE"]
+
+    def test_order_step_gates_and_stops(self):
+        df = _df({"Order_Number": ["A", "A"], "Quantity": [1, 1]})
+        rules = [{
+            "name": "gate", "level": "order", "priority": 1,
+            "steps": [
+                {"conditions": [{"field": "item_count", "operator": "equals", "value": 99}],
+                 "match": "ALL",
+                 "actions": [{"type": "ADD_TAG", "value": "NO"}]},
+                {"conditions": [{"field": "item_count", "operator": "equals", "value": 2}],
+                 "match": "ALL",
+                 "actions": [{"type": "ADD_TAG", "value": "ALSO_NO"}]},
+            ],
+        }]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", ""]
+```
+
+`ADD_ORDER_TAG` is routed to `apply_to_all_actions` by the current code
+(rules.py:858), so `test_first_row_action_targets_one_row_with_duplicate_index_labels`
+asserts both rows are tagged. Before writing the assertion, confirm that routing
+is still what the code does; if `ADD_ORDER_TAG` has moved to the first-row branch,
+the expectation becomes `["ONCE", ""]`. Do not change the routing in this task.
+
+- [ ] **Step 2: Run the tests to verify which fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules.py::TestOrderRuleLoopRewrite -v`
+
+Expected: `test_first_row_action_targets_one_row_with_duplicate_index_labels`
+FAILS on the current label-based addressing. The other three should PASS — they
+are the equivalence baseline that must keep passing through the rewrite. If any
+of those three fails now, the rewrite has no safe baseline: stop and report it
+rather than proceeding.
+
+- [ ] **Step 3: Rewrite the loop**
+
+Replace the whole block at rules.py:820-874 (`if order_rules and "Order_Number" in df.columns:`
+through the end of the order-rule `for` body) with:
+
+```python
+        if order_rules and "Order_Number" in df.columns:
+            # Group once. .indices gives positional arrays, so every slice and
+            # mask below is positional -- index labels are not guaranteed unique
+            # (apply() itself concatenates with ignore_index at the end).
+            positions_by_order = df.groupby("Order_Number", sort=False).indices
+
+            for order_number, positions in positions_by_order.items():
+                for rule in order_rules:
+                    rule_name = rule.get("name", "Unnamed")
+                    steps = rule.get("steps", [])
+
+                    for step_idx, step in enumerate(steps):
+                        # Re-taken every step on purpose: a later step's
+                        # conditions must see what an earlier step's actions
+                        # wrote. O(len(order)), not O(len(df)).
+                        order_df = df.iloc[positions]
+
+                        matched = self._evaluate_order_conditions(
+                            order_df,
+                            step.get("conditions", []),
+                            step.get("match", "ALL"),
+                        )
+                        if not matched:
+                            logger.info(
+                                f"[RULE ENGINE] Order {order_number} rule "
+                                f"'{rule_name}' step {step_idx+1}: no match, stopping"
+                            )
+                            break
+
+                        actions = step.get("actions", [])
+                        apply_to_all = [
+                            a for a in actions
+                            if a.get("type", "").upper() in ("ADD_TAG", "ADD_ORDER_TAG")
+                        ]
+                        apply_to_first = [
+                            a for a in actions
+                            if a.get("type", "").upper() not in ("ADD_TAG", "ADD_ORDER_TAG")
+                        ]
+
+                        # Masks are built only once a step has matched and has
+                        # actions, so the O(len(df)) allocation stays off the
+                        # hot path.
+                        if apply_to_all:
+                            mask = pd.Series(False, index=df.index)
+                            mask.iloc[positions] = True
+                            all_new_rows.extend(
+                                self._execute_actions(df, mask, apply_to_all)
+                            )
+
+                        if apply_to_first:
+                            mask = pd.Series(False, index=df.index)
+                            mask.iloc[positions[0]] = True
+                            all_new_rows.extend(
+                                self._execute_actions(df, mask, apply_to_first)
+                            )
+```
+
+What this deletes, deliberately:
+- `order_mask = df["Order_Number"] == order_number` — an O(rows) scan per order,
+  replaced by the single groupby
+- `df[order_mask]` on the old line 824 — computed and discarded
+- `order_eligible_mask = order_mask.copy()` — never reassigned inside the step
+  loop, so it never narrowed anything (F4)
+- `eligible_df.index[0]` label addressing — now `positions[0]` (F5)
+
+`positions_by_order` is keyed by order number; `.items()` preserves first-seen
+order because of `sort=False`, which keeps log output in the same sequence as
+before.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules.py -v`
+
+Expected: all PASS, including all four in `TestOrderRuleLoopRewrite`.
+
+- [ ] **Step 5: Correct the step-semantics documentation**
+
+Order-level steps gate; article-level steps narrow. Two places say otherwise.
+
+In `gui/settings/rules.py:359`, replace the tooltip:
+
+```python
+        add_step_btn.setToolTip(
+            "Add a step to this rule.\n"
+            "article rules: each step narrows the rows matched by the step before it.\n"
+            "order rules: each step is a gate on the whole order - if it does not\n"
+            "match, the rule stops and later steps do not run."
+        )
+```
+
+In `shopify_tool/rules.py`, extend the `apply()` docstring's
+"Supports both article-level (row-by-row) and order-level (entire order) rules."
+line with:
+
+```
+        Multi-step rules behave differently by level: article-level steps narrow
+        the matched rows progressively, while order-level steps act as sequential
+        gates on the whole order.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shopify_tool/rules.py gui/settings/rules.py tests/test_rules.py
+git commit -m "perf(rules): group orders once and index positionally in the order-rule loop"
+```
+
+---
+
+### Task 3: Quiet the leftover debug logging
+
+Closes F6. Task 1 already removed the per-condition dumps in `_get_matching_rows`;
+this task handles the editor side.
+
+**Files:**
+- Modify: `gui/settings/rules.py:194-226` (`get_available_rule_fields`)
+- Modify: `shopify_tool/rules.py` (three comments, Step 2)
+- Test: none — this is deletion of logging and comment translation, with no
+  behavioural surface.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing. `get_available_rule_fields()` keeps its current signature
+  here; Task 5 changes it.
+
+- [ ] **Step 1: Delete the development-time logging**
+
+In `get_available_rule_fields`, delete these five `logger` calls outright:
+
+```python
+logger.info(f"[RULE ENGINE] DataFrame has {len(all_columns)} columns")
+logger.info(f"[RULE ENGINE] ALL COLUMNS: {all_columns}")
+logger.info(f"[RULE ENGINE] 'Stock' in columns: {'Stock' in all_columns}")
+logger.info(f"[RULE ENGINE] 'Total_Price' in columns: {'Total_Price' in all_columns}")
+logger.info(f"[RULE ENGINE] Found {len(custom_columns)} custom columns: {custom_columns}")
+```
+
+Keep the `logger.warning` in the `else` branch — a missing `analysis_df` is worth
+knowing about. Leave the surrounding logic untouched.
+
+- [ ] **Step 2: Translate the two Ukrainian comments in the rewritten area**
+
+The spec limits this to comments next to code these tasks already touch — no
+repo-wide sweep. Task 2 rewrote the order-rule loop, which sits between these
+two, in `shopify_tool/rules.py`:
+
+```python
+    # Збирати нові рядки з ADD_PRODUCT actions        (~line 772)
+    all_new_rows = []
+```
+becomes
+```python
+    # Rows created by ADD_PRODUCT actions, appended after all rules run.
+    all_new_rows = []
+```
+
+and
+
+```python
+    # Додати всі нові рядки з ADD_PRODUCT actions     (~line 876)
+    if all_new_rows:
+```
+becomes
+```python
+    # Append the rows ADD_PRODUCT actions created.
+    if all_new_rows:
+```
+
+There is a third inside `_execute_actions` (`new_rows = []  # Збирати нові рядки тут`)
+— translate it to `# Rows to append, collected here.` while you are in the file.
+Leave every other Ukrainian string alone; the Phase 6 tag-categories task owns
+those.
+
+- [ ] **Step 3: Verify nothing else referenced them**
+
+Run: `.venv/bin/ruff check gui/settings/rules.py`
+
+Expected: clean. If `logger` is now unused in the module, ruff will say so —
+check before deleting the import, since other methods in this 1256-line file use
+it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gui/settings/rules.py shopify_tool/rules.py
+git commit -m "chore(rules): drop development-time column logging, translate stale comments"
+```
+
+---
+
+### Task 4 (optional, droppable): OPERATOR_MAP holds functions
+
+Closes F5's tidy half of the spec (section 1.5). **Drop this task if the diff is
+already large** — it is cleanup, not a fix, and nothing depends on it.
+
+**Files:**
+- Modify: `shopify_tool/rules.py:26-52` (`OPERATOR_MAP`) and its eight call sites
+- Test: `tests/test_rules.py` (existing coverage is the check)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `OPERATOR_MAP: dict[str, Callable]` — values become the operator
+  functions themselves rather than their names. Nothing outside `rules.py`
+  imports it (verified: the only other operator vocabulary is
+  `CONDITION_OPERATORS` in `gui/settings/fields.py`, a plain list of display
+  strings, which is unaffected).
+
+- [ ] **Step 1: Move the map below the operator definitions**
+
+`OPERATOR_MAP` currently sits at line 26, above every `_op_*` function, which is
+why it holds strings. Move the literal to just after `_op_does_not_match_regex`
+(the last operator, ending around line 630) and above `class RuleEngine`, then
+change the values from names to references:
+
+```python
+OPERATOR_MAP = {
+    "equals": _op_equals,
+    "does not equal": _op_not_equals,
+    "contains": _op_contains,
+    "does not contain": _op_not_contains,
+    "is greater than": _op_greater_than,
+    "is less than": _op_less_than,
+    "is greater than or equal": _op_greater_than_or_equal,
+    "is less than or equal": _op_less_than_or_equal,
+    "starts with": _op_starts_with,
+    "ends with": _op_ends_with,
+    "is empty": _op_is_empty,
+    "is not empty": _op_is_not_empty,
+    "in list": _op_in_list,
+    "not in list": _op_not_in_list,
+    "between": _op_between,
+    "not between": _op_not_between,
+    "date before": _op_date_before,
+    "date after": _op_date_after,
+    "date equals": _op_date_equals,
+    "matches regex": _op_matches_regex,
+    "does not match regex": _op_does_not_match_regex,
+}
+```
+
+Drop the `# NEW:` comments while moving it — they have not been new for a long
+time.
+
+- [ ] **Step 2: Replace every `globals()` lookup**
+
+Change all eight occurrences of
+
+```python
+op_func = globals()[OPERATOR_MAP[operator]]
+```
+
+to
+
+```python
+op_func = OPERATOR_MAP[operator]
+```
+
+They are at (pre-edit line numbers) 1289, 1297, 1363, 1379, 1409, 1447, plus the
+one Task 1 wrote into `_get_matching_rows`. Find them all with
+`grep -n "globals()\[" shopify_tool/rules.py` and confirm the count reaches zero
+afterwards.
+
+Also update the module docstring at rules.py:18-19, which describes the map as
+pointing at "internal function names".
+
+- [ ] **Step 3: Run the full rule suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules.py -v`
+
+Expected: all PASS. The existing operator tests are the real check here — this
+change is behaviour-preserving by construction, so any failure means a name was
+mistyped in the map.
+
+Run: `grep -n "globals()\[" shopify_tool/rules.py` — expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shopify_tool/rules.py
+git commit -m "refactor(rules): OPERATOR_MAP holds operator functions, not their names"
+```
+
+---
+
+### Task 5: Level-aware field lists, one source of truth
+
+Closes F2 and F9. This is where Phase 2 starts, and it is the task that stops
+users creating the conditions Task 1 now fails closed.
+
+**Files:**
+- Modify: `gui/settings/rules.py:156-226` (`get_available_rule_fields`)
+- Modify: `gui/settings/rules.py:524-560` (`add_condition_row`, combo population)
+- Modify: `gui/settings/rules.py:253-398` (`add_rule_widget`, level change wiring)
+- Modify: `gui/settings/fields.py:29-40` (delete dead lists)
+- Test: `tests/test_rules_page.py` (create)
+
+**Interfaces:**
+- Consumes: `RuleEngine.ORDER_LEVEL_FIELDS` (a `dict[str, str]`; only its keys
+  are used here).
+- Produces:
+  - `RulesPage.get_available_rule_fields(self, level="article")` — returns
+    `list[str]`. When `level == "order"` the returned list starts with the
+    `"--- ORDER-LEVEL FIELDS ---"` separator followed by the engine's order-level
+    field names; when `level == "article"` that block is omitted entirely.
+  - `RulesPage._repopulate_field_combos(self, rule_widget_refs)` — returns
+    `None`. Rebuilds every condition field combo in the rule for the rule's
+    current level, preserving each combo's current selection.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_rules_page.py`:
+
+```python
+"""RulesPage field vocabularies and level awareness."""
+import pandas as pd
+import pytest
+
+from gui.settings.rules import RulesPage
+from shopify_tool.rules import RuleEngine
+
+
+@pytest.fixture
+def analysis_df():
+    return pd.DataFrame({
+        "Order_Number": ["A", "B"],
+        "SKU": ["x", "y"],
+        "Quantity": [1, 2],
+    })
+
+
+def _order_field_names():
+    return set(RuleEngine.ORDER_LEVEL_FIELDS.keys())
+
+
+class TestLevelAwareFields:
+    def test_article_level_omits_order_fields(self, qtbot, analysis_df):
+        page = RulesPage([], analysis_df)
+        qtbot.addWidget(page)
+        fields = set(page.get_available_rule_fields(level="article"))
+        assert not (fields & _order_field_names())
+        assert "--- ORDER-LEVEL FIELDS ---" not in fields
+
+    def test_order_level_includes_every_engine_order_field(self, qtbot, analysis_df):
+        page = RulesPage([], analysis_df)
+        qtbot.addWidget(page)
+        fields = set(page.get_available_rule_fields(level="order"))
+        assert _order_field_names() <= fields
+
+    def test_article_level_still_offers_dataframe_columns(self, qtbot, analysis_df):
+        page = RulesPage([], analysis_df)
+        qtbot.addWidget(page)
+        fields = page.get_available_rule_fields(level="article")
+        assert "SKU" in fields
+        assert "Quantity" in fields
+
+
+class TestLevelSwitchPreservesSavedField:
+    def test_switching_to_article_keeps_unknown_field_selected(self, qtbot, analysis_df):
+        rule = {
+            "name": "r", "level": "order",
+            "steps": [{
+                "conditions": [{"field": "item_count", "operator": "equals", "value": "2"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+        page = RulesPage([rule], analysis_df)
+        qtbot.addWidget(page)
+
+        refs = page.rule_widgets[0]
+        refs["level_combo"].setCurrentText("article")
+
+        combo = refs["steps"][0]["conditions"][0]["field"]
+        assert combo.currentText() == "item_count"
+        assert page.collect()["rules"][0]["steps"][0]["conditions"][0]["field"] == "item_count"
+```
+
+If `qtbot` is not available, check `tests/conftest.py` for the fixture this repo
+already uses for widget tests (`tests/test_column_config_dialog.py` is a working
+example) and follow that pattern instead — do not add `pytest-qt` as a
+dependency for this.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py -v`
+
+Expected: FAIL with `TypeError: get_available_rule_fields() got an unexpected
+keyword argument 'level'`.
+
+- [ ] **Step 3: Make the field list level-aware and engine-sourced**
+
+In `gui/settings/rules.py`, add the import:
+
+```python
+from shopify_tool.rules import RuleEngine
+```
+
+Then change the signature and the hardcoded block:
+
+```python
+    def get_available_rule_fields(self, level="article"):
+        """Fields offered for a condition on a rule of the given level.
+
+        Order-level field names come from RuleEngine.ORDER_LEVEL_FIELDS so the
+        editor cannot drift from what the engine dispatches on, and they are
+        offered only on order-level rules -- on an article rule they are never
+        DataFrame columns, so selecting one produces a condition the engine
+        treats as no-match.
+        """
+        fields = []
+        if level == "order":
+            fields += ["--- ORDER-LEVEL FIELDS ---"]
+            fields += list(RuleEngine.ORDER_LEVEL_FIELDS.keys())
+```
+
+Keep the rest of the method as it is (common fields, then discovered DataFrame
+columns), appending to `fields` instead of concatenating the removed
+`order_level_fields` local. Delete that local entirely.
+
+- [ ] **Step 4: Pass the level in, and preserve unknown selections**
+
+In `add_condition_row`, the level is reachable from the rule the step belongs to.
+The simplest correct route: give `add_condition_row` the level via the step refs.
+Add a `"level_combo"` key to `step_refs` in `_add_step_widget` (it already
+receives `rule_widget_refs`):
+
+```python
+        step_refs = {
+            "step_box": step_box,
+            "separator_label": separator_label,
+            "match_combo": match_combo,
+            "conditions_layout": conditions_rows_layout,
+            "actions_layout": actions_rows_layout,
+            "conditions": [],
+            "actions": [],
+            "level_combo": rule_widget_refs["level_combo"],
+        }
+```
+
+Then in `add_condition_row`, replace
+
+```python
+        available_fields = self.get_available_rule_fields()
+```
+
+with
+
+```python
+        level_combo = rule_widget_refs.get("level_combo")
+        level = level_combo.currentText() if level_combo else "article"
+        available_fields = self.get_available_rule_fields(level=level)
+```
+
+The existing "field not found in combo box - add it to preserve saved value"
+branch (around line 570) already handles a saved field that the level no longer
+offers. Leave it exactly as it is — it is the mechanism the spec relies on.
+
+- [ ] **Step 5: Rebuild combos when the level changes**
+
+Add this method to `RulesPage`, next to `_update_priority_labels`:
+
+```python
+    def _repopulate_field_combos(self, rule_widget_refs):
+        """Rebuilds condition field combos after the rule's level changed.
+
+        A field the new level does not offer is kept as an extra item so a
+        saved condition is never silently reset; Task 6's validation marks it.
+        """
+        level = rule_widget_refs["level_combo"].currentText()
+        available_fields = self.get_available_rule_fields(level=level)
+
+        for step_refs in rule_widget_refs.get("steps", []):
+            for cond_refs in step_refs["conditions"]:
+                combo = cond_refs["field"]
+                previous = combo.currentText()
+
+                combo.blockSignals(True)
+                combo.clear()
+                for field in available_fields:
+                    combo.addItem(field)
+                    if field.startswith("---"):
+                        combo.model().item(combo.count() - 1).setEnabled(False)
+
+                index = combo.findText(previous)
+                if index < 0:
+                    combo.addItem(previous)
+                    index = combo.count() - 1
+                combo.setCurrentIndex(index)
+                combo.blockSignals(False)
+```
+
+`blockSignals` matters: `currentTextChanged` is wired to
+`_on_rule_condition_changed`, which rebuilds the value widget. Letting it fire
+once per `addItem` during a rebuild would churn widgets and can drop the user's
+typed value.
+
+Wire it in `add_rule_widget`, alongside the existing button connections:
+
+```python
+        level_combo.currentTextChanged.connect(
+            lambda: [self._repopulate_field_combos(widget_refs),
+                     self._update_priority_labels()]
+        )
+```
+
+`_update_priority_labels` is included because the label is per-level, so changing
+a rule's level renumbers every rule.
+
+- [ ] **Step 6: Delete the dead duplicate lists**
+
+In `gui/settings/fields.py`, delete `ORDER_LEVEL_FIELDS` (lines 29-38) and
+`CONDITION_FIELDS` (line 40) together with the comment above them. Nothing
+imports either name.
+
+Verify first: `grep -rn "CONDITION_FIELDS\|ORDER_LEVEL_FIELDS" --include=*.py . | grep -v .venv`
+Expected after the change: only `shopify_tool/rules.py` and the new uses in
+`gui/settings/rules.py`.
+
+- [ ] **Step 7: Run the tests**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py tests/test_rules.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add gui/settings/rules.py gui/settings/fields.py tests/test_rules_page.py
+git commit -m "fix(rules-ui): offer order-level fields only on order rules, sourced from the engine"
+```
+
+---
+
+### Task 6: Flag conditions the engine cannot evaluate
+
+Closes the UI half of decision D1. Without this, Task 1's fail-closed change is
+discovered from a log file after a run instead of in the editor before it.
+
+**Files:**
+- Modify: `gui/settings/rules.py:807-855` (`_show_validation_feedback` area — add
+  a sibling helper)
+- Modify: `gui/settings/rules.py:738-806` (`_perform_validation`)
+- Modify: `gui/settings/rules.py:611-709` (`_on_rule_condition_changed` — trigger)
+- Test: `tests/test_rules_page.py`
+
+**Interfaces:**
+- Consumes: `RulesPage.get_available_rule_fields(level=...)` from Task 5.
+- Produces: `RulesPage._check_field_resolvable(self, condition_refs)` — returns
+  `bool`. `True` when the selected field is one the engine can evaluate for this
+  rule's level. Styles the field combo red and shows a message when `False`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_rules_page.py`:
+
+```python
+class TestUnresolvableFieldIsFlagged:
+    def test_order_field_on_article_rule_is_flagged(self, qtbot, analysis_df):
+        rule = {
+            "name": "r", "level": "article",
+            "steps": [{
+                "conditions": [{"field": "item_count", "operator": "equals", "value": "2"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+        page = RulesPage([rule], analysis_df)
+        qtbot.addWidget(page)
+
+        cond_refs = page.rule_widgets[0]["steps"][0]["conditions"][0]
+        assert page._check_field_resolvable(cond_refs) is False
+        assert "border" in cond_refs["field"].styleSheet()
+
+    def test_real_column_is_not_flagged(self, qtbot, analysis_df):
+        rule = {
+            "name": "r", "level": "article",
+            "steps": [{
+                "conditions": [{"field": "SKU", "operator": "equals", "value": "x"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+        page = RulesPage([rule], analysis_df)
+        qtbot.addWidget(page)
+
+        cond_refs = page.rule_widgets[0]["steps"][0]["conditions"][0]
+        assert page._check_field_resolvable(cond_refs) is True
+        assert cond_refs["field"].styleSheet() == ""
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py::TestUnresolvableFieldIsFlagged -v`
+
+Expected: FAIL with `AttributeError: 'RulesPage' object has no attribute '_check_field_resolvable'`.
+
+- [ ] **Step 3: Add the check**
+
+Add to `RulesPage`, directly after `_show_validation_feedback`:
+
+```python
+    def _check_field_resolvable(self, condition_refs):
+        """Marks a field the engine will treat as no-match.
+
+        The engine fails a condition closed when its field is not a column (or,
+        on an order rule, a known order-level field). Showing that here means the
+        user sees it while editing rather than finding a rule that quietly
+        stopped firing.
+
+        Returns:
+            bool: True when the field is one the engine can evaluate.
+        """
+        theme = get_theme_manager().get_current_theme()
+        combo = condition_refs.get("field")
+        if combo is None:
+            return True
+
+        field = combo.currentText()
+        level_combo = condition_refs.get("level_combo")
+        level = level_combo.currentText() if level_combo else "article"
+        known = set(self.get_available_rule_fields(level=level))
+        resolvable = bool(field) and not field.startswith("---") and field in known
+
+        if resolvable:
+            combo.setStyleSheet("")
+        else:
+            combo.setStyleSheet(f"border: 1px solid {theme.accent_red};")
+            self._show_validation_feedback(
+                condition_refs,
+                "error",
+                f"'{field}' is not available on an {level} rule - this condition "
+                f"will never match.",
+            )
+        return resolvable
+```
+
+`_show_validation_feedback` styles `value_widget` and reuses `feedback_label`;
+this helper styles the *field* combo itself, so the two do not fight over the
+same widget.
+
+- [ ] **Step 4: Give conditions access to their level, and call the check**
+
+`_check_field_resolvable` reads `condition_refs["level_combo"]`. Set it where
+`condition_refs` is built in `add_condition_row`:
+
+```python
+        condition_refs = {
+            "widget": row_widget,
+            "field": field_combo,
+            "op": op_combo,
+            "value_widget": None,
+            "value_layout": row_layout,
+            "level_combo": rule_widget_refs.get("level_combo"),
+        }
+```
+
+Then call the check at the end of `_perform_validation`, so it runs on the same
+trigger as the existing value validation:
+
+```python
+        self._check_field_resolvable(condition_refs)
+```
+
+Place it as the final statement of the method, after the existing operator-based
+branches — a value that is itself valid should still show the field error.
+
+Also call it from `_repopulate_field_combos` (Task 5), once per condition after
+`combo.blockSignals(False)`, so changing a rule's level re-marks affected
+conditions immediately:
+
+```python
+                self._check_field_resolvable(cond_refs)
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/settings/rules.py tests/test_rules_page.py
+git commit -m "feat(rules-ui): flag conditions the engine cannot evaluate"
+```
+
+---
+
+### Task 7: Collapsible rule cards with a summary header
+
+Closes F7. The largest UI change; keep `collect()` untouched so a collapsed rule
+still round-trips.
+
+**Files:**
+- Modify: `gui/settings/rules.py:253-398` (`add_rule_widget`)
+- Test: `tests/test_rules_page.py`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 5-6 beyond the existing `widget_refs` dict.
+- Produces: two new `widget_refs` keys —
+  - `"body"`: the `QWidget` holding level combo, steps container and "+ Add Step";
+    its visibility is the collapse state
+  - `"summary_label"`: the `QLabel` in the header showing the counts line
+  - and `RulesPage._update_rule_summary(self, widget_refs)` returning `None`,
+    which rewrites that label from the current widget state.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_rules_page.py`:
+
+```python
+class TestCollapsibleRuleCards:
+    def _rule(self, name="r"):
+        return {
+            "name": name, "level": "article",
+            "steps": [{
+                "conditions": [{"field": "SKU", "operator": "equals", "value": "x"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+
+    def test_loaded_rules_start_collapsed(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        assert page.rule_widgets[0]["body"].isVisibleTo(page) is False
+
+    def test_added_rule_starts_expanded(self, qtbot, analysis_df):
+        page = RulesPage([], analysis_df)
+        qtbot.addWidget(page)
+        page.add_rule_widget()
+        assert page.rule_widgets[0]["body"].isVisibleTo(page) is True
+
+    def test_summary_reports_counts(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        text = page.rule_widgets[0]["summary_label"].text()
+        assert "article" in text
+        assert "1 step" in text
+        assert "1 condition" in text
+        assert "1 action" in text
+
+    def test_collect_is_unaffected_by_collapse_state(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        collapsed = page.collect()
+        page.rule_widgets[0]["body"].setVisible(True)
+        assert page.collect() == collapsed
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py::TestCollapsibleRuleCards -v`
+
+Expected: FAIL with `KeyError: 'body'`.
+
+- [ ] **Step 3: Move the rule body into a toggled widget**
+
+In `add_rule_widget`, add a disclosure button as the first header widget, before
+the priority label:
+
+```python
+        toggle_btn = QPushButton("▶")
+        set_button_role(toggle_btn, "secondary")
+        toggle_btn.setMaximumWidth(30)
+        toggle_btn.setToolTip("Show or hide this rule's conditions and actions")
+        header_layout.addWidget(toggle_btn)
+```
+
+Add the summary label after the name field, before the Delete button:
+
+```python
+        summary_label = QLabel("")
+        summary_label.setStyleSheet(f"color: {theme.text_secondary}; {font_css('caption')}")
+        header_layout.addWidget(summary_label)
+```
+
+Then wrap everything below the header in a body widget. Replace the direct
+`rule_layout.addLayout(level_layout)` / `rule_layout.addLayout(steps_container)` /
+`rule_layout.addWidget(add_step_btn, ...)` calls with:
+
+```python
+        body = QWidget()
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+        body_layout.addLayout(level_layout)
+        body_layout.addLayout(steps_container)
+        body_layout.addWidget(add_step_btn, 0, Qt.AlignLeft)
+        rule_layout.addWidget(body)
+```
+
+Register both in `widget_refs`:
+
+```python
+            "body": body,
+            "summary_label": summary_label,
+```
+
+and wire the toggle:
+
+```python
+        def _toggle():
+            visible = not body.isVisible()
+            body.setVisible(visible)
+            toggle_btn.setText("▼" if visible else "▶")
+
+        toggle_btn.clicked.connect(_toggle)
+```
+
+- [ ] **Step 4: Set the initial state**
+
+A rule loaded from config starts collapsed; a rule the user just added starts
+expanded, because they are about to edit it. `add_rule_widget(config=None)` is
+exactly that distinction — it is called with a config when loading
+(`for rule_config in rules: self.add_rule_widget(rule_config)`) and without one
+from the "Add New Rule" button. At the end of `add_rule_widget`, after the steps
+are loaded:
+
+```python
+        expanded = config_was_none
+        body.setVisible(expanded)
+        toggle_btn.setText("▼" if expanded else "▶")
+        self._update_rule_summary(widget_refs)
+```
+
+`config_was_none` must be captured at the very top of the method, before the
+`if not isinstance(config, dict): config = {...}` line overwrites it:
+
+```python
+        config_was_none = not isinstance(config, dict)
+```
+
+- [ ] **Step 5: Add the summary**
+
+```python
+    def _update_rule_summary(self, widget_refs):
+        """Rewrites a rule's header summary from its current widget state."""
+        level = widget_refs["level_combo"].currentText()
+        steps = widget_refs.get("steps", [])
+        conditions = sum(len(s["conditions"]) for s in steps)
+        actions = sum(len(s["actions"]) for s in steps)
+
+        def plural(n, word):
+            return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+        widget_refs["summary_label"].setText(
+            f"{level} · {plural(len(steps), 'step')} · "
+            f"{plural(conditions, 'condition')} · {plural(actions, 'action')}"
+        )
+```
+
+Keep it accurate by calling it wherever the counts can change. Add
+`self._update_rule_summary(rule_widget_refs)` as the last line of
+`_add_step_widget`, `_delete_step`, `add_condition_row` and `add_action_row`, and
+in the `level_combo.currentTextChanged` lambda from Task 5. The condition and
+action *delete* buttons route through `_delete_row_from_list`, which does not
+receive the rule refs — extend those two `clicked.connect` lambdas instead:
+
+```python
+        delete_btn.clicked.connect(
+            lambda: [self._delete_row_from_list(row_widget,
+                                                rule_widget_refs["conditions"],
+                                                condition_refs),
+                     self._update_rule_summary_for_step(rule_widget_refs)]
+        )
+```
+
+where the step-level helper resolves back to the owning rule:
+
+```python
+    def _update_rule_summary_for_step(self, step_refs):
+        """Finds the rule a step belongs to and refreshes its summary."""
+        for rule_w in self.rule_widgets:
+            if step_refs in rule_w.get("steps", []):
+                self._update_rule_summary(rule_w)
+                return
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py -v`
+
+Expected: all PASS, including Tasks 5 and 6's tests — Task 5's
+`test_switching_to_article_keeps_unknown_field_selected` reaches into
+`refs["steps"][0]["conditions"][0]`, which the body rewrap must not disturb.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/settings/rules.py tests/test_rules_page.py
+git commit -m "feat(rules-ui): collapsible rule cards with a counts summary"
+```
+
+---
+
+### Task 8: Filter box and level-aware reordering
+
+Closes F8 and the filter half of F7.
+
+**Files:**
+- Modify: `gui/settings/rules.py:44-69` (`__init__` header row)
+- Modify: `gui/settings/rules.py:84-155` (`_move_rule_up`, `_move_rule_down`,
+  `_update_priority_labels`)
+- Test: `tests/test_rules_page.py`
+
+**Interfaces:**
+- Consumes: `widget_refs["group_box"]` and `widget_refs["level_combo"]`.
+- Produces: `RulesPage._filter_rules(self, text)` returning `None` — hides rule
+  cards whose name does not contain `text`, case-insensitively. Empty text shows
+  all.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_rules_page.py`:
+
+```python
+class TestFilterAndReorder:
+    def _rule(self, name, level="article"):
+        return {
+            "name": name, "level": level,
+            "steps": [{
+                "conditions": [{"field": "SKU", "operator": "equals", "value": "x"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+
+    def test_filter_hides_non_matching_rules(self, qtbot, analysis_df):
+        page = RulesPage([self._rule("alpha"), self._rule("beta")], analysis_df)
+        qtbot.addWidget(page)
+        page._filter_rules("alp")
+        assert page.rule_widgets[0]["group_box"].isVisibleTo(page) is True
+        assert page.rule_widgets[1]["group_box"].isVisibleTo(page) is False
+
+    def test_empty_filter_shows_everything(self, qtbot, analysis_df):
+        page = RulesPage([self._rule("alpha"), self._rule("beta")], analysis_df)
+        qtbot.addWidget(page)
+        page._filter_rules("alp")
+        page._filter_rules("")
+        assert page.rule_widgets[1]["group_box"].isVisibleTo(page) is True
+
+    def test_move_up_skips_over_other_level(self, qtbot, analysis_df):
+        page = RulesPage(
+            [self._rule("a1", "article"),
+             self._rule("o1", "order"),
+             self._rule("a2", "article")],
+            analysis_df,
+        )
+        qtbot.addWidget(page)
+        page._move_rule_up(page.rule_widgets[2])
+        names = [r["name_edit"].text() for r in page.rule_widgets]
+        assert names == ["a2", "o1", "a1"]
+
+    def test_first_of_its_level_cannot_move_up(self, qtbot, analysis_df):
+        page = RulesPage(
+            [self._rule("a1", "article"), self._rule("o1", "order")],
+            analysis_df,
+        )
+        qtbot.addWidget(page)
+        assert page.rule_widgets[0]["up_btn"].isEnabled() is False
+        assert page.rule_widgets[1]["up_btn"].isEnabled() is False
+```
+
+`test_move_up_skips_over_other_level` expects a *swap* with the previous
+article rule (`a1`), which sits two positions up — `o1` keeps its slot.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py::TestFilterAndReorder -v`
+
+Expected: FAIL — `_filter_rules` does not exist, and the reorder tests fail
+because the current code swaps with the adjacent entry regardless of level.
+
+- [ ] **Step 3: Add the filter box**
+
+In `__init__`, between the Add button and the stretch in `header_row`:
+
+```python
+        self.filter_edit = QLineEdit()
+        self.filter_edit.setPlaceholderText("Filter rules by name…")
+        self.filter_edit.setClearButtonEnabled(True)
+        self.filter_edit.textChanged.connect(self._filter_rules)
+        header_row.addWidget(self.filter_edit)
+```
+
+and the method:
+
+```python
+    def _filter_rules(self, text):
+        """Hides rule cards whose name does not contain `text`."""
+        needle = (text or "").strip().lower()
+        for rule_w in self.rule_widgets:
+            name = rule_w["name_edit"].text().lower()
+            rule_w["group_box"].setVisible(not needle or needle in name)
+```
+
+- [ ] **Step 4: Reorder within level**
+
+Replace `_move_rule_up` and `_move_rule_down` with a shared implementation that
+finds the nearest neighbour of the same level:
+
+```python
+    def _neighbour_of_same_level(self, idx, direction):
+        """Index of the nearest rule sharing this one's level, or None."""
+        level = self.rule_widgets[idx]["level_combo"].currentText()
+        candidate = idx + direction
+        while 0 <= candidate < len(self.rule_widgets):
+            if self.rule_widgets[candidate]["level_combo"].currentText() == level:
+                return candidate
+            candidate += direction
+        return None
+
+    def _swap_rules(self, idx_a, idx_b):
+        """Swaps two rules in both the refs list and the layout."""
+        widgets = self.rule_widgets
+        widgets[idx_a], widgets[idx_b] = widgets[idx_b], widgets[idx_a]
+
+        layout = self.rules_layout
+        for position in sorted((idx_a, idx_b)):
+            box = widgets[position]["group_box"]
+            layout.removeWidget(box)
+            layout.insertWidget(position, box)
+
+        self._update_priority_labels()
+
+    def _move_rule_up(self, widget_refs):
+        """Moves a rule above the nearest rule of the same level."""
+        idx = self.rule_widgets.index(widget_refs)
+        target = self._neighbour_of_same_level(idx, -1)
+        if target is not None:
+            self._swap_rules(idx, target)
+
+    def _move_rule_down(self, widget_refs):
+        """Moves a rule below the nearest rule of the same level."""
+        idx = self.rule_widgets.index(widget_refs)
+        target = self._neighbour_of_same_level(idx, +1)
+        if target is not None:
+            self._swap_rules(idx, target)
+```
+
+`_swap_rules` re-inserts in ascending position order so the second `insertWidget`
+is not thrown off by the first one's removal.
+
+- [ ] **Step 5: Enable the buttons per level**
+
+In `_update_priority_labels`, replace the two `setEnabled` lines:
+
+```python
+            rule_w["up_btn"].setEnabled(
+                self._neighbour_of_same_level(idx, -1) is not None
+            )
+            rule_w["down_btn"].setEnabled(
+                self._neighbour_of_same_level(idx, +1) is not None
+            )
+```
+
+The per-level `Article #n` / `Order #n` labelling above them is already correct
+and does not change — it is the button behaviour that was out of step with it.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/settings/rules.py tests/test_rules_page.py
+git commit -m "feat(rules-ui): filter box, and reorder within a rule's own level"
+```
+
+---
+
+### Task 9: Full gate and graph refresh
+
+**Files:**
+- No source changes expected. If the gate finds something, fix it here.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+- [ ] **Step 1: Run the whole suite**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest`
+
+Expected: PASS. The baseline before this work was 541 passing tests; this plan
+adds roughly 20, so expect ~561. A *drop* below 541 means something was
+deleted or broken — investigate rather than accepting the new number.
+
+- [ ] **Step 2: Lint**
+
+Run: `.venv/bin/ruff check . --exclude shared`
+
+Expected: clean. Likely findings after these tasks: an unused `logging` import in
+`gui/settings/fields.py` after the deletions, or an unused local where
+`order_level_fields` used to be.
+
+- [ ] **Step 3: Headless smoke check**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -c "
+import pandas as pd
+from PySide6.QtWidgets import QApplication
+from gui.settings.rules import RulesPage
+app = QApplication([])
+df = pd.DataFrame({'Order_Number': ['A'], 'SKU': ['x'], 'Quantity': [1]})
+rule = {'name': 'smoke', 'level': 'article', 'steps': [{'conditions': [{'field': 'SKU', 'operator': 'equals', 'value': 'x'}], 'match': 'ALL', 'actions': [{'type': 'ADD_TAG', 'value': 'T'}]}]}
+page = RulesPage([rule], df)
+print(page.collect())
+"`
+
+Expected: prints a `{'rules': [...]}` dict whose single rule round-trips the SKU
+condition and the ADD_TAG action, with `priority: 1`. This catches a page that
+imports and constructs but cannot serialise.
+
+- [ ] **Step 4: Refresh the knowledge graph**
+
+Run: `graphify update .`
+
+Required by this repo's CLAUDE.md after modifying code.
+
+- [ ] **Step 5: Commit anything the gate changed**
+
+```bash
+git add -A
+git commit -m "chore(rules): gate fixes and graph refresh"
+```
+
+Skip this commit if the gate was clean and `graphify update` produced no tracked
+changes.
+
+---
+
+## Notes for the implementer
+
+**The one behaviour change is Task 1.** Everything else is performance, dead code,
+or UI. If Task 1's tests pass but a pre-existing test breaks, that test may be
+encoding the old widening behaviour — read it before touching it, and say so in
+the commit message if you change its expectation.
+
+**Task 4 is optional.** Drop it if the diff is already large; nothing depends on
+it.
+
+**Do not restructure the editor into separate article and order sections.** That
+was considered and deliberately left out of scope — Task 8's within-level
+reordering is the smaller answer to the same problem.
+
+**Watch the `rule_widget_refs` parameter name.** `add_condition_row` and
+`add_action_row` declare a parameter called `rule_widget_refs`, but they are
+called as `self.add_condition_row(step_refs, ...)` — inside those two methods the
+name refers to a *step's* refs, not a rule's. That is why Task 5 puts
+`"level_combo"` on `step_refs` and Task 7 passes that same object to
+`_update_rule_summary_for_step` (which searches for the owning rule) rather than
+to `_update_rule_summary` (which needs rule refs). Renaming the parameter is out
+of scope; just do not assume it means what it says.
+
+**`collect()` must not change.** Tasks 7 and 8 alter how rules are displayed and
+ordered, never how they serialise. `test_collect_is_unaffected_by_collapse_state`
+guards the collapse half; the existing settings round-trip tests guard the rest.

--- a/docs/superpowers/specs/2026-08-13-rule-engine-ui-design.md
+++ b/docs/superpowers/specs/2026-08-13-rule-engine-ui-design.md
@@ -1,0 +1,297 @@
+# Rule Engine & Rule UI — Design
+
+Date: 2026-08-13
+Roadmap: Phase 6 — "Rule engine / Rule UI: fresh look at logic and UI"
+Touches: `shopify_tool/rules.py`, `gui/settings/rules.py`
+
+## Problem
+
+The rule engine and its editor have grown to 1457 and 1256 lines respectively
+without a review pass. Reading both end to end surfaced one correctness bug that
+silently changes which orders get tagged, one performance problem that scales
+with order count, and a UI that has no overview at all.
+
+This document covers both halves in one change, engine first.
+
+## Findings
+
+### F1 — Invalid conditions widen the match (correctness)
+
+`_get_matching_rows` evaluates a rule's conditions and skips any it cannot
+resolve:
+
+```python
+if field not in df.columns:
+    logger.warning(...)
+    continue          # rules.py:963
+```
+
+The skipped condition never reaches `condition_results`, so `ALL` (`.all(axis=1)`)
+combines only the survivors. A rule written as
+
+> `Order_Type equals Single` **AND** `item_count is greater than 3`
+
+where the second condition cannot resolve does not stop matching — it silently
+becomes
+
+> `Order_Type equals Single`
+
+and tags **every** single-type row instead of a narrow subset. The failure is
+invisible: a `WARNING` in a log no warehouse operator reads, and correct-looking
+output that is simply too broad.
+
+The order-level path handles the identical mistake the opposite way:
+
+```python
+if field not in order_df.columns or operator not in OPERATOR_MAP:
+    result = False    # rules.py:1294 — fails closed
+```
+
+So the two evaluation paths disagree on the same input.
+
+### F2 — The UI hands users the input that triggers F1
+
+`get_available_rule_fields()` returns the order-level fields
+(`item_count`, `total_quantity`, `has_sku`, …) unconditionally, and
+`add_condition_row` offers that same list on **every** condition regardless of
+the rule's level. On an article-level rule those names are never DataFrame
+columns, so selecting one produces exactly the unresolvable condition F1 then
+drops. The most natural user mistake and the silent-widening bug are wired
+directly together.
+
+### F3 — Order-rule evaluation is O(orders x rules x steps x rows)
+
+```python
+for order_number in df["Order_Number"].unique():
+    order_mask = df["Order_Number"] == order_number   # O(N)
+    df[order_mask]                                    # O(N), result discarded
+    for rule in order_rules:
+        order_eligible_mask = order_mask.copy()
+        for step_idx, step in enumerate(steps):
+            eligible_df = df[order_eligible_mask]     # O(N), every step
+```
+
+Every slice is a boolean mask over the **whole** DataFrame, re-taken per step per
+rule per order. For 3000 orders, 3 order-level rules and 9000 rows that is on the
+order of 10^8 element operations spent selecting rows, before a single condition
+is evaluated. Line 824 (`df[order_mask]`) computes a slice and discards it
+outright.
+
+### F4 — Order-rule steps gate, they do not narrow
+
+`order_eligible_mask` is copied at rules.py:833 and never reassigned inside the
+step loop. Article-level rules genuinely narrow (`current_matches & full_step_matches`,
+rules.py:805); order-level rules re-evaluate the same full order every step and
+either proceed or `break`.
+
+Gating is arguably the correct semantics — order-level conditions are aggregates
+over the whole order, so "narrowing" the order is not meaningful. The defect is
+that the code carries a narrowing-shaped variable that never narrows, and the
+"+ Add Step" tooltip promises narrowing unconditionally:
+
+> "Add a new step to this rule (narrowing: each step filters rows from previous step)"
+
+### F5 — Label-based row addressing is unsafe
+
+`first_row_index = eligible_df.index[0]` followed by
+`first_row_mask[first_row_index] = True` (rules.py:870-872) addresses by index
+*label*. `apply()` ends with `pd.concat([df, new_df], ignore_index=True)`, and
+callers are free to hand in a DataFrame with duplicate labels; a duplicate label
+would set more than one row. Latent, not currently observed.
+
+### F6 — Debug logging left at INFO
+
+`_get_matching_rows` logs the column dtype, the rule value's repr and five sample
+values for **every condition of every step of every rule**. `get_available_rule_fields`
+logs the full column list plus leftover probes:
+
+```python
+logger.info(f"[RULE ENGINE] 'Total_Price' in columns: {'Total_Price' in all_columns}")
+```
+
+These are development aids that shipped. They cost log I/O on a network share and
+bury the per-rule audit line that is actually worth keeping.
+
+### F7 — No overview in the editor
+
+Every rule renders fully expanded into one scroll area: header row, level combo,
+then N steps each with an `IF` group box of condition rows and a `THEN` group box
+of action rows. There is no collapse, no summary, no filter. A dozen rules is an
+unreadable scroll, and finding the rule you want to edit means visually scanning
+all of them.
+
+### F8 — Reorder buttons disagree with priority labels
+
+`_move_rule_up`/`_move_rule_down` swap adjacent entries in the single mixed
+`self.rule_widgets` list. `_update_priority_labels` numbers **per level**
+(`Article #1`, `Order #1`). Moving an article rule past an order rule therefore
+changes nothing the user can see and nothing the engine does — `apply()`
+partitions by level before sorting by priority, so priorities only ever compare
+within a level. The button appears broken because, for that pairing, it is.
+
+## Decisions
+
+Two decisions were put to the user before designing; both were answered.
+
+**D1 — Unresolvable conditions fail closed, and the UI flags them.**
+An unresolvable condition evaluates to `False` rather than being dropped. This
+composes correctly under both match types with no rule-level special case: under
+`ALL` the rule stops matching, under `ANY` the remaining conditions still decide.
+It also makes the article path agree with what the order path already does.
+
+This is a live behaviour change. A rule that currently "works" because a broken
+condition is being ignored will stop firing after this change — which is the
+intent, but it means output can shift on the first run. The UI half is what makes
+that survivable: the offending condition is marked in the editor before the run,
+using the existing validation-feedback mechanism.
+
+**D2 — Both halves, engine first, one PR in two phases.**
+Phase 1 carries the correctness and performance value and is well covered by the
+existing `tests/test_rules.py`. Phase 2 is the larger, riskier Qt diff and depends
+on nothing in Phase 1 except the level-aware field list.
+
+## Design
+
+### Phase 1 — Engine
+
+**1.1 One condition-resolution rule, failing closed.**
+Both `_get_matching_rows` and `_evaluate_order_conditions` classify each condition
+as resolvable or not, on the same criteria: field present, operator present and in
+`OPERATOR_MAP`, field is a real column (or, on the order path, a known
+`ORDER_LEVEL_FIELDS` key). A separator field (`--- … ---`) is unresolvable like any
+other — separators are disabled items in the combo, so they can only reach the
+engine from a hand-edited config, where `False` is the right answer.
+
+Unresolvable yields an all-`False` result for that condition and a single
+`WARNING` naming the rule, the field and why. The existing behaviour when *every*
+condition is unresolvable (all-`False`) is unchanged; only mixed valid/invalid
+rules move.
+
+**1.2 Group orders once; index positionally.**
+
+```python
+positions_by_order = df.groupby("Order_Number", sort=False).indices  # once
+for positions in positions_by_order.values():
+    for rule in order_rules:
+        for step in rule.get("steps", []):
+            order_df = df.iloc[positions]        # O(k), not O(N)
+            if not self._evaluate_order_conditions(order_df, ...):
+                break
+            ...
+```
+
+`order_df` is still re-taken per step, deliberately: today's code re-slices each
+step, so a later step's conditions observe writes made by an earlier step's
+actions. Hoisting the slice out of the loop would silently change that. The win is
+replacing an O(N) boolean mask with an O(k) positional take.
+
+`.indices` returns positional arrays, and all row addressing moves to `.iloc`,
+which fixes F5 for free:
+
+```python
+mask = pd.Series(False, index=df.index)
+mask.iloc[positions] = True          # all rows of the order
+mask.iloc[positions[0]] = True       # first row only
+```
+
+Masks are built only after a step's conditions pass and only when that step has
+actions, so the O(N) allocation happens on the rare path instead of every step.
+
+The discarded `df[order_mask]` (F3) and the never-reassigned `order_eligible_mask`
+(F4) both disappear in this rewrite.
+
+**1.3 Say what steps actually do.**
+Order-level step semantics stay as they are — sequential gates. The `_add_step_widget`
+tooltip becomes level-accurate: article steps narrow the matched rows, order steps
+gate on the whole order. Docstrings on `apply()` follow.
+
+**1.4 Logging levels.**
+Per-condition dtype/sample-value dumps drop to `DEBUG`. The leftover
+`'Stock' in columns` / `'Total_Price' in columns` probes and the full-column-list
+dump in `get_available_rule_fields` are deleted. The per-rule `INFO` line (name,
+priority, step count, matched count) stays — that is the audit trail worth having.
+
+**1.5 Optional tidy, droppable.**
+`OPERATOR_MAP` maps operator names to function *name strings*, resolved through
+`globals()[...]` at eight call sites. Mapping to the functions directly removes the
+indirection and makes the module statically checkable. It has no consumers outside
+`rules.py`. This is cleanup, not a fix — drop it if the diff is already large.
+
+### Phase 2 — UI
+
+**2.1 Collapsible rule cards.**
+The header row (priority label, up/down, Test, name, Delete) stays visible. Level
+combo, steps container and "+ Add Step" move into a body widget toggled by a
+disclosure button. Rules load **collapsed**; "Add New Rule" creates an expanded
+one, since you are about to edit it.
+
+**2.2 Header summary line.**
+Collapsed cards need to be identifiable without expanding. The header gains a
+level badge and a counts summary — `article · 2 steps · 3 conditions · 2 actions`
+— rebuilt on collect-relevant edits. Counts, not a rendered sentence: cheap to
+keep correct, and enough to find the rule you meant.
+
+**2.3 Filter box.**
+A `QLineEdit` above the list that hides cards whose rule name does not match.
+`setVisible` on the group box; no model, no proxy.
+
+**2.4 Reorder within level.**
+↑/↓ swap with the nearest rule of the **same** level rather than the adjacent list
+entry, so the per-level label always changes and the button is never a no-op.
+Enablement follows the same rule (first/last *of its level*). This keeps the
+existing flat list; splitting the page into article and order sections is the
+larger alternative and is deliberately not done here.
+
+**2.5 Level-aware field lists (closes F2).**
+`get_available_rule_fields()` takes the rule's level and omits the order-level
+block for article rules. `level_combo.currentTextChanged` repopulates the field
+combos of that rule's conditions. A previously-saved field that is no longer
+offered is preserved as an extra combo item and marked invalid, reusing the
+existing "field not found in combo box — add it to preserve saved value" path at
+`gui/settings/rules.py:570` and the existing `_show_validation_feedback` styling.
+Nothing is silently reset.
+
+**2.6 Flag unresolvable conditions (closes D1's UI half).**
+`_perform_validation` gains a field-resolvability check on the same code path as
+the current regex/date/range validation, so a condition the engine will now treat
+as `False` is visibly marked in the editor before the run rather than discovered
+afterwards.
+
+## Testing
+
+**Engine** — extend `tests/test_rules.py`:
+- mixed valid/invalid condition under `ALL` no longer matches (the F1 regression;
+  must fail on `main`)
+- mixed valid/invalid under `ANY` still matches on the valid condition
+- order-level and article-level paths agree on an unresolvable field
+- a separator field resolves to no match
+- groupby rewrite is output-equivalent to the current implementation on a
+  multi-order, multi-step, multi-rule fixture
+- a later step observes an earlier step's action writes (guards the deliberate
+  re-slice in 1.2)
+- first-row-only actions target exactly one row when index labels are duplicated
+  (F5)
+
+**UI** — a focused test module, offscreen:
+- collapse toggle hides/shows the body; new rules start expanded
+- filter box hides non-matching cards
+- ↑/↓ swap within level and disable correctly at level boundaries
+- article-level rules are not offered order-level fields; switching level
+  preserves an unknown saved field as a flagged item
+- `collect()` output is unchanged by collapse state (a collapsed rule must still
+  round-trip)
+
+Gate before finishing: `QT_QPA_PLATFORM=offscreen python -m pytest` and
+`ruff check . --exclude shared`.
+
+## Out of scope
+
+- Splitting the editor into separate article and order sections (2.4 alternative)
+- Deprecated action types (`SET_PRIORITY`, `EXCLUDE_FROM_REPORT`,
+  `SET_PACKAGING_TAG`, `EXCLUDE_SKU`) still warn-and-skip; removing them is a
+  config-migration question, not a cleanup
+- The `ColumnConfigPanel` list-stretch bug noted during the Mappings work — its
+  own ticket
+- Ukrainian inline comments in `rules.py` are cleaned where the surrounding code
+  is already being rewritten, but no repo-wide sweep; that belongs to the Phase 6
+  tag-categories task

--- a/docs/superpowers/specs/2026-08-13-rule-engine-ui-design.md
+++ b/docs/superpowers/specs/2026-08-13-rule-engine-ui-design.md
@@ -129,6 +129,23 @@ changes nothing the user can see and nothing the engine does — `apply()`
 partitions by level before sorting by priority, so priorities only ever compare
 within a level. The button appears broken because, for that pairing, it is.
 
+### F9 — Three copies of the order-level field list, one of them dead
+
+The names of the order-level fields exist in three places:
+
+1. `RuleEngine.ORDER_LEVEL_FIELDS` (rules.py:636) — the authority; the engine
+   dispatches on these keys
+2. `get_available_rule_fields()` (gui/settings/rules.py:166) — a hardcoded list
+   that feeds the editor's dropdowns
+3. `gui/settings/fields.py:31` — `ORDER_LEVEL_FIELDS` and the `CONDITION_FIELDS`
+   built from it
+
+Copy 3 is **dead**: nothing imports either name (`gui/settings/rules.py` takes only
+`ACTION_TYPES` and `CONDITION_OPERATORS` from that module). It has also drifted —
+it lists `Has_SKU`, which the engine has never supported, so anything reviving it
+would offer users a field that cannot match. Copy 2 is live but must be kept in
+step with copy 1 by hand.
+
 ## Decisions
 
 Two decisions were put to the user before designing; both were answered.
@@ -242,9 +259,12 @@ Enablement follows the same rule (first/last *of its level*). This keeps the
 existing flat list; splitting the page into article and order sections is the
 larger alternative and is deliberately not done here.
 
-**2.5 Level-aware field lists (closes F2).**
+**2.5 Level-aware field lists (closes F2 and F9).**
 `get_available_rule_fields()` takes the rule's level and omits the order-level
-block for article rules. `level_combo.currentTextChanged` repopulates the field
+block for article rules. Its hardcoded order-level names are replaced by
+`RuleEngine.ORDER_LEVEL_FIELDS.keys()` so the editor cannot drift from what the
+engine dispatches on, and the dead `ORDER_LEVEL_FIELDS`/`CONDITION_FIELDS` pair in
+`gui/settings/fields.py` is deleted. `level_combo.currentTextChanged` repopulates the field
 combos of that rule's conditions. A previously-saved field that is no longer
 offered is preserved as an extra combo item and marked invalid, reusing the
 existing "field not found in combo box — add it to preserve saved value" path at

--- a/gui/settings/fields.py
+++ b/gui/settings/fields.py
@@ -26,19 +26,6 @@ FILTERABLE_COLUMNS: list[str] = [
 
 FILTER_OPERATORS: list[str] = ["==", "!=", "in", "not in", "contains"]
 
-# Order-level fields are grouped first, with the separator rows the combo
-# boxes render as non-selectable headers.
-ORDER_LEVEL_FIELDS: list[str] = [
-    "--- ORDER-LEVEL FIELDS ---",
-    "item_count",
-    "total_quantity",
-    "has_sku",
-    "Has_SKU",
-    "--- ARTICLE-LEVEL FIELDS ---",
-]
-
-CONDITION_FIELDS: list[str] = ORDER_LEVEL_FIELDS + FILTERABLE_COLUMNS
-
 CONDITION_OPERATORS: list[str] = [
     "equals",
     "does not equal",

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -50,6 +50,13 @@ class RulesPage(SettingsPage):
         set_button_role(add_rule_btn, "secondary")
         add_rule_btn.clicked.connect(lambda: [self.add_rule_widget(), self._update_priority_labels(), self._update_rules_count_label()])
         header_row.addWidget(add_rule_btn)
+
+        self.filter_edit = QLineEdit()
+        self.filter_edit.setPlaceholderText("Filter rules by name…")
+        self.filter_edit.setClearButtonEnabled(True)
+        self.filter_edit.textChanged.connect(self._filter_rules)
+        header_row.addWidget(self.filter_edit)
+
         header_row.addStretch()
         self.rules_count_label = QLabel("")
         theme = get_theme_manager().get_current_theme()
@@ -82,51 +89,42 @@ class RulesPage(SettingsPage):
         row_widget.deleteLater()
         ref_list.remove(ref_dict)
 
-    def _move_rule_up(self, widget_refs):
-        """Moves a rule up in the list (higher priority)."""
-        idx = self.rule_widgets.index(widget_refs)
-        if idx == 0:
-            return  # Already at top
+    def _neighbour_of_same_level(self, idx, direction):
+        """Index of the nearest rule sharing this one's level, or None."""
+        level = self.rule_widgets[idx]["level_combo"].currentText()
+        candidate = idx + direction
+        while 0 <= candidate < len(self.rule_widgets):
+            if self.rule_widgets[candidate]["level_combo"].currentText() == level:
+                return candidate
+            candidate += direction
+        return None
 
-        # Swap in list
-        self.rule_widgets[idx], self.rule_widgets[idx - 1] = \
-            self.rule_widgets[idx - 1], self.rule_widgets[idx]
+    def _swap_rules(self, idx_a, idx_b):
+        """Swaps two rules in both the refs list and the layout."""
+        widgets = self.rule_widgets
+        widgets[idx_a], widgets[idx_b] = widgets[idx_b], widgets[idx_a]
 
-        # Swap in UI layout
         layout = self.rules_layout
-        widget = widget_refs["group_box"]
-        prev_widget = self.rule_widgets[idx]["group_box"]
+        for position in sorted((idx_a, idx_b)):
+            box = widgets[position]["group_box"]
+            layout.removeWidget(box)
+            layout.insertWidget(position, box)
 
-        layout.removeWidget(widget)
-        layout.removeWidget(prev_widget)
-        layout.insertWidget(idx - 1, widget)
-        layout.insertWidget(idx, prev_widget)
-
-        # Update priority labels
         self._update_priority_labels()
+
+    def _move_rule_up(self, widget_refs):
+        """Moves a rule above the nearest rule of the same level."""
+        idx = self.rule_widgets.index(widget_refs)
+        target = self._neighbour_of_same_level(idx, -1)
+        if target is not None:
+            self._swap_rules(idx, target)
 
     def _move_rule_down(self, widget_refs):
-        """Moves a rule down in the list (lower priority)."""
+        """Moves a rule below the nearest rule of the same level."""
         idx = self.rule_widgets.index(widget_refs)
-        if idx >= len(self.rule_widgets) - 1:
-            return  # Already at bottom
-
-        # Swap in list
-        self.rule_widgets[idx], self.rule_widgets[idx + 1] = \
-            self.rule_widgets[idx + 1], self.rule_widgets[idx]
-
-        # Swap in UI layout
-        layout = self.rules_layout
-        widget = widget_refs["group_box"]
-        next_widget = self.rule_widgets[idx]["group_box"]
-
-        layout.removeWidget(widget)
-        layout.removeWidget(next_widget)
-        layout.insertWidget(idx, next_widget)
-        layout.insertWidget(idx + 1, widget)
-
-        # Update priority labels
-        self._update_priority_labels()
+        target = self._neighbour_of_same_level(idx, +1)
+        if target is not None:
+            self._swap_rules(idx, target)
 
     def _update_priority_labels(self):
         """Updates priority labels and button states for all rules.
@@ -148,11 +146,19 @@ class RulesPage(SettingsPage):
                 rule_w["priority_label"].setText(f"Order #{order_count}")
                 order_count += 1
 
-            # Disable up button for first rule
-            rule_w["up_btn"].setEnabled(idx > 0)
+            rule_w["up_btn"].setEnabled(
+                self._neighbour_of_same_level(idx, -1) is not None
+            )
+            rule_w["down_btn"].setEnabled(
+                self._neighbour_of_same_level(idx, +1) is not None
+            )
 
-            # Disable down button for last rule
-            rule_w["down_btn"].setEnabled(idx < len(self.rule_widgets) - 1)
+    def _filter_rules(self, text):
+        """Hides rule cards whose name does not contain `text`."""
+        needle = (text or "").strip().lower()
+        for rule_w in self.rule_widgets:
+            name = rule_w["name_edit"].text().lower()
+            rule_w["group_box"].setVisible(not needle or needle in name)
 
     def _repopulate_field_combos(self, rule_widget_refs):
         """Rebuilds condition field combos after the rule's level changed.

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -194,12 +194,6 @@ class RulesPage(SettingsPage):
         # Get ALL columns from DataFrame
         if self.analysis_df is not None and not self.analysis_df.empty:
             all_columns = sorted(self.analysis_df.columns.tolist())
-            logger.info(f"[RULE ENGINE] DataFrame has {len(all_columns)} columns")
-            logger.info(f"[RULE ENGINE] ALL COLUMNS: {all_columns}")
-
-            # Check if specific columns exist
-            logger.info(f"[RULE ENGINE] 'Stock' in columns: {'Stock' in all_columns}")
-            logger.info(f"[RULE ENGINE] 'Total_Price' in columns: {'Total_Price' in all_columns}")
 
             # Filter out internal columns (starting with _) and already listed common fields
             # But keep separators for checking
@@ -210,8 +204,6 @@ class RulesPage(SettingsPage):
                 if not col.startswith('_')
                 and col not in common_field_names  # Avoid duplicates
             ]
-
-            logger.info(f"[RULE ENGINE] Found {len(custom_columns)} custom columns: {custom_columns}")
 
             # Combine: order-level fields first, then common fields, then separator, then custom
             if custom_columns:

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -23,6 +23,7 @@ from gui.settings.fields import ACTION_TYPES, CONDITION_OPERATORS
 from gui.theme_manager import font_css, get_theme_manager, set_button_role
 from gui.wheel_ignore_combobox import WheelIgnoreComboBox
 from shopify_tool.core import get_unique_column_values
+from shopify_tool.rules import RuleEngine
 
 logger = logging.getLogger(__name__)
 
@@ -153,28 +154,47 @@ class RulesPage(SettingsPage):
             # Disable down button for last rule
             rule_w["down_btn"].setEnabled(idx < len(self.rule_widgets) - 1)
 
-    def get_available_rule_fields(self):
-        """Get all available fields for rules from DataFrame + common fields.
+    def _repopulate_field_combos(self, rule_widget_refs):
+        """Rebuilds condition field combos after the rule's level changed.
 
-        Returns a list of field names including:
-        - Order-level fields (shown first)
-        - Common article-level fields
-        - All other DataFrame columns (dynamically discovered)
-        - Separators (disabled items starting with "---")
+        A field the new level does not offer is kept as an extra item so a
+        saved condition is never silently reset; Task 6's validation marks it.
         """
-        # Start with order-level fields (these are ALWAYS available)
-        order_level_fields = [
-            "--- ORDER-LEVEL FIELDS ---",
-            "item_count",
-            "total_quantity",
-            "unique_sku_count",
-            "max_quantity",
-            "has_sku",
-            "has_product",
-            "order_volumetric_weight",
-            "all_no_packaging",
-            "order_min_box",
-        ]
+        level = rule_widget_refs["level_combo"].currentText()
+        available_fields = self.get_available_rule_fields(level=level)
+
+        for step_refs in rule_widget_refs.get("steps", []):
+            for cond_refs in step_refs["conditions"]:
+                combo = cond_refs["field"]
+                previous = combo.currentText()
+
+                combo.blockSignals(True)
+                combo.clear()
+                for field in available_fields:
+                    combo.addItem(field)
+                    if field.startswith("---"):
+                        combo.model().item(combo.count() - 1).setEnabled(False)
+
+                index = combo.findText(previous)
+                if index < 0:
+                    combo.addItem(previous)
+                    index = combo.count() - 1
+                combo.setCurrentIndex(index)
+                combo.blockSignals(False)
+
+    def get_available_rule_fields(self, level="article"):
+        """Fields offered for a condition on a rule of the given level.
+
+        Order-level field names come from RuleEngine.ORDER_LEVEL_FIELDS so the
+        editor cannot drift from what the engine dispatches on, and they are
+        offered only on order-level rules -- on an article rule they are never
+        DataFrame columns, so selecting one produces a condition the engine
+        treats as no-match.
+        """
+        fields = []
+        if level == "order":
+            fields += ["--- ORDER-LEVEL FIELDS ---"]
+            fields += list(RuleEngine.ORDER_LEVEL_FIELDS.keys())
 
         # Common article-level fields
         common_fields = [
@@ -191,6 +211,8 @@ class RulesPage(SettingsPage):
             "Destination_Country",
         ]
 
+        fields += common_fields
+
         # Get ALL columns from DataFrame
         if self.analysis_df is not None and not self.analysis_df.empty:
             all_columns = sorted(self.analysis_df.columns.tolist())
@@ -205,17 +227,12 @@ class RulesPage(SettingsPage):
                 and col not in common_field_names  # Avoid duplicates
             ]
 
-            # Combine: order-level fields first, then common fields, then separator, then custom
             if custom_columns:
-                return order_level_fields + common_fields + [
-                    "--- OTHER AVAILABLE FIELDS ---"
-                ] + custom_columns
-            else:
-                return order_level_fields + common_fields
+                fields += ["--- OTHER AVAILABLE FIELDS ---"] + custom_columns
         else:
             logger.warning(f"[RULE ENGINE] No analysis_df available (is None: {self.analysis_df is None})")
 
-        return order_level_fields + common_fields  # Fallback to order-level + common only
+        return fields
 
     def _update_rules_count_label(self):
         """Update the rules summary label in the Rules tab header."""
@@ -375,6 +392,10 @@ class RulesPage(SettingsPage):
         down_btn.clicked.connect(lambda: self._move_rule_down(widget_refs))
         test_btn.clicked.connect(lambda: self._test_rule(widget_refs))
         add_step_btn.clicked.connect(lambda: self._add_step_widget(widget_refs))
+        level_combo.currentTextChanged.connect(
+            lambda: [self._repopulate_field_combos(widget_refs),
+                     self._update_priority_labels()]
+        )
 
         # Update test button state based on data availability
         self._update_test_button_state(widget_refs)
@@ -478,6 +499,7 @@ class RulesPage(SettingsPage):
             "actions_layout": actions_rows_layout,
             "conditions": [],
             "actions": [],
+            "level_combo": rule_widget_refs["level_combo"],
         }
         steps.append(step_refs)
 
@@ -536,7 +558,9 @@ class RulesPage(SettingsPage):
         field_combo = WheelIgnoreComboBox()
 
         # Get dynamic fields from analysis DataFrame
-        available_fields = self.get_available_rule_fields()
+        level_combo = rule_widget_refs.get("level_combo")
+        level = level_combo.currentText() if level_combo else "article"
+        available_fields = self.get_available_rule_fields(level=level)
 
         # Add fields with separators disabled
         for field in available_fields:

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -187,6 +187,10 @@ class RulesPage(SettingsPage):
                     index = combo.count() - 1
                 combo.setCurrentIndex(index)
                 combo.blockSignals(False)
+                # Re-run the value validation first so a field that just became
+                # resolvable again does not keep the old "never match" message,
+                # then re-apply the resolvability mark on top of it.
+                self._perform_validation(cond_refs)
                 self._check_field_resolvable(cond_refs)
 
     def _update_rule_summary(self, widget_refs):
@@ -447,7 +451,7 @@ class RulesPage(SettingsPage):
         )
 
         def _toggle():
-            visible = not body.isVisible()
+            visible = body.isHidden()
             body.setVisible(visible)
             toggle_btn.setText("▼" if visible else "▶")
 
@@ -735,6 +739,7 @@ class RulesPage(SettingsPage):
 
         # Operators that don't need a value input
         if op in ["is_empty", "is_not_empty"]:
+            self._check_field_resolvable(condition_refs)
             return  # No widget will be created or added
 
         # Determine if a ComboBox should be used
@@ -798,6 +803,12 @@ class RulesPage(SettingsPage):
         # Connect validation for QLineEdit widgets (QLineEdit is already imported globally)
         if isinstance(new_widget, QLineEdit):
             new_widget.textChanged.connect(lambda: self._validate_condition_value(condition_refs))
+
+        # Mark an unresolvable field as soon as the row is built. This is the
+        # only path that runs on load -- the value validation that also calls it
+        # is driven by textChanged, which a programmatic setText above does not
+        # reach (it is connected after the text is set).
+        self._check_field_resolvable(condition_refs)
 
     def _validate_condition_value(self, condition_refs):
         """
@@ -967,8 +978,19 @@ class RulesPage(SettingsPage):
         field = combo.currentText()
         level_combo = condition_refs.get("level_combo")
         level = level_combo.currentText() if level_combo else "article"
-        known = set(self.get_available_rule_fields(level=level))
-        resolvable = bool(field) and not field.startswith("---") and field in known
+
+        if not field or field.startswith("---"):
+            resolvable = False
+        elif field in set(self.get_available_rule_fields(level=level)):
+            resolvable = True
+        elif self.analysis_df is None or self.analysis_df.empty:
+            # No analysis loaded, so the offered list is only a hardcoded guess
+            # at the columns and any real client column would flag falsely. The
+            # one thing still provable is an order-level field on an article
+            # rule -- that never resolves whatever the data looks like.
+            resolvable = field not in RuleEngine.ORDER_LEVEL_FIELDS
+        else:
+            resolvable = False
 
         if resolvable:
             combo.setStyleSheet("")

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -183,6 +183,28 @@ class RulesPage(SettingsPage):
                 combo.blockSignals(False)
                 self._check_field_resolvable(cond_refs)
 
+    def _update_rule_summary(self, widget_refs):
+        """Rewrites a rule's header summary from its current widget state."""
+        level = widget_refs["level_combo"].currentText()
+        steps = widget_refs.get("steps", [])
+        conditions = sum(len(s["conditions"]) for s in steps)
+        actions = sum(len(s["actions"]) for s in steps)
+
+        def plural(n, word):
+            return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+        widget_refs["summary_label"].setText(
+            f"{level} · {plural(len(steps), 'step')} · "
+            f"{plural(conditions, 'condition')} · {plural(actions, 'action')}"
+        )
+
+    def _update_rule_summary_for_step(self, step_refs):
+        """Finds the rule a step belongs to and refreshes its summary."""
+        for rule_w in self.rule_widgets:
+            if step_refs in rule_w.get("steps", []):
+                self._update_rule_summary(rule_w)
+                return
+
     def get_available_rule_fields(self, level="article"):
         """Fields offered for a condition on a rule of the given level.
 
@@ -269,11 +291,19 @@ class RulesPage(SettingsPage):
                 blank rule.
         """
         theme = get_theme_manager().get_current_theme()
+        config_was_none = not isinstance(config, dict)
         if not isinstance(config, dict):
             config = {"name": "New Rule", "level": "article", "match": "ALL", "conditions": [], "actions": []}
         rule_box = QGroupBox()
         rule_layout = QVBoxLayout(rule_box)
         header_layout = QHBoxLayout()
+
+        # Disclosure toggle
+        toggle_btn = QPushButton("▶")
+        set_button_role(toggle_btn, "secondary")
+        toggle_btn.setMaximumWidth(30)
+        toggle_btn.setToolTip("Show or hide this rule's conditions and actions")
+        header_layout.addWidget(toggle_btn)
 
         # Priority label (e.g., "Article #1", "Order #2")
         priority_label = QLabel("")
@@ -321,6 +351,11 @@ class RulesPage(SettingsPage):
         header_layout.addWidget(QLabel("Rule Name:"))
         name_edit = QLineEdit(config.get("name", ""))
         header_layout.addWidget(name_edit)
+
+        summary_label = QLabel("")
+        summary_label.setStyleSheet(f"color: {theme.text_secondary}; {font_css('caption')}")
+        header_layout.addWidget(summary_label)
+
         delete_rule_btn = QPushButton("Delete Rule")
         set_button_role(delete_rule_btn, "secondary")
         # The per-widget background wins over the role on purpose: destructive
@@ -357,11 +392,8 @@ class RulesPage(SettingsPage):
         level_layout.addWidget(level_combo)
         level_layout.addStretch()
 
-        rule_layout.addLayout(level_layout)
-
         # Steps container
         steps_container = QVBoxLayout()
-        rule_layout.addLayout(steps_container)
 
         # "Add Step" button
         add_step_btn = QPushButton("+ Add Step")
@@ -373,7 +405,14 @@ class RulesPage(SettingsPage):
             "match, the rule stops and later steps do not run."
         )
         add_step_btn.setStyleSheet(f"color: {theme.accent_blue}; font-weight: bold;")
-        rule_layout.addWidget(add_step_btn, 0, Qt.AlignLeft)
+
+        body = QWidget()
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(0, 0, 0, 0)
+        body_layout.addLayout(level_layout)
+        body_layout.addLayout(steps_container)
+        body_layout.addWidget(add_step_btn, 0, Qt.AlignLeft)
+        rule_layout.addWidget(body)
 
         self.rules_layout.addWidget(rule_box)
         widget_refs = {
@@ -386,6 +425,8 @@ class RulesPage(SettingsPage):
             "level_combo": level_combo,
             "steps_container": steps_container,
             "steps": [],
+            "body": body,
+            "summary_label": summary_label,
         }
         self.rule_widgets.append(widget_refs)
         delete_rule_btn.clicked.connect(lambda: self._delete_widget_from_list(widget_refs, self.rule_widgets))
@@ -395,8 +436,16 @@ class RulesPage(SettingsPage):
         add_step_btn.clicked.connect(lambda: self._add_step_widget(widget_refs))
         level_combo.currentTextChanged.connect(
             lambda: [self._repopulate_field_combos(widget_refs),
-                     self._update_priority_labels()]
+                     self._update_priority_labels(),
+                     self._update_rule_summary(widget_refs)]
         )
+
+        def _toggle():
+            visible = not body.isVisible()
+            body.setVisible(visible)
+            toggle_btn.setText("▼" if visible else "▶")
+
+        toggle_btn.clicked.connect(_toggle)
 
         # Update test button state based on data availability
         self._update_test_button_state(widget_refs)
@@ -414,6 +463,13 @@ class RulesPage(SettingsPage):
                 "actions": config.get("actions", []),
             }
             self._add_step_widget(widget_refs, single_step)
+
+        # A rule loaded from config starts collapsed; a rule the user just
+        # added starts expanded, since they are about to edit it.
+        expanded = config_was_none
+        body.setVisible(expanded)
+        toggle_btn.setText("▼" if expanded else "▶")
+        self._update_rule_summary(widget_refs)
 
     def _add_step_widget(self, rule_widget_refs, step_config=None):
         """Adds a step (IF conditions + THEN actions) to a rule.
@@ -516,6 +572,8 @@ class RulesPage(SettingsPage):
         for act_config in step_config.get("actions", []):
             self.add_action_row(step_refs, act_config)
 
+        self._update_rule_summary(rule_widget_refs)
+
     def _delete_step(self, rule_widget_refs, step_refs):
         """Delete a step from a rule (never deletes step 1)."""
         steps = rule_widget_refs["steps"]
@@ -540,6 +598,8 @@ class RulesPage(SettingsPage):
                 s["separator_label"].setParent(None)
                 s["separator_label"].deleteLater()
                 s["separator_label"] = None
+
+        self._update_rule_summary(rule_widget_refs)
 
     def add_condition_row(self, rule_widget_refs, config=None):
         """Adds a new row of widgets for a single condition within a rule.
@@ -628,8 +688,11 @@ class RulesPage(SettingsPage):
         rule_widget_refs["conditions_layout"].addWidget(row_widget)
         rule_widget_refs["conditions"].append(condition_refs)
         delete_btn.clicked.connect(
-            lambda: self._delete_row_from_list(row_widget, rule_widget_refs["conditions"], condition_refs)
+            lambda: [self._delete_row_from_list(row_widget, rule_widget_refs["conditions"], condition_refs),
+                     self._update_rule_summary_for_step(rule_widget_refs)]
         )
+
+        self._update_rule_summary_for_step(rule_widget_refs)
 
     def _on_rule_condition_changed(self, condition_refs, initial_value=None):
         """Dynamically changes the rule's value widget based on other selections.
@@ -1110,8 +1173,11 @@ class RulesPage(SettingsPage):
         rule_widget_refs["actions"].append(action_refs)
 
         delete_btn.clicked.connect(
-            lambda: self._delete_row_from_list(row_widget, rule_widget_refs["actions"], action_refs)
+            lambda: [self._delete_row_from_list(row_widget, rule_widget_refs["actions"], action_refs),
+                     self._update_rule_summary_for_step(rule_widget_refs)]
         )
+
+        self._update_rule_summary_for_step(rule_widget_refs)
 
     def _on_action_type_changed(self, action_refs, initial_config=None):
         """Dynamically updates parameter widgets based on action type."""

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -356,7 +356,12 @@ class RulesPage(SettingsPage):
         # "Add Step" button
         add_step_btn = QPushButton("+ Add Step")
         set_button_role(add_step_btn, "secondary")
-        add_step_btn.setToolTip("Add a new step to this rule (narrowing: each step filters rows from previous step)")
+        add_step_btn.setToolTip(
+            "Add a step to this rule.\n"
+            "article rules: each step narrows the rows matched by the step before it.\n"
+            "order rules: each step is a gate on the whole order - if it does not\n"
+            "match, the rule stops and later steps do not run."
+        )
         add_step_btn.setStyleSheet(f"color: {theme.accent_blue}; font-weight: bold;")
         rule_layout.addWidget(add_step_btn, 0, Qt.AlignLeft)
 

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -181,6 +181,7 @@ class RulesPage(SettingsPage):
                     index = combo.count() - 1
                 combo.setCurrentIndex(index)
                 combo.blockSignals(False)
+                self._check_field_resolvable(cond_refs)
 
     def get_available_rule_fields(self, level="article"):
         """Fields offered for a condition on a rule of the given level.
@@ -612,6 +613,7 @@ class RulesPage(SettingsPage):
             "op": op_combo,
             "value_widget": None,
             "value_layout": row_layout,
+            "level_combo": rule_widget_refs.get("level_combo"),
         }
 
         row_layout.addWidget(delete_btn)
@@ -825,6 +827,8 @@ class RulesPage(SettingsPage):
             # No validation needed for other operators
             self._show_validation_feedback(condition_refs, "clear", "")
 
+        self._check_field_resolvable(condition_refs)
+
     def _show_validation_feedback(self, condition_refs, status, message):
         """
         Show validation feedback with visual indicators.
@@ -874,6 +878,40 @@ class RulesPage(SettingsPage):
         elif status == "clear":
             value_widget.setStyleSheet("")
             feedback_label.hide()
+
+    def _check_field_resolvable(self, condition_refs):
+        """Marks a field the engine will treat as no-match.
+
+        The engine fails a condition closed when its field is not a column (or,
+        on an order rule, a known order-level field). Showing that here means the
+        user sees it while editing rather than finding a rule that quietly
+        stopped firing.
+
+        Returns:
+            bool: True when the field is one the engine can evaluate.
+        """
+        theme = get_theme_manager().get_current_theme()
+        combo = condition_refs.get("field")
+        if combo is None:
+            return True
+
+        field = combo.currentText()
+        level_combo = condition_refs.get("level_combo")
+        level = level_combo.currentText() if level_combo else "article"
+        known = set(self.get_available_rule_fields(level=level))
+        resolvable = bool(field) and not field.startswith("---") and field in known
+
+        if resolvable:
+            combo.setStyleSheet("")
+        else:
+            combo.setStyleSheet(f"border: 1px solid {theme.accent_red};")
+            self._show_validation_feedback(
+                condition_refs,
+                "error",
+                f"'{field}' is not available on an {level} rule - this condition "
+                f"will never match.",
+            )
+        return resolvable
 
     def _parse_date_for_widget(self, date_str):
         """

--- a/shopify_tool/rules.py
+++ b/shopify_tool/rules.py
@@ -748,6 +748,9 @@ class RuleEngine:
         and then executes the rule's actions on those matching rows.
 
         Supports both article-level (row-by-row) and order-level (entire order) rules.
+        Multi-step rules behave differently by level: article-level steps narrow
+        the matched rows progressively, while order-level steps act as sequential
+        gates on the whole order.
 
         The DataFrame is modified in place.
 
@@ -819,59 +822,60 @@ class RuleEngine:
 
         # Apply order-level rules with multi-step support
         if order_rules and "Order_Number" in df.columns:
-            for order_number in df["Order_Number"].unique():
-                order_mask = df["Order_Number"] == order_number
-                df[order_mask]
+            # Group once. .indices gives positional arrays, so every slice and
+            # mask below is positional -- index labels are not guaranteed unique
+            # (apply() itself concatenates with ignore_index at the end).
+            positions_by_order = df.groupby("Order_Number", sort=False).indices
 
+            for order_number, positions in positions_by_order.items():
                 for rule in order_rules:
                     rule_name = rule.get("name", "Unnamed")
-                    priority = rule.get("priority", 1000)
                     steps = rule.get("steps", [])
-                    logger.info(f"[RULE ENGINE] Applying order rule: {rule_name} (Priority: {priority}, Steps: {len(steps)})")
-
-                    # Track which rows in order are still eligible (for narrowing)
-                    order_eligible_mask = order_mask.copy()
 
                     for step_idx, step in enumerate(steps):
-                        # Evaluate conditions on eligible order rows
-                        eligible_df = df[order_eligible_mask]
-                        if eligible_df.empty:
-                            break
+                        # Re-taken every step on purpose: a later step's
+                        # conditions must see what an earlier step's actions
+                        # wrote. O(len(order)), not O(len(df)).
+                        order_df = df.iloc[positions]
 
-                        matches = self._evaluate_order_conditions(
-                            eligible_df,
+                        matched = self._evaluate_order_conditions(
+                            order_df,
                             step.get("conditions", []),
-                            step.get("match", "ALL")
+                            step.get("match", "ALL"),
                         )
-
-                        if not matches:
-                            logger.info(f"[RULE ENGINE] Order {order_number} step {step_idx+1}: No match, stopping")
+                        if not matched:
+                            logger.info(
+                                f"[RULE ENGINE] Order {order_number} rule "
+                                f"'{rule_name}' step {step_idx+1}: no match, stopping"
+                            )
                             break
 
-                        # Separate actions by scope
                         actions = step.get("actions", [])
-                        apply_to_all_actions = []
-                        apply_to_first_actions = []
+                        apply_to_all = [
+                            a for a in actions
+                            if a.get("type", "").upper() in ("ADD_TAG", "ADD_ORDER_TAG")
+                        ]
+                        apply_to_first = [
+                            a for a in actions
+                            if a.get("type", "").upper() not in ("ADD_TAG", "ADD_ORDER_TAG")
+                        ]
 
-                        for action in actions:
-                            action_type = action.get("type", "").upper()
-                            if action_type in ("ADD_TAG", "ADD_ORDER_TAG"):
-                                apply_to_all_actions.append(action)
-                            else:
-                                apply_to_first_actions.append(action)
+                        # Masks are built only once a step has matched and has
+                        # actions, so the O(len(df)) allocation stays off the
+                        # hot path.
+                        if apply_to_all:
+                            mask = pd.Series(False, index=df.index)
+                            mask.iloc[positions] = True
+                            all_new_rows.extend(
+                                self._execute_actions(df, mask, apply_to_all)
+                            )
 
-                        # Apply to all rows of order
-                        if apply_to_all_actions:
-                            new_rows = self._execute_actions(df, order_eligible_mask, apply_to_all_actions)
-                            all_new_rows.extend(new_rows)
-
-                        # Apply to first row only
-                        if apply_to_first_actions:
-                            first_row_index = eligible_df.index[0]
-                            first_row_mask = pd.Series(False, index=df.index)
-                            first_row_mask[first_row_index] = True
-                            new_rows = self._execute_actions(df, first_row_mask, apply_to_first_actions)
-                            all_new_rows.extend(new_rows)
+                        if apply_to_first:
+                            mask = pd.Series(False, index=df.index)
+                            mask.iloc[positions[0]] = True
+                            all_new_rows.extend(
+                                self._execute_actions(df, mask, apply_to_first)
+                            )
 
         # Додати всі нові рядки з ADD_PRODUCT actions
         if all_new_rows:

--- a/shopify_tool/rules.py
+++ b/shopify_tool/rules.py
@@ -772,7 +772,7 @@ class RuleEngine:
         # Create columns for actions if they don't exist
         self._prepare_df_for_actions(df)
 
-        # Збирати нові рядки з ADD_PRODUCT actions
+        # Rows created by ADD_PRODUCT actions, appended after all rules run.
         all_new_rows = []
 
         # Separate rules by level
@@ -877,7 +877,7 @@ class RuleEngine:
                                 self._execute_actions(df, mask, apply_to_first)
                             )
 
-        # Додати всі нові рядки з ADD_PRODUCT actions
+        # Append the rows ADD_PRODUCT actions created.
         if all_new_rows:
             new_df = pd.DataFrame(all_new_rows)
             df = pd.concat([df, new_df], ignore_index=True)
@@ -1037,7 +1037,7 @@ class RuleEngine:
         import logging
         logger = logging.getLogger(__name__)
 
-        new_rows = []  # Збирати нові рядки тут
+        new_rows = []  # Rows to append, collected here.
 
         for action in actions:
             action_type = action.get("type", "").upper()

--- a/shopify_tool/rules.py
+++ b/shopify_tool/rules.py
@@ -827,6 +827,16 @@ class RuleEngine:
             # (apply() itself concatenates with ignore_index at the end).
             positions_by_order = df.groupby("Order_Number", sort=False).indices
 
+            # Audit trail, hoisted above the order loop -- one line per rule,
+            # not one per rule per order.
+            for idx, rule in enumerate(order_rules):
+                logger.info(
+                    f"[RULE ENGINE] Applying order rule #{idx+1}: "
+                    f"{rule.get('name', 'Unnamed')} "
+                    f"(Priority: {rule.get('priority', 1000)}, "
+                    f"Steps: {len(rule.get('steps', []))})"
+                )
+
             for order_number, positions in positions_by_order.items():
                 for rule in order_rules:
                     rule_name = rule.get("name", "Unnamed")
@@ -1307,12 +1317,9 @@ class RuleEngine:
                 else:
                     # For numeric fields: wrap in Series, use global operator
                     field_value = calc_method(order_df, None)
-                    if operator not in OPERATOR_MAP:
-                        result = False
-                    else:
-                        scalar_series = pd.Series([field_value])
-                        op_func = globals()[OPERATOR_MAP[operator]]
-                        result = bool(op_func(scalar_series, value).iloc[0])
+                    scalar_series = pd.Series([field_value])
+                    op_func = globals()[OPERATOR_MAP[operator]]
+                    result = bool(op_func(scalar_series, value).iloc[0])
 
             else:
                 # Regular article-level field - check if ANY row matches

--- a/shopify_tool/rules.py
+++ b/shopify_tool/rules.py
@@ -915,6 +915,45 @@ class RuleEngine:
         if "Internal_Tags" in needed_columns and "Internal_Tags" not in df.columns:
             df["Internal_Tags"] = "[]"
 
+    def _resolve_condition(self, cond, columns, allow_order_fields):
+        """Resolves a condition to (field, operator, value, error).
+
+        A condition the engine cannot evaluate is an error, not something to
+        skip. Skipping one drops it out of an ALL-match, which makes the rule
+        fire on its remaining conditions and match more rows than written.
+
+        Args:
+            cond (dict): The condition, with 'field', 'operator' and 'value'.
+            columns: The DataFrame columns available to this condition.
+            allow_order_fields (bool): True on the order-level path, where
+                ORDER_LEVEL_FIELDS names are computed rather than looked up.
+
+        Returns:
+            tuple: (field, operator, value, error). error is None when the
+                condition is usable; otherwise it explains why not and the
+                other three values must not be used.
+        """
+        field = cond.get("field")
+        operator = cond.get("operator")
+        value = cond.get("value")
+
+        if not field:
+            return None, None, None, "condition has no field"
+        if field.startswith("---"):
+            return None, None, None, f"'{field}' is a dropdown separator, not a field"
+        if not operator:
+            return None, None, None, f"condition on '{field}' has no operator"
+        if operator not in OPERATOR_MAP:
+            return None, None, None, f"unknown operator '{operator}'"
+
+        if allow_order_fields and field in self.ORDER_LEVEL_FIELDS:
+            return field, operator, value, None
+        if field not in columns:
+            hint = "" if allow_order_fields else " (order-level fields need level: order)"
+            return None, None, None, f"field '{field}' is not a column{hint}"
+
+        return field, operator, value, None
+
     def _get_matching_rows(self, df, rule):
         """Evaluates a rule's conditions and finds all matching rows.
 
@@ -944,44 +983,23 @@ class RuleEngine:
         # Get a boolean Series for each individual condition
         condition_results = []
         for cond in conditions:
-            field = cond.get("field")
-            operator = cond.get("operator")
-            value = cond.get("value")
-
-            # Skip separator fields (from UI)
-            if field and field.startswith("---"):
-                logger.info(f"[RULE ENGINE] Skipping separator field: {field}")
+            field, operator, value, error = self._resolve_condition(
+                cond, df.columns, allow_order_fields=False
+            )
+            if error:
+                logger.warning(
+                    f"[RULE ENGINE] Condition cannot be evaluated and is treated "
+                    f"as no-match: {error}"
+                )
+                condition_results.append(pd.Series(False, index=df.index))
                 continue
 
-            # Check conditions
-            if not field:
-                logger.warning(f"[RULE ENGINE] Condition missing field: {cond}")
-                continue
-            if not operator:
-                logger.warning(f"[RULE ENGINE] Condition missing operator: {cond}")
-                continue
-            if field not in df.columns:
-                logger.warning(f"[RULE ENGINE] Field '{field}' not in DataFrame columns: {list(df.columns)}")
-                continue
-            if operator not in OPERATOR_MAP:
-                logger.warning(f"[RULE ENGINE] Operator '{operator}' not in OPERATOR_MAP: {list(OPERATOR_MAP.keys())}")
-                continue
-
-            op_func_name = OPERATOR_MAP[operator]
-            op_func = globals()[op_func_name]
-
-            logger.info(f"[RULE ENGINE] Evaluating condition: {field} {operator} {value}")
-
-            # Log data types and sample values
-            logger.info(f"[RULE ENGINE] Field '{field}' dtype: {df[field].dtype}")
-            logger.info(f"[RULE ENGINE] Rule value type: {type(value).__name__}, value: {value!r}")
-            unique_vals = df[field].dropna().unique()[:5]
-            logger.info(f"[RULE ENGINE] Sample values in '{field}': {list(unique_vals)}")
-
+            op_func = globals()[OPERATOR_MAP[operator]]
+            logger.debug(
+                f"[RULE ENGINE] {field} {operator} {value!r} "
+                f"(dtype {df[field].dtype})"
+            )
             result = op_func(df[field], value)
-            matches_count = result.sum()
-            logger.info(f"[RULE ENGINE] Condition matched {matches_count} rows")
-
             condition_results.append(result)
 
         if not condition_results:
@@ -1255,18 +1273,21 @@ class RuleEngine:
         Returns:
             bool: True if conditions met
         """
+        import logging
+        logger = logging.getLogger(__name__)
+
         results = []
 
         for condition in conditions:
-            field = condition.get("field")
-            operator = condition.get("operator")
-            value = condition.get("value")
-
-            if not all([field, operator]):
-                continue
-
-            # Skip separator fields (from UI)
-            if field and field.startswith("---"):
+            field, operator, value, error = self._resolve_condition(
+                condition, order_df.columns, allow_order_fields=True
+            )
+            if error:
+                logger.warning(
+                    f"[RULE ENGINE] Order condition cannot be evaluated and is "
+                    f"treated as no-match: {error}"
+                )
+                results.append(False)
                 continue
 
             # Check if this is an order-level field
@@ -1291,12 +1312,9 @@ class RuleEngine:
 
             else:
                 # Regular article-level field - check if ANY row matches
-                if field not in order_df.columns or operator not in OPERATOR_MAP:
-                    result = False
-                else:
-                    op_func = globals()[OPERATOR_MAP[operator]]
-                    series_result = op_func(order_df[field], value)
-                    result = series_result.any()  # At least one row matches
+                op_func = globals()[OPERATOR_MAP[operator]]
+                series_result = op_func(order_df[field], value)
+                result = series_result.any()  # At least one row matches
 
             results.append(result)
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -67,9 +67,11 @@ class TestOperatorsCorrectBehavior:
         out = RuleEngine(any_rule).apply(df.copy())
         assert out["Status_Note"].tolist() == ["MATCH", "MATCH", ""]
 
-    def test_unrecognized_operator_condition_is_skipped_not_fatal(self):
-        # Per _get_matching_rows: field/operator not found -> condition skipped,
-        # remaining conditions still apply (documented current behavior).
+    def test_unrecognized_operator_condition_fails_the_rule_closed(self):
+        # Was documenting the widening bug: a bad condition used to be dropped
+        # from the ALL-match, letting the rule fire on the remaining condition
+        # alone. It now fails closed instead -- see
+        # TestUnresolvableConditionsFailClosed.
         df = _df({"A": [1, 2]})
         rules = [_rule(
             [{"field": "A", "operator": "not_a_real_operator", "value": 1},
@@ -77,7 +79,7 @@ class TestOperatorsCorrectBehavior:
             [{"type": "ADD_TAG", "value": "X"}], match="ALL",
         )]
         out = RuleEngine(rules).apply(df.copy())
-        assert out["Status_Note"].tolist() == ["X", ""]
+        assert out["Status_Note"].tolist() == ["", ""]
 
 
 class TestRulePriorityAndAccumulation:
@@ -191,3 +193,68 @@ class TestConfirmedBugs:
         )]
         out = RuleEngine(rules).apply(df.copy())  # currently raises KeyError
         assert "A" in out.loc[0, "Status_Note"]
+
+
+class TestUnresolvableConditionsFailClosed:
+    """An unresolvable condition evaluates to False, it is not dropped.
+
+    Before this change _get_matching_rows skipped conditions it could not
+    resolve, so an ALL-match rule fired on its surviving conditions alone and
+    tagged more rows than the rule was written to tag.
+    """
+
+    def test_all_match_with_unknown_field_does_not_fire(self):
+        df = _df({"Order_Type": ["Single", "Single", "Multi"]})
+        rules = [_rule(
+            [{"field": "Order_Type", "operator": "equals", "value": "Single"},
+             {"field": "item_count", "operator": "is greater than", "value": 3}],
+            [{"type": "ADD_TAG", "value": "NOPE"}],
+            match="ALL",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", "", ""]
+
+    def test_any_match_with_unknown_field_still_fires_on_valid_condition(self):
+        df = _df({"Order_Type": ["Single", "Multi"]})
+        rules = [_rule(
+            [{"field": "Order_Type", "operator": "equals", "value": "Single"},
+             {"field": "no_such_column", "operator": "equals", "value": "x"}],
+            [{"type": "ADD_TAG", "value": "YES"}],
+            match="ANY",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["YES", ""]
+
+    def test_unknown_operator_fails_closed(self):
+        df = _df({"Order_Type": ["Single", "Multi"]})
+        rules = [_rule(
+            [{"field": "Order_Type", "operator": "sounds like", "value": "Single"}],
+            [{"type": "ADD_TAG", "value": "NOPE"}],
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", ""]
+
+    def test_separator_field_fails_closed(self):
+        df = _df({"Order_Type": ["Single", "Multi"]})
+        rules = [_rule(
+            [{"field": "Order_Type", "operator": "equals", "value": "Single"},
+             {"field": "--- ORDER-LEVEL FIELDS ---", "operator": "equals", "value": ""}],
+            [{"type": "ADD_TAG", "value": "NOPE"}],
+            match="ALL",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", ""]
+
+    def test_order_level_rule_agrees_on_unknown_field(self):
+        df = _df({
+            "Order_Number": ["A", "A"],
+            "Quantity": [1, 2],
+        })
+        rules = [_rule(
+            [{"field": "item_count", "operator": "equals", "value": 2},
+             {"field": "no_such_column", "operator": "equals", "value": "x"}],
+            [{"type": "ADD_TAG", "value": "NOPE"}],
+            match="ALL", level="order",
+        )]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", ""]

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -258,3 +258,73 @@ class TestUnresolvableConditionsFailClosed:
         )]
         out = RuleEngine(rules).apply(df.copy())
         assert out["Status_Note"].tolist() == ["", ""]
+
+
+class TestOrderRuleLoopRewrite:
+    """Order-level rules: same results, without O(rows) slicing per step."""
+
+    def test_multi_order_multi_rule_output_unchanged(self):
+        df = _df({
+            "Order_Number": ["A", "A", "B", "C", "C", "C"],
+            "Quantity": [1, 2, 5, 1, 1, 1],
+            "SKU": ["x", "y", "z", "x", "x", "y"],
+        })
+        rules = [
+            _rule([{"field": "item_count", "operator": "is greater than", "value": 2}],
+                  [{"type": "ADD_TAG", "value": "BIG"}],
+                  level="order", priority=1, name="big"),
+            _rule([{"field": "total_quantity", "operator": "is greater than or equal", "value": 5}],
+                  [{"type": "ADD_TAG", "value": "HEAVY"}],
+                  level="order", priority=2, name="heavy"),
+        ]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == [
+            "", "", "HEAVY", "BIG", "BIG", "BIG",
+        ]
+
+    def test_later_step_sees_earlier_step_action_writes(self):
+        """Guards the deliberate re-slice: order_df is re-taken every step."""
+        df = _df({
+            "Order_Number": ["A", "A"],
+            "Quantity": [1, 1],
+        })
+        rules = [{
+            "name": "two-step", "level": "order", "priority": 1,
+            "steps": [
+                {"conditions": [{"field": "item_count", "operator": "equals", "value": 2}],
+                 "match": "ALL",
+                 "actions": [{"type": "ADD_TAG", "value": "FIRST"}]},
+                {"conditions": [{"field": "Status_Note", "operator": "contains", "value": "FIRST"}],
+                 "match": "ALL",
+                 "actions": [{"type": "ADD_TAG", "value": "SECOND"}]},
+            ],
+        }]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["FIRST, SECOND", "FIRST, SECOND"]
+
+    def test_first_row_action_targets_one_row_with_duplicate_index_labels(self):
+        df = pd.DataFrame(
+            {"Order_Number": ["A", "A"], "Quantity": [1, 1]},
+            index=[0, 0],
+        )
+        rules = [_rule([{"field": "item_count", "operator": "equals", "value": 2}],
+                       [{"type": "ADD_ORDER_TAG", "value": "ONCE"}],
+                       level="order")]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["ONCE", "ONCE"]
+
+    def test_order_step_gates_and_stops(self):
+        df = _df({"Order_Number": ["A", "A"], "Quantity": [1, 1]})
+        rules = [{
+            "name": "gate", "level": "order", "priority": 1,
+            "steps": [
+                {"conditions": [{"field": "item_count", "operator": "equals", "value": 99}],
+                 "match": "ALL",
+                 "actions": [{"type": "ADD_TAG", "value": "NO"}]},
+                {"conditions": [{"field": "item_count", "operator": "equals", "value": 2}],
+                 "match": "ALL",
+                 "actions": [{"type": "ADD_TAG", "value": "ALSO_NO"}]},
+            ],
+        }]
+        out = RuleEngine(rules).apply(df.copy())
+        assert out["Status_Note"].tolist() == ["", ""]

--- a/tests/test_rules_page.py
+++ b/tests/test_rules_page.py
@@ -94,3 +94,42 @@ class TestUnresolvableFieldIsFlagged:
         cond_refs = page.rule_widgets[0]["steps"][0]["conditions"][0]
         assert page._check_field_resolvable(cond_refs) is True
         assert cond_refs["field"].styleSheet() == ""
+
+
+class TestCollapsibleRuleCards:
+    def _rule(self, name="r"):
+        return {
+            "name": name, "level": "article",
+            "steps": [{
+                "conditions": [{"field": "SKU", "operator": "equals", "value": "x"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+
+    def test_loaded_rules_start_collapsed(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        assert page.rule_widgets[0]["body"].isVisibleTo(page) is False
+
+    def test_added_rule_starts_expanded(self, qtbot, analysis_df):
+        page = RulesPage([], analysis_df)
+        qtbot.addWidget(page)
+        page.add_rule_widget()
+        assert page.rule_widgets[0]["body"].isVisibleTo(page) is True
+
+    def test_summary_reports_counts(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        text = page.rule_widgets[0]["summary_label"].text()
+        assert "article" in text
+        assert "1 step" in text
+        assert "1 condition" in text
+        assert "1 action" in text
+
+    def test_collect_is_unaffected_by_collapse_state(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        collapsed = page.collect()
+        page.rule_widgets[0]["body"].setVisible(True)
+        assert page.collect() == collapsed

--- a/tests/test_rules_page.py
+++ b/tests/test_rules_page.py
@@ -60,3 +60,37 @@ class TestLevelSwitchPreservesSavedField:
         combo = refs["steps"][0]["conditions"][0]["field"]
         assert combo.currentText() == "item_count"
         assert page.collect()["rules"][0]["steps"][0]["conditions"][0]["field"] == "item_count"
+
+
+class TestUnresolvableFieldIsFlagged:
+    def test_order_field_on_article_rule_is_flagged(self, qtbot, analysis_df):
+        rule = {
+            "name": "r", "level": "article",
+            "steps": [{
+                "conditions": [{"field": "item_count", "operator": "equals", "value": "2"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+        page = RulesPage([rule], analysis_df)
+        qtbot.addWidget(page)
+
+        cond_refs = page.rule_widgets[0]["steps"][0]["conditions"][0]
+        assert page._check_field_resolvable(cond_refs) is False
+        assert "border" in cond_refs["field"].styleSheet()
+
+    def test_real_column_is_not_flagged(self, qtbot, analysis_df):
+        rule = {
+            "name": "r", "level": "article",
+            "steps": [{
+                "conditions": [{"field": "SKU", "operator": "equals", "value": "x"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+        page = RulesPage([rule], analysis_df)
+        qtbot.addWidget(page)
+
+        cond_refs = page.rule_widgets[0]["steps"][0]["conditions"][0]
+        assert page._check_field_resolvable(cond_refs) is True
+        assert cond_refs["field"].styleSheet() == ""

--- a/tests/test_rules_page.py
+++ b/tests/test_rules_page.py
@@ -133,3 +133,50 @@ class TestCollapsibleRuleCards:
         collapsed = page.collect()
         page.rule_widgets[0]["body"].setVisible(True)
         assert page.collect() == collapsed
+
+
+class TestFilterAndReorder:
+    def _rule(self, name, level="article"):
+        return {
+            "name": name, "level": level,
+            "steps": [{
+                "conditions": [{"field": "SKU", "operator": "equals", "value": "x"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+
+    def test_filter_hides_non_matching_rules(self, qtbot, analysis_df):
+        page = RulesPage([self._rule("alpha"), self._rule("beta")], analysis_df)
+        qtbot.addWidget(page)
+        page._filter_rules("alp")
+        assert page.rule_widgets[0]["group_box"].isVisibleTo(page) is True
+        assert page.rule_widgets[1]["group_box"].isVisibleTo(page) is False
+
+    def test_empty_filter_shows_everything(self, qtbot, analysis_df):
+        page = RulesPage([self._rule("alpha"), self._rule("beta")], analysis_df)
+        qtbot.addWidget(page)
+        page._filter_rules("alp")
+        page._filter_rules("")
+        assert page.rule_widgets[1]["group_box"].isVisibleTo(page) is True
+
+    def test_move_up_skips_over_other_level(self, qtbot, analysis_df):
+        page = RulesPage(
+            [self._rule("a1", "article"),
+             self._rule("o1", "order"),
+             self._rule("a2", "article")],
+            analysis_df,
+        )
+        qtbot.addWidget(page)
+        page._move_rule_up(page.rule_widgets[2])
+        names = [r["name_edit"].text() for r in page.rule_widgets]
+        assert names == ["a2", "o1", "a1"]
+
+    def test_first_of_its_level_cannot_move_up(self, qtbot, analysis_df):
+        page = RulesPage(
+            [self._rule("a1", "article"), self._rule("o1", "order")],
+            analysis_df,
+        )
+        qtbot.addWidget(page)
+        assert page.rule_widgets[0]["up_btn"].isEnabled() is False
+        assert page.rule_widgets[1]["up_btn"].isEnabled() is False

--- a/tests/test_rules_page.py
+++ b/tests/test_rules_page.py
@@ -59,6 +59,7 @@ class TestLevelSwitchPreservesSavedField:
 
         combo = refs["steps"][0]["conditions"][0]["field"]
         assert combo.currentText() == "item_count"
+        assert "border" in combo.styleSheet()  # preserved, but flagged
         assert page.collect()["rules"][0]["steps"][0]["conditions"][0]["field"] == "item_count"
 
 
@@ -76,8 +77,43 @@ class TestUnresolvableFieldIsFlagged:
         qtbot.addWidget(page)
 
         cond_refs = page.rule_widgets[0]["steps"][0]["conditions"][0]
-        assert page._check_field_resolvable(cond_refs) is False
+        # Asserted before calling the helper: the flag has to be there on load,
+        # which is the only moment the user sees a rule they did not just edit.
         assert "border" in cond_refs["field"].styleSheet()
+        assert page._check_field_resolvable(cond_refs) is False
+
+    def test_order_field_on_article_rule_is_flagged_without_an_analysis(self, qtbot):
+        rule = {
+            "name": "r", "level": "article",
+            "steps": [{
+                "conditions": [{"field": "item_count", "operator": "equals", "value": "2"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+        page = RulesPage([rule], pd.DataFrame())
+        qtbot.addWidget(page)
+
+        cond_refs = page.rule_widgets[0]["steps"][0]["conditions"][0]
+        assert "border" in cond_refs["field"].styleSheet()
+
+    def test_unlisted_column_is_not_flagged_without_an_analysis(self, qtbot):
+        """Settings opens before any analysis runs, and the offered field list
+        is then only a hardcoded guess -- a real client column must not be
+        called a never-match on the strength of that guess."""
+        rule = {
+            "name": "r", "level": "article",
+            "steps": [{
+                "conditions": [{"field": "Total_Price", "operator": "equals", "value": "1"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+        page = RulesPage([rule], pd.DataFrame())
+        qtbot.addWidget(page)
+
+        cond_refs = page.rule_widgets[0]["steps"][0]["conditions"][0]
+        assert cond_refs["field"].styleSheet() == ""
 
     def test_real_column_is_not_flagged(self, qtbot, analysis_df):
         rule = {
@@ -180,3 +216,12 @@ class TestFilterAndReorder:
         qtbot.addWidget(page)
         assert page.rule_widgets[0]["up_btn"].isEnabled() is False
         assert page.rule_widgets[1]["up_btn"].isEnabled() is False
+
+    def test_last_of_its_level_cannot_move_down(self, qtbot, analysis_df):
+        page = RulesPage(
+            [self._rule("a1", "article"), self._rule("o1", "order")],
+            analysis_df,
+        )
+        qtbot.addWidget(page)
+        assert page.rule_widgets[0]["down_btn"].isEnabled() is False
+        assert page.rule_widgets[1]["down_btn"].isEnabled() is False

--- a/tests/test_rules_page.py
+++ b/tests/test_rules_page.py
@@ -1,0 +1,62 @@
+"""RulesPage field vocabularies and level awareness."""
+import pandas as pd
+import pytest
+
+from gui.settings.rules import RulesPage
+from shopify_tool.rules import RuleEngine
+
+
+@pytest.fixture
+def analysis_df():
+    return pd.DataFrame({
+        "Order_Number": ["A", "B"],
+        "SKU": ["x", "y"],
+        "Quantity": [1, 2],
+    })
+
+
+def _order_field_names():
+    return set(RuleEngine.ORDER_LEVEL_FIELDS.keys())
+
+
+class TestLevelAwareFields:
+    def test_article_level_omits_order_fields(self, qtbot, analysis_df):
+        page = RulesPage([], analysis_df)
+        qtbot.addWidget(page)
+        fields = set(page.get_available_rule_fields(level="article"))
+        assert not (fields & _order_field_names())
+        assert "--- ORDER-LEVEL FIELDS ---" not in fields
+
+    def test_order_level_includes_every_engine_order_field(self, qtbot, analysis_df):
+        page = RulesPage([], analysis_df)
+        qtbot.addWidget(page)
+        fields = set(page.get_available_rule_fields(level="order"))
+        assert _order_field_names() <= fields
+
+    def test_article_level_still_offers_dataframe_columns(self, qtbot, analysis_df):
+        page = RulesPage([], analysis_df)
+        qtbot.addWidget(page)
+        fields = page.get_available_rule_fields(level="article")
+        assert "SKU" in fields
+        assert "Quantity" in fields
+
+
+class TestLevelSwitchPreservesSavedField:
+    def test_switching_to_article_keeps_unknown_field_selected(self, qtbot, analysis_df):
+        rule = {
+            "name": "r", "level": "order",
+            "steps": [{
+                "conditions": [{"field": "item_count", "operator": "equals", "value": "2"}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+        page = RulesPage([rule], analysis_df)
+        qtbot.addWidget(page)
+
+        refs = page.rule_widgets[0]
+        refs["level_combo"].setCurrentText("article")
+
+        combo = refs["steps"][0]["conditions"][0]["field"]
+        assert combo.currentText() == "item_count"
+        assert page.collect()["rules"][0]["steps"][0]["conditions"][0]["field"] == "item_count"


### PR DESCRIPTION
## ⚠️ Live behaviour change — read this first

**A rule with a broken condition will stop firing after this merges. That is the point, but it can change tagging output for rules that "work" today.**

Previously, a condition the engine could not evaluate (field isn't a column, unknown operator, order-level field on an article rule) was silently **dropped from the mask**. Dropping a condition out of an `ALL` match doesn't narrow the rule — it *widens* it, so the rule fired on its remaining conditions and tagged more orders than it was written to tag.

Conditions now **fail closed**: an unresolvable condition evaluates to `False`. This composes correctly under both `ALL` and `ANY`, and matches what the order-level path already did.

**What to check after merging:** any rule that currently tags more than you'd expect from reading it. Those are the ones that were riding on a dropped condition. Each one now logs a `WARNING` naming the field or operator that failed to resolve.

The settings editor makes this visible before it bites: a condition the engine can't evaluate is marked with a red border and a "this condition will never match" message, on load — not only once you edit it.

---

## Engine (`shopify_tool/rules.py`)

- **Fail closed** (above). Single classifier `_resolve_condition()` used by both the article path (`_get_matching_rows`) and the order path (`_evaluate_order_conditions`), so the two can't drift.
- **Perf:** orders are grouped once via `groupby(...).indices` and indexed positionally, instead of regrouping per rule. This also fixes a latent correctness hazard — index labels aren't guaranteed unique (`apply()` concatenates with `ignore_index` at the end), so the old label-based addressing could have addressed the wrong rows.
- Dropped development-time column logging; the per-rule INFO audit line stays (hoisted above the order loop so it's one line per rule, not one per rule per order). Three stale Ukrainian comments translated — the rest are left to the tag-categories task that owns those files.

## UI (`gui/settings/rules.py`, `gui/settings/fields.py`)

- **Order-level fields are offered only on order rules**, sourced from `RuleEngine.ORDER_LEVEL_FIELDS` so the editor can't drift from what the engine dispatches on. The hand-maintained duplicate lists in `gui/settings/fields.py` are deleted. **This closes F2 and F9 by construction** — no separate fix to look for.
- A field the new level doesn't offer is **kept as an extra combo item** when switching levels, so a saved condition is never silently reset; it's flagged instead.
- Collapsible rule cards with a conditions/actions counts summary; loaded rules start collapsed, a newly added rule starts expanded.
- Filter box, and reordering restricted to a rule's own level (an article rule moves past other article rules, skipping over order rules).

## Notes for review

- **Plan Task 4 dropped** — the optional refactor making `OPERATOR_MAP` hold functions rather than name strings. The plan permitted dropping it if the diff was already large; it had no dependents, and all 7 lookup sites still take the string-name path.
- **One test's expectation was flipped**, `test_unrecognized_operator_condition_is_skipped_not_fatal` → `..._fails_the_rule_closed`. It was documenting the pre-fix widening bug.
- `add_condition_row(self, rule_widget_refs, ...)` and `add_action_row(...)` have a parameter *named* `rule_widget_refs` that actually receives a **step's** refs. That's why summary updates from inside those two go through `_update_rule_summary_for_step()`. Pre-existing; renaming it was out of scope.
- The article path still uses label-based addressing at `rules.py:806`. Not currently reachable, but the order path now has a regression test for that hazard and the article path doesn't — worth a follow-up.

## Verification

`549 passed` (`QT_QPA_PLATFORM=offscreen python -m pytest`), `ruff check . --exclude shared` clean.

A code review pass over the full diff found the editor-side flag was never triggered on load and misfired when no analysis was loaded — both fixed in `12bfaf7`, with tests that assert the flag's presence *before* calling the helper by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbeVRvXHmGLRwazhYC7gGH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added collapsible rule cards with summaries, name filtering, level-aware fields, and rule reordering.
  - Added validation feedback for unavailable or unresolved fields.
  - Improved multi-step and order-level rule processing, including duplicate-row handling and updated data evaluation.

- **Bug Fixes**
  - Invalid conditions now fail safely instead of being silently ignored.
  - Improved action behavior across order rows and processing steps.

- **Documentation**
  - Added design and implementation plans for the rule engine and editor improvements.

- **Tests**
  - Expanded coverage for rule evaluation, validation, filtering, collapsing, and reordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->