### PR TITLE
Phase 6 — Rule Test dialog: stop crashing when a rule changes the frame's shape

### DIFF
--- a/docs/superpowers/plans/2026-08-13-rule-test-dialog-alignment-plan.md
+++ b/docs/superpowers/plans/2026-08-13-rule-test-dialog-alignment-plan.md
@@ -1,0 +1,514 @@
+# Rule Test Dialog Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Runner note:** executing-plans will offer to switch to
+> `subagent-driven-development`. **Decline it** and stay in-session — the
+> roadmap runner forbids subagents at Stage B.
+
+**Goal:** Make `RuleTestDialog` stop crashing (and stop silently under-reporting) when a rule creates a column or adds a row, by aligning `df_before` and `df_after` once instead of guarding each access site.
+
+**Architecture:** `RuleEngine.apply()` can change a frame's columns, index, and row count. The dialog assumes it changes none of them. Add one `_align_frames()` step immediately after `apply()` that (a) splits `df_after` positionally into original rows and appended rows, reattaching `df_before`'s index to the originals, and (b) `reindex`es `df_before`'s columns onto `df_after`'s. Every populate method then reads the aligned frames, so no per-site `KeyError` guard is needed. Added rows become a counted, displayed category of their own rather than a diff.
+
+**Tech Stack:** Python 3.14, PySide6 (`QDialog`, `QTableWidget`), pandas, pytest + pytest-qt (`qtbot`), ruff.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-rule-test-dialog-alignment-design.md`
+
+## Global Constraints
+
+- **Windows-only production**; development on Ubuntu. Run GUI tests with `QT_QPA_PLATFORM=offscreen`.
+- **Never hand-edit `shared/`** — one-way synced from `../packing-tool`.
+- **No hardcoded colours in stylesheets** — use `theme_manager` tokens. The two literal diff-highlight hexes in `rule_test_dialog.py` are a documented, `ponytail:`-commented exception at a single call site; extend that comment rather than adding a new `ThemeTokens` field.
+- **Do not modify `shopify_tool/rules.py`.** The engine is correct; the dialog is wrong. See spec §5.
+- Gate before finishing: `QT_QPA_PLATFORM=offscreen python -m pytest` and `ruff check . --exclude shared`.
+- Use `.venv/bin/python` — bare `python` is not on PATH on this machine. In a fresh worktree run `./scripts/setup_venv.sh` first.
+- Version string is **not** bumped by this change (bugfix on an unreleased line).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `gui/rule_test_dialog.py` (modify) | Add `_align_frames()`; rewrite `_detect_changed_rows`, `_populate_conditions_table`, `_populate_preview_table` and `_populate_after_actions_table` to read the aligned frames. |
+| `tests/test_rule_test_dialog.py` (create) | New file. There is no existing coverage for this dialog. Holds the five spec §2 scenarios plus the engine-ordering assumption test. |
+
+No new modules. `rule_test_dialog.py` is 431 lines and gains roughly 40 — no split warranted.
+
+---
+
+### Task 1: Pin the crashes and the engine assumption with failing tests
+
+Establishes the harness and reproduces every symptom before any fix. `_run_test` swallows exceptions into a `QMessageBox.critical`, so "did it crash" is asserted via the `no_modals` fixture from `tests/conftest.py`, which records popups into a list and returns it.
+
+**Files:**
+- Create: `tests/test_rule_test_dialog.py`
+- Read for reference: `gui/rule_test_dialog.py`, `tests/conftest.py:96-109`
+
+**Interfaces:**
+- Consumes: `no_modals` fixture (`tests/conftest.py`), `qtbot` (pytest-qt), `RuleTestDialog(rule_config, analysis_df, parent=None)`.
+- Produces: `analysis_df` fixture and `_rule(*actions)` helper used by Tasks 2-4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_rule_test_dialog.py`:
+
+```python
+"""RuleTestDialog before/after frame alignment.
+
+RuleEngine.apply() can add columns (CALCULATE/COPY_FIELD targets) and append
+rows (ADD_PRODUCT, concatenated with ignore_index). The dialog diffs
+df_before against df_after, so every one of those shape changes used to
+either raise or silently report nothing.
+"""
+import pandas as pd
+import pytest
+
+from gui.rule_test_dialog import RuleTestDialog
+
+
+@pytest.fixture
+def analysis_df():
+    """Analysis-shaped: Status_Note and Internal_Tags already exist.
+
+    analysis.py:1097 and :1103 initialise both on every real analysis, so a
+    fixture without them tests a frame production never produces.
+    """
+    return pd.DataFrame({
+        "Order_Number": ["1001", "1002", "1003"],
+        "SKU": ["A", "B", "A"],
+        "Quantity": [1, 2, 3],
+        "Total_Price": [10.0, 20.0, 30.0],
+        "Product_Name": ["Pa", "Pb", "Pa"],
+        "Warehouse_Name": ["Wa", "Wb", "Wa"],
+        "Order_Fulfillment_Status": ["Ready", "Not Ready", "Ready"],
+        "Status_Note": ["", "", ""],
+        "Internal_Tags": ["[]", "[]", "[]"],
+    })
+
+
+def _rule(*actions):
+    """Single-step rule matching the two 'Ready' rows."""
+    return {
+        "name": "t",
+        "enabled": True,
+        "steps": [{
+            "match": "ALL",
+            "conditions": [{
+                "field": "Order_Fulfillment_Status",
+                "operator": "equals",
+                "value": "Ready",
+            }],
+            "actions": list(actions),
+        }],
+    }
+
+
+def _open(qtbot, rule, df):
+    dialog = RuleTestDialog(rule, df)
+    qtbot.addWidget(dialog)
+    return dialog
+
+
+class TestNoCrashOnShapeChange:
+    def test_add_tag_is_unaffected(self, qtbot, analysis_df, no_modals):
+        """Baseline: passes today. Status_Note already exists, so nothing
+        about the frame's shape changes."""
+        dialog = _open(qtbot, _rule({"type": "ADD_TAG", "value": "hello"}), analysis_df)
+        assert no_modals == []
+        assert dialog.matched_count == 2
+
+    def test_calculate_target_column_does_not_crash(self, qtbot, analysis_df, no_modals):
+        """CALCULATE creates its target at rules.py:1190, so the column is in
+        df_after and not in df_before."""
+        dialog = _open(qtbot, _rule({
+            "type": "CALCULATE", "operation": "multiply",
+            "field1": "Quantity", "field2": "Total_Price",
+            "target": "Line_Total",
+        }), analysis_df)
+        assert no_modals == []
+        assert dialog.matched_count == 2
+
+    def test_copy_field_target_column_does_not_crash(self, qtbot, analysis_df, no_modals):
+        dialog = _open(qtbot, _rule({
+            "type": "COPY_FIELD", "source": "SKU", "target": "SKU_Copy",
+        }), analysis_df)
+        assert no_modals == []
+        assert dialog.matched_count == 2
+
+    def test_add_product_with_a_tag_does_not_crash(self, qtbot, analysis_df, no_modals):
+        """ADD_PRODUCT appends rows with ignore_index, so a boolean mask built
+        on df_before.index no longer aligns with df_after."""
+        dialog = _open(qtbot, _rule(
+            {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
+            {"type": "ADD_TAG", "value": "bonus"},
+        ), analysis_df)
+        assert no_modals == []
+
+
+class TestAddedRowsAreReported:
+    def test_add_product_alone_reports_the_added_rows(self, qtbot, analysis_df, no_modals):
+        """Two matched rows each spawn one product row. Reporting 0 tells the
+        user a working rule does nothing."""
+        dialog = _open(qtbot, _rule(
+            {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
+        ), analysis_df)
+        assert no_modals == []
+        assert len(dialog.added_rows) == 2
+        assert dialog.matched_count == 2
+
+
+class TestEngineOrderingAssumption:
+    def test_added_rows_are_appended_not_interleaved(self, qtbot, analysis_df, no_modals):
+        """_align_frames slices df_after positionally, which is only correct
+        while apply() appends. If the engine ever reorders or drops rows, this
+        fails here instead of silently mispairing rows in the preview."""
+        dialog = _open(qtbot, _rule(
+            {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
+        ), analysis_df)
+        n = len(dialog.df_before)
+        original = dialog.df_after.iloc[:n]
+        assert list(original["Order_Number"]) == list(dialog.df_before["Order_Number"])
+        assert list(original["SKU"]) == list(dialog.df_before["SKU"])
+```
+
+- [ ] **Step 2: Run the tests to verify they fail for the documented reasons**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rule_test_dialog.py -v
+```
+
+Expected on `main`:
+- `test_add_tag_is_unaffected` — **PASS** (baseline).
+- `test_calculate_target_column_does_not_crash` — FAIL, `no_modals` non-empty (swallowed `KeyError: 'Line_Total'`).
+- `test_copy_field_target_column_does_not_crash` — FAIL, `no_modals` non-empty (swallowed `KeyError: 'SKU_Copy'`).
+- `test_add_product_with_a_tag_does_not_crash` — FAIL, `no_modals` non-empty (swallowed `IndexingError: Unalignable boolean Series`).
+- `test_add_product_alone_reports_the_added_rows` — FAIL, `AttributeError: 'RuleTestDialog' object has no attribute 'added_rows'`.
+- `test_added_rows_are_appended_not_interleaved` — **PASS** (documents current engine behaviour).
+
+If any *other* failure appears, stop and read it — the fix in Task 2 assumes these exact causes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_rule_test_dialog.py
+git commit -m "test: pin RuleTestDialog crashes on engine shape changes"
+```
+
+---
+
+### Task 2: Align the frames once, after apply()
+
+**Files:**
+- Modify: `gui/rule_test_dialog.py:174-237` (`_run_test`, `_detect_changed_rows`)
+- Test: `tests/test_rule_test_dialog.py`
+
+**Interfaces:**
+- Consumes: `self.df_before`, `self.df_after` as set by `_run_test`.
+- Produces: three new instance attributes read by Task 3 —
+  - `self.before_aligned: pd.DataFrame` — `df_before` reindexed onto `df_after.columns`; same index as `df_before`.
+  - `self.after_existing: pd.DataFrame` — the original rows of `df_after`, carrying `df_before`'s index.
+  - `self.added_rows: pd.DataFrame` — rows `apply()` appended; empty when none.
+  - `self.matched_count: int` — now `changed.sum() + len(added_rows)`.
+  - `self.matches: pd.Series` — unchanged meaning: boolean, indexed like `df_before`, True where an **existing** row changed.
+
+- [ ] **Step 1: Add the three attribute declarations in `__init__`**
+
+In `gui/rule_test_dialog.py`, after the existing `self.matched_count = 0` (line 61):
+
+```python
+        # Set by _align_frames(): df_before/df_after made comparable.
+        self.before_aligned = None
+        self.after_existing = None
+        self.added_rows = None
+```
+
+- [ ] **Step 2: Call `_align_frames()` from `_run_test`**
+
+Replace lines 196-197 (`# Detect matched rows…` and `self.matches = self._detect_changed_rows()`) with:
+
+```python
+            # RuleEngine.apply() may add columns and append rows, so make the
+            # two frames comparable before anything diffs them.
+            self._align_frames()
+
+            # Detect matched rows by comparing before/after (works for all rule types)
+            self.matches = self._detect_changed_rows()
+```
+
+And replace line 198 (`self.matched_count = self.matches.sum()`) with:
+
+```python
+            self.matched_count = int(self.matches.sum()) + len(self.added_rows)
+```
+
+- [ ] **Step 3: Write `_align_frames()`**
+
+Insert immediately before `_detect_changed_rows` (i.e. before line 215):
+
+```python
+    def _align_frames(self):
+        """Make df_before and df_after comparable.
+
+        apply() changes the frame two ways: CALCULATE/COPY_FIELD create their
+        target column mid-apply, and ADD_PRODUCT rows are concatenated with
+        ignore_index=True. Either one breaks a naive before/after diff.
+
+        apply() only ever appends -- it has no drop, sort, or reindex -- so
+        the first len(df_before) positional rows of df_after are the original
+        rows in order. Slice positionally rather than by label: it is correct
+        whether or not ignore_index fired, and label alignment is precisely
+        what breaks. tests/test_rule_test_dialog.py asserts that assumption.
+        """
+        n = len(self.df_before)
+
+        self.after_existing = self.df_after.iloc[:n].copy()
+        self.after_existing.index = self.df_before.index
+        self.added_rows = self.df_after.iloc[n:]
+
+        # A column the rule created reads as NaN before and a value after,
+        # which is the truth: the rule changed that cell from nothing.
+        self.before_aligned = self.df_before.reindex(columns=self.df_after.columns)
+
+        if len(self.added_rows):
+            logger.info(f"[RULE TEST] Rule appended {len(self.added_rows)} new rows")
+```
+
+- [ ] **Step 4: Rewrite `_detect_changed_rows` to use the aligned frames**
+
+Replace the whole body of `_detect_changed_rows` (lines 216-237) with:
+
+```python
+        """Detect which existing rows were modified, comparing aligned frames.
+
+        Rows the rule *added* are not changes -- they have no before state --
+        and are tracked separately in self.added_rows.
+        """
+        changed = pd.Series(False, index=self.before_aligned.index)
+
+        for col in self.df_after.columns:
+            before_vals = self.before_aligned[col].fillna("").astype(str)
+            after_vals = self.after_existing[col].fillna("").astype(str)
+            changed = changed | (before_vals != after_vals)
+
+        return changed
+```
+
+Both frames now carry exactly `df_after.columns` and `df_before.index`, so the
+`common_cols`/`new_cols` split and the `.loc[]` lookup are gone. A newly
+created column compares `""` (from `NaN`) against its value, so a row only
+counts as changed where the rule actually wrote something — the old
+`notna() & != 0 & != "" & != 0.0` heuristic is no longer needed.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rule_test_dialog.py -v
+```
+
+Expected: `TestAddedRowsAreReported` and `TestEngineOrderingAssumption` PASS. The `TestNoCrashOnShapeChange` cases may still FAIL — `_populate_after_actions_table` is fixed in Task 3.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/rule_test_dialog.py
+git commit -m "fix: align before/after frames once in RuleTestDialog"
+```
+
+---
+
+### Task 3: Read the aligned frames in every populate method
+
+**Files:**
+- Modify: `gui/rule_test_dialog.py:239-397` (`_populate_conditions_table`, `_populate_preview_table`, `_populate_after_actions_table`)
+- Test: `tests/test_rule_test_dialog.py`
+
+**Interfaces:**
+- Consumes: `self.before_aligned`, `self.after_existing`, `self.added_rows`, `self.matches`, `self.matched_count` from Task 2.
+- Produces: nothing new.
+
+- [ ] **Step 1: Report the added-row split in the summary label**
+
+In `_populate_conditions_table`, replace the summary block (lines 270-272) with:
+
+```python
+        summary = f"Final Result ({step_info}, narrowing): "
+        summary += f"<span style='color: {theme.accent_green}; {font_css('heading')}'>{self.matched_count}</span> rows affected "
+        summary += f"({percentage:.1f}% of {total_rows} total rows)"
+        if len(self.added_rows):
+            summary += f" — {len(self.added_rows)} added by rule"
+```
+
+Changed and added rows are different things; conflating them into one count is
+what made ADD_PRODUCT read as a no-op.
+
+- [ ] **Step 2: Point `_populate_preview_table` at the aligned before-frame**
+
+In `_populate_preview_table`, replace line 288:
+
+```python
+        matched_df = self.df_before[self.matches].head(5)
+```
+
+with:
+
+```python
+        matched_df = self.before_aligned[self.matches].head(5)
+```
+
+`_get_display_columns` then sees the same column set the after-table does, so
+the two previews line up column-for-column.
+
+- [ ] **Step 3: Rewrite `_populate_after_actions_table`**
+
+Replace lines 368-397 (everything after the `matched_count == 0` early return, through `resizeColumnsToContents`) with:
+
+```python
+        # Aligned frames: same columns, same index, same length.
+        matched_before = self.before_aligned[self.matches].head(5)
+        matched_after = self.after_existing[self.matches].head(5)
+        added = self.added_rows.head(5)
+
+        display_cols = self._get_display_columns(self.after_existing)
+
+        self.after_table.setRowCount(len(matched_after) + len(added))
+        self.after_table.setColumnCount(len(display_cols))
+        self.after_table.setHorizontalHeaderLabels(display_cols)
+
+        for row_idx, (idx_after, row_after) in enumerate(matched_after.iterrows()):
+            row_before = matched_before.loc[idx_after]
+
+            for col_idx, col_name in enumerate(display_cols):
+                value_before = row_before[col_name]
+                value_after = row_after[col_name]
+
+                item = QTableWidgetItem(str(value_after))
+
+                # Highlight changed cells
+                # ponytail: literal diff-highlight yellow/green, not worth two
+                # new ThemeTokens fields for this one call site.
+                if value_before != value_after and not (pd.isna(value_before) and pd.isna(value_after)):
+                    item.setBackground(QColor("#FFEB3B"))  # Yellow
+                    item.setToolTip(f"Changed from: {value_before}")
+
+                self.after_table.setItem(row_idx, col_idx, item)
+
+        # Rows the rule created have no before state, so they are tinted whole
+        # rather than diffed cell by cell.
+        for offset, (_, row_added) in enumerate(added.iterrows()):
+            row_idx = len(matched_after) + offset
+            for col_idx, col_name in enumerate(display_cols):
+                item = QTableWidgetItem(str(row_added[col_name]))
+                item.setBackground(QColor("#C8E6C9"))  # Green
+                item.setToolTip("Added by rule")
+                self.after_table.setItem(row_idx, col_idx, item)
+
+        self.after_table.resizeColumnsToContents()
+```
+
+- [ ] **Step 4: Extend the legend**
+
+Replace line 167:
+
+```python
+        legend = QLabel("Yellow highlight = Modified by rule actions")
+```
+
+with:
+
+```python
+        legend = QLabel(
+            "Yellow highlight = Modified by rule actions   |   "
+            "Green highlight = Row added by rule"
+        )
+```
+
+- [ ] **Step 5: Fix the `matched_count == 0` early return**
+
+At line 360 the guard returns before drawing anything. With added rows counted
+into `matched_count`, an ADD_PRODUCT-only rule now has `matched_count > 0` and
+`self.matches.sum() == 0`, so it falls through correctly and the added rows
+render. No change is needed to the condition itself — **verify** it reads:
+
+```python
+        if self.matches is None or self.matched_count == 0:
+```
+
+and leave it. The same guard in `_populate_preview_table` (line 279) also
+stays: that table shows *before* rows, and an added row has no before state, so
+"No rows matched the conditions" is the right thing to show there.
+
+- [ ] **Step 6: Run the tests**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rule_test_dialog.py -v
+```
+
+Expected: all six PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/rule_test_dialog.py
+git commit -m "fix: show added rows and stop KeyErroring on rule-created columns"
+```
+
+---
+
+### Task 4: Full gate
+
+**Files:**
+- Modify: none expected.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: a green branch.
+
+- [ ] **Step 1: Run the whole suite**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+```
+
+Expected: 567 prior + 6 new = **573 passed**. If anything else broke, it is
+almost certainly a test asserting the old `matched_count` semantics — read it
+before changing it, and prefer fixing the dialog over loosening the test.
+
+- [ ] **Step 2: Lint**
+
+```bash
+.venv/bin/ruff check . --exclude shared
+```
+
+Expected: clean. Watch for an unused `pd` import if the `pd.isna` call moved.
+
+- [ ] **Step 3: Commit any gate fixes**
+
+```bash
+git add -A
+git commit -m "fix: gate fixes for rule test dialog alignment"
+```
+
+Skip if nothing changed.
+
+- [ ] **Step 4: Push**
+
+```bash
+git push -u origin worktree-rule-test-crash
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3(a) new columns → Task 2 Step 3 (`reindex`), Task 3 Step 3 (`display_cols` from `after_existing`). Tests: `test_calculate_…`, `test_copy_field_…`.
+- §3(b) appended rows → Task 2 Step 3 (positional split). Test: `test_add_product_with_a_tag_does_not_crash`.
+- §3 silent under-report → Task 2 Step 2 (`matched_count`), Task 3 Step 1 (summary). Test: `test_add_product_alone_reports_the_added_rows`.
+- §4.1 ordering assumption → Task 1, `test_added_rows_are_appended_not_interleaved`.
+- §4.3 added rows displayed → Task 3 Steps 3-4.
+- §5 out-of-scope items → Global Constraints forbids touching `rules.py`.
+
+**Placeholders:** none — every code step carries the literal code.
+
+**Type consistency:** `before_aligned`, `after_existing`, `added_rows` are declared in Task 2 Step 1, set in Task 2 Step 3, and consumed under those exact names in Task 3 Steps 1-3 and in Task 1's tests. `matched_count` stays `int`; `matches` keeps its `df_before`-indexed boolean meaning.

--- a/docs/superpowers/specs/2026-08-13-rule-test-dialog-alignment-design.md
+++ b/docs/superpowers/specs/2026-08-13-rule-test-dialog-alignment-design.md
@@ -1,0 +1,190 @@
+# Rule Test dialog — before/after frame alignment
+
+**Date:** 2026-08-13
+**Todoist:** `6hGfgP6cF5gJMfcV` (p2, "Rule Test button crashes")
+**Status:** design, ready to implement
+
+---
+
+## 1. The report
+
+The user tested the rule editor on the `worktree-rule-engine-ui` branch and
+filed: *the Rule Test button crashes*. It is not a disabled button and not a
+visible traceback — `RuleTestDialog._run_test` wraps everything in
+`except Exception` and shows a "Failed to test rule" `QMessageBox`, so the
+symptom the user sees is a modal error box where a preview should be.
+
+## 2. What was actually reproduced
+
+The previous run's diagnosis was **"`rule_test_dialog.py:383` KeyErrors on
+`Status_Note`, created by ADD_TAG"**, with a caveat that the repro used a
+synthetic DataFrame. That caveat turned out to matter: **the ADD_TAG theory is
+wrong on real data.**
+
+`shopify_tool/analysis.py:1097` and `:1103` initialise `Status_Note` and
+`Internal_Tags` on every analysis DataFrame. So `_prepare_df_for_actions`
+(`rules.py:927-930`) finds them already present and creates nothing, and
+ADD_TAG never introduces a new column on a real analysis df.
+
+Driving the real `RuleTestDialog` against an analysis-shaped df (all of
+`Order_Number`, `SKU`, `Quantity`, `Total_Price`, `Product_Name`,
+`Warehouse_Name`, `Order_Fulfillment_Status`, `Status_Note`, `Internal_Tags`
+present), with the swallow-all handler removed:
+
+| Rule under test | Result |
+|---|---|
+| `ADD_TAG` only | OK — matched 2 |
+| `CALCULATE` → new `target` | **`KeyError: 'Line_Total'`** |
+| `COPY_FIELD` → new `target` | **`KeyError: 'SKU_Copy'`** |
+| `ADD_PRODUCT` only | No crash, but reports **"0 rows affected"** for a rule that added 2 rows |
+| `ADD_PRODUCT` + `ADD_TAG` | **`IndexingError: Unalignable boolean Series provided as indexer`** |
+
+Repro driver: `/home/cognitiveghost/.claude/jobs/d7a71174/tmp/repro2.py`
+(scratch, not committed — Task 1 replaces it with a committed test).
+
+## 3. Root cause
+
+`RuleTestDialog` compares `self.df_before` against `self.df_after` and assumes
+the two frames share **columns**, **index**, and **row count**. `RuleEngine`
+guarantees none of the three.
+
+`df_before` is snapshotted at `rule_test_dialog.py:191`, *before*
+`engine.apply()` runs. `apply()` then changes the frame's shape in two ways:
+
+**(a) New columns appear mid-apply.** `_prepare_df_for_actions` only ever
+materialises `Status_Note` and `Internal_Tags` (`rules.py:927-930`) — it
+collects `COPY_FIELD`/`CALCULATE` targets into `needed_columns`
+(`rules.py:920-923`) and then never creates them. Those columns are instead
+created by the action itself: `CALCULATE` at `rules.py:1189-1190`
+(`df[target] = 0.0`), and `COPY_FIELD` likewise. Either way the column exists
+in `df_after` and not in `df_before`.
+
+`_detect_changed_rows` handles this correctly — it has a dedicated `new_cols`
+branch (`rule_test_dialog.py:220`, `:231-235`) that marks rows changed when a
+new column holds a value. But `_populate_after_actions_table` then derives
+`display_cols` from `matched_after` (`:373`) — which *includes* the new column
+— and indexes `row_before[col_name]` (`:383`) with it. `row_before` came from
+`df_before`, which has no such column. **KeyError.**
+
+**(b) New rows appear at the end.** `ADD_PRODUCT` accumulates rows and
+`apply()` concatenates them at `rules.py:891-893` with `ignore_index=True`, so
+`df_after` is longer than `df_before` and carries a fresh `RangeIndex`.
+`self.matches` is a boolean Series on `df_before.index`. At
+`rule_test_dialog.py:370`, `self.df_after[self.matches]` is a boolean indexer
+whose length no longer matches the frame. **IndexingError.**
+
+The same mismatch is why `ADD_PRODUCT`-only reports 0 rows:
+`_detect_changed_rows` compares `df_after.loc[df_before.index]` positionally
+against `df_before` and finds the original rows unmodified, while the appended
+rows fall outside `df_before.index` entirely and are never considered. The
+dialog tells the user a rule that adds products does nothing. This is worse
+than the crash — a crash is visible; this is silently wrong.
+
+`_populate_preview_table` is safe today only by accident: it reads from
+`df_before` and picks `display_cols` from `df_before` too (`:288-291`).
+
+**One root cause, four symptoms.** Guarding line 383 alone — the previously
+proposed fix — leaves (b) crashing and leaves ADD_PRODUCT silently wrong.
+
+## 4. Design
+
+Normalise the two frames **once**, immediately after `apply()`, so every
+consumer downstream is comparing like with like. No per-site guards.
+
+### 4.1 Splitting original rows from added rows
+
+`apply()` never drops, sorts, reindexes, or reorders rows — `git grep` over
+`shopify_tool/rules.py` finds no `.drop(`, `sort_values`, `reset_index`, or
+`.reindex(` anywhere in the file. The concat at `rules.py:893` is the only
+shape change, and it appends: `pd.concat([df, new_df])`.
+
+Therefore **the first `len(df_before)` positional rows of `df_after` are the
+original rows, in their original order.** Slice positionally and reattach
+`df_before`'s labels:
+
+```python
+n = len(self.df_before)
+after_existing = self.df_after.iloc[:n].copy()
+after_existing.index = self.df_before.index
+added_rows = self.df_after.iloc[n:]
+```
+
+Positional slicing is deliberate: it is correct whether `ignore_index` fired
+or not, and it does not care what the index labels are. Label-based alignment
+(`df_after.loc[df_before.index]`) is what breaks today.
+
+This is an assumption about `RuleEngine`, so it gets asserted by a test
+(Task 1, `test_added_rows_are_appended_not_interleaved`) rather than trusted.
+If a future engine change starts reordering rows, that test fails loudly
+instead of the dialog quietly mispairing rows.
+
+### 4.2 Aligning columns
+
+```python
+before_aligned = self.df_before.reindex(columns=self.df_after.columns)
+```
+
+A column the rule created reads as `NaN` in `before_aligned` and as its value
+in `after_existing` — which is exactly right: the rule *did* change that cell,
+from "not there" to a value. It highlights, and the tooltip shows the change.
+`row_before[col]` can no longer `KeyError` for any column drawn from
+`df_after`.
+
+`reindex(columns=...)` is stdlib pandas doing the whole job in one call. No
+loop, no `.get()` guards, no defaulting logic.
+
+### 4.3 Added rows are a category, not a change
+
+`ADD_PRODUCT` rows have no "before" to diff against, so they are not part of
+`changed`. They are counted and displayed separately:
+
+- `matched_count` becomes `changed.sum() + len(added_rows)` — the number the
+  summary label reports as "rows affected". A rule that adds 2 products
+  affects 2 rows; reporting 0 is the bug.
+- The summary label spells the split out when rows were added, so the two
+  kinds are never conflated: `"… 2 rows affected (2 added by rule)"`.
+- The after-table appends the added rows below the changed ones, tinted green
+  with an "Added by rule" tooltip, so the preview shows what the rule will
+  actually produce.
+
+**Decision — show added rows rather than only counting them.** Counting is the
+smaller diff, but the dialog exists to answer "what will this rule do to my
+data", and a rule whose entire effect is adding rows would render an empty
+preview. The rows are already in the frame; displaying them is a few lines.
+
+**Decision — green tint, literal hex, no new theme token.** Follows the
+precedent already set and commented at `rule_test_dialog.py:389-390` for the
+yellow diff highlight. Two literal colours at one call site do not earn a
+`ThemeTokens` field.
+
+### 4.4 Where the normalisation lives
+
+A new `_align_frames()` called from `_run_test` between `apply()` and
+`_detect_changed_rows()`, setting `self.before_aligned`, `self.after_existing`,
+`self.added_rows`. Every populate method then reads those three instead of
+`df_before`/`df_after`.
+
+`df_before` and `df_after` stay as they are — they are the raw record of what
+the engine did, and tests assert against them.
+
+## 5. Out of scope
+
+- **`_prepare_df_for_actions` never creates `COPY_FIELD`/`CALCULATE` targets**
+  despite collecting them into `needed_columns` (`rules.py:920-923`). Dead
+  intent in the engine. Harmless — the actions create their own targets — and
+  fixing it changes engine behaviour to fix a display bug. Left alone
+  deliberately; worth its own task.
+- **`ignore_index=True` at `rules.py:893`.** Correct for the production
+  pipeline (it prevents duplicate index labels after the concat). The dialog is
+  what is wrong, not the engine.
+- The two sibling tasks from the same testing session —
+  `6hGfgP9C7355Gm83` (validation feedback unreadable) and
+  `6hGfgPGhxWp2cFwV` (rule actions refactor). Different code paths.
+
+## 6. Verification
+
+`QT_QPA_PLATFORM=offscreen python -m pytest` (567 passing on `main` at
+`f441346`) plus `ruff check . --exclude shared`.
+
+The five rows of the table in §2 become five committed tests, and each one
+fails on `main` today for the reason listed.

--- a/gui/rule_test_dialog.py
+++ b/gui/rule_test_dialog.py
@@ -169,7 +169,10 @@ class RuleTestDialog(QDialog):
         layout.addWidget(self.after_table)
 
         # Legend for highlights
-        legend = QLabel("Yellow highlight = Modified by rule actions")
+        legend = QLabel(
+            "Yellow highlight = Modified by rule actions   |   "
+            "Green highlight = Row added by rule"
+        )
         theme = get_theme_manager().get_current_theme()
         legend.setStyleSheet(f"color: {theme.text_secondary}; {font_css('caption')} margin-top: 5px;")
         layout.addWidget(legend)
@@ -240,8 +243,9 @@ class RuleTestDialog(QDialog):
         self.after_existing.index = self.df_before.index
         self.added_rows = self.df_after.iloc[n:]
 
-        # A column the rule created reads as NaN before and a value after,
-        # which is the truth: the rule changed that cell from nothing.
+        # A column the rule created is absent from df_before -- reindex adds
+        # it as NaN so every populate method can read a uniform column set.
+        # _detect_changed_rows treats new columns specially; see there.
         self.before_aligned = self.df_before.reindex(columns=self.df_after.columns)
 
         if len(self.added_rows):
@@ -252,13 +256,27 @@ class RuleTestDialog(QDialog):
 
         Rows the rule *added* are not changes -- they have no before state --
         and are tracked separately in self.added_rows.
+
+        A column the rule creates (CALCULATE/COPY_FIELD's target) is a
+        special case: rules.py seeds it for *every* row (e.g. CALCULATE's
+        `df[target] = 0.0`) before writing real results only into matched
+        rows, so an unmatched row's cell also differs from the reindexed
+        NaN even though the rule never touched that row. Pre-existing
+        columns don't have this seeding step, so a plain before/after
+        string diff is exact for them; a brand-new column instead needs the
+        "does it hold a real value" check.
         """
+        original_cols = set(self.df_before.columns)
         changed = pd.Series(False, index=self.before_aligned.index)
 
         for col in self.df_after.columns:
-            before_vals = self.before_aligned[col].fillna("").astype(str)
-            after_vals = self.after_existing[col].fillna("").astype(str)
-            changed = changed | (before_vals != after_vals)
+            after_vals = self.after_existing[col]
+            if col in original_cols:
+                before_vals = self.before_aligned[col].fillna("").astype(str)
+                changed = changed | (before_vals != after_vals.fillna("").astype(str))
+            else:
+                has_value = after_vals.notna() & (after_vals != 0) & (after_vals != "") & (after_vals != 0.0)
+                changed = changed | has_value
 
         return changed
 
@@ -296,6 +314,8 @@ class RuleTestDialog(QDialog):
         summary = f"Final Result ({step_info}, narrowing): "
         summary += f"<span style='color: {theme.accent_green}; {font_css('heading')}'>{self.matched_count}</span> rows affected "
         summary += f"({percentage:.1f}% of {total_rows} total rows)"
+        if len(self.added_rows):
+            summary += f" — {len(self.added_rows)} added by rule"
 
         self.match_summary_label.setText(summary)
 
@@ -311,7 +331,7 @@ class RuleTestDialog(QDialog):
             return
 
         # Get matched rows (first 5)
-        matched_df = self.df_before[self.matches].head(5)
+        matched_df = self.before_aligned[self.matches].head(5)
 
         # Select relevant columns to display
         display_cols = self._get_display_columns(matched_df)
@@ -391,14 +411,14 @@ class RuleTestDialog(QDialog):
             self.after_table.setItem(0, 0, no_match_item)
             return
 
-        # Get matched rows before and after (first 5)
-        matched_before = self.df_before[self.matches].head(5)
-        matched_after = self.df_after[self.matches].head(5)
+        # Aligned frames: same columns, same index, same length.
+        matched_before = self.before_aligned[self.matches].head(5)
+        matched_after = self.after_existing[self.matches].head(5)
+        added = self.added_rows.head(5)
 
-        # Select relevant columns to display
-        display_cols = self._get_display_columns(matched_after)
+        display_cols = self._get_display_columns(self.after_existing)
 
-        self.after_table.setRowCount(len(matched_after))
+        self.after_table.setRowCount(len(matched_after) + len(added))
         self.after_table.setColumnCount(len(display_cols))
         self.after_table.setHorizontalHeaderLabels(display_cols)
 
@@ -412,12 +432,22 @@ class RuleTestDialog(QDialog):
                 item = QTableWidgetItem(str(value_after))
 
                 # Highlight changed cells
-                # ponytail: literal diff-highlight yellow, not worth a new
-                # ThemeTokens field for this one call site.
+                # ponytail: literal diff-highlight yellow/green, not worth two
+                # new ThemeTokens fields for this one call site.
                 if value_before != value_after and not (pd.isna(value_before) and pd.isna(value_after)):
                     item.setBackground(QColor("#FFEB3B"))  # Yellow
                     item.setToolTip(f"Changed from: {value_before}")
 
+                self.after_table.setItem(row_idx, col_idx, item)
+
+        # Rows the rule created have no before state, so they are tinted whole
+        # rather than diffed cell by cell.
+        for offset, (_, row_added) in enumerate(added.iterrows()):
+            row_idx = len(matched_after) + offset
+            for col_idx, col_name in enumerate(display_cols):
+                item = QTableWidgetItem(str(row_added[col_name]))
+                item.setBackground(QColor("#C8E6C9"))  # Green
+                item.setToolTip("Added by rule")
                 self.after_table.setItem(row_idx, col_idx, item)
 
         self.after_table.resizeColumnsToContents()

--- a/gui/rule_test_dialog.py
+++ b/gui/rule_test_dialog.py
@@ -59,6 +59,7 @@ class RuleTestDialog(QDialog):
         self.df_after = None
         self.matches = None
         self.matched_count = 0
+        self.changed_count = 0
 
         # Set by _align_frames(): df_before/df_after made comparable.
         self.before_aligned = None
@@ -207,7 +208,8 @@ class RuleTestDialog(QDialog):
 
             # Detect matched rows by comparing before/after (works for all rule types)
             self.matches = self._detect_changed_rows()
-            self.matched_count = int(self.matches.sum()) + len(self.added_rows)
+            self.changed_count = int(self.matches.sum())
+            self.matched_count = self.changed_count + len(self.added_rows)
             logger.info(f"[RULE TEST] Rule affected {self.matched_count} rows")
 
             # Populate UI sections
@@ -265,6 +267,17 @@ class RuleTestDialog(QDialog):
         columns don't have this seeding step, so a plain before/after
         string diff is exact for them; a brand-new column instead needs the
         "does it hold a real value" check.
+
+        ponytail: that check is a heuristic, not a proof, and it is wrong at
+        both ends. It *under*-reports a matched row whose CALCULATE result is
+        legitimately 0/0.0/NaN -- indistinguishable from the seed once apply()
+        has returned. It *over*-reports a brand-new Internal_Tags, which
+        _prepare_df_for_actions seeds with the truthy string "[]" for every
+        row. Both are pre-existing behaviour, and the second is latent in
+        practice: analysis.py initialises Internal_Tags on every real
+        analysis, so it always takes the exact pre-existing-column path.
+        Exact counts need rules.py to report which rows it wrote, which is
+        out of scope here -- the engine is correct, the dialog was wrong.
         """
         original_cols = set(self.df_before.columns)
         changed = pd.Series(False, index=self.before_aligned.index)
@@ -308,12 +321,14 @@ class RuleTestDialog(QDialog):
 
         # Update summary label
         total_rows = len(self.test_df)
-        percentage = (self.matched_count / total_rows * 100) if total_rows > 0 else 0
+        # Percentage is of existing rows only -- added rows have no denominator
+        # to belong to, and counting them made this read 133.3%.
+        percentage = (self.changed_count / total_rows * 100) if total_rows > 0 else 0
         step_info = f"{len(steps)} step(s)" if len(steps) > 1 else "1 step"
 
         summary = f"Final Result ({step_info}, narrowing): "
         summary += f"<span style='color: {theme.accent_green}; {font_css('heading')}'>{self.matched_count}</span> rows affected "
-        summary += f"({percentage:.1f}% of {total_rows} total rows)"
+        summary += f"({self.changed_count} of {total_rows} existing rows, {percentage:.1f}%)"
         if len(self.added_rows):
             summary += f" — {len(self.added_rows)} added by rule"
 
@@ -322,10 +337,17 @@ class RuleTestDialog(QDialog):
     def _populate_preview_table(self):
         """Populate preview table with first 5 matched rows."""
         theme = get_theme_manager().get_current_theme()
-        if self.matches is None or self.matched_count == 0:
+        # This table shows *before* rows, so it is empty whenever no existing
+        # row matched -- even if the rule appended rows (an ADD_PRODUCT-only
+        # rule has matched_count > 0 but nothing to preview). Guard on the
+        # existing-row count, or that case renders a blank table.
+        if self.matches is None or self.changed_count == 0:
             self.preview_table.setRowCount(1)
             self.preview_table.setColumnCount(1)
-            no_match_item = QTableWidgetItem("No rows matched the conditions")
+            message = "No rows matched the conditions"
+            if self.added_rows is not None and len(self.added_rows):
+                message += f" — {len(self.added_rows)} rows added by the rule (see After Actions)"
+            no_match_item = QTableWidgetItem(message)
             no_match_item.setForeground(QColor(theme.text_secondary))
             self.preview_table.setItem(0, 0, no_match_item)
             return
@@ -350,9 +372,9 @@ class RuleTestDialog(QDialog):
         self.preview_table.resizeColumnsToContents()
 
         # Show "and X more" if there are more matches
-        if self.matched_count > 5:
-            remaining = self.matched_count - 5
-            logger.info(f"[RULE TEST] Showing 5 of {self.matched_count} matched rows ({remaining} more)")
+        if self.changed_count > 5:
+            remaining = self.changed_count - 5
+            logger.info(f"[RULE TEST] Showing 5 of {self.changed_count} matched rows ({remaining} more)")
 
     def _populate_actions_list(self):
         """Populate actions list with actions from all steps."""
@@ -433,9 +455,12 @@ class RuleTestDialog(QDialog):
 
                 # Highlight changed cells
                 # ponytail: literal diff-highlight yellow/green, not worth two
-                # new ThemeTokens fields for this one call site.
+                # new ThemeTokens fields for this one call site. The tints are
+                # light in both themes, so pin a dark foreground too -- dark
+                # theme's text_primary is near-white and vanishes on them.
                 if value_before != value_after and not (pd.isna(value_before) and pd.isna(value_after)):
                     item.setBackground(QColor("#FFEB3B"))  # Yellow
+                    item.setForeground(QColor("#000000"))
                     item.setToolTip(f"Changed from: {value_before}")
 
                 self.after_table.setItem(row_idx, col_idx, item)
@@ -447,6 +472,7 @@ class RuleTestDialog(QDialog):
             for col_idx, col_name in enumerate(display_cols):
                 item = QTableWidgetItem(str(row_added[col_name]))
                 item.setBackground(QColor("#C8E6C9"))  # Green
+                item.setForeground(QColor("#000000"))
                 item.setToolTip("Added by rule")
                 self.after_table.setItem(row_idx, col_idx, item)
 

--- a/gui/rule_test_dialog.py
+++ b/gui/rule_test_dialog.py
@@ -60,6 +60,11 @@ class RuleTestDialog(QDialog):
         self.matches = None
         self.matched_count = 0
 
+        # Set by _align_frames(): df_before/df_after made comparable.
+        self.before_aligned = None
+        self.after_existing = None
+        self.added_rows = None
+
         self.setWindowTitle(f"Test Rule: {rule_config.get('name', 'Unnamed')}")
         self.setMinimumSize(1000, 800)
         self.setModal(True)
@@ -193,9 +198,13 @@ class RuleTestDialog(QDialog):
             # Apply rule (modifies test_df in-place)
             self.df_after = engine.apply(self.test_df)
 
+            # RuleEngine.apply() may add columns and append rows, so make the
+            # two frames comparable before anything diffs them.
+            self._align_frames()
+
             # Detect matched rows by comparing before/after (works for all rule types)
             self.matches = self._detect_changed_rows()
-            self.matched_count = self.matches.sum()
+            self.matched_count = int(self.matches.sum()) + len(self.added_rows)
             logger.info(f"[RULE TEST] Rule affected {self.matched_count} rows")
 
             # Populate UI sections
@@ -212,27 +221,44 @@ class RuleTestDialog(QDialog):
                 f"Failed to test rule:\n\n{e!s}\n\nCheck logs for details."
             )
 
+    def _align_frames(self):
+        """Make df_before and df_after comparable.
+
+        apply() changes the frame two ways: CALCULATE/COPY_FIELD create their
+        target column mid-apply, and ADD_PRODUCT rows are concatenated with
+        ignore_index=True. Either one breaks a naive before/after diff.
+
+        apply() only ever appends -- it has no drop, sort, or reindex -- so
+        the first len(df_before) positional rows of df_after are the original
+        rows in order. Slice positionally rather than by label: it is correct
+        whether or not ignore_index fired, and label alignment is precisely
+        what breaks. tests/test_rule_test_dialog.py asserts that assumption.
+        """
+        n = len(self.df_before)
+
+        self.after_existing = self.df_after.iloc[:n].copy()
+        self.after_existing.index = self.df_before.index
+        self.added_rows = self.df_after.iloc[n:]
+
+        # A column the rule created reads as NaN before and a value after,
+        # which is the truth: the rule changed that cell from nothing.
+        self.before_aligned = self.df_before.reindex(columns=self.df_after.columns)
+
+        if len(self.added_rows):
+            logger.info(f"[RULE TEST] Rule appended {len(self.added_rows)} new rows")
+
     def _detect_changed_rows(self):
-        """Detect which rows were modified by comparing before/after DataFrames."""
-        # Find common columns
-        common_cols = [c for c in self.df_before.columns if c in self.df_after.columns]
-        # Also check new columns added by CALCULATE
-        new_cols = [c for c in self.df_after.columns if c not in self.df_before.columns]
+        """Detect which existing rows were modified, comparing aligned frames.
 
-        # Compare common columns
-        changed = pd.Series(False, index=self.df_before.index)
-        for col in common_cols:
-            before_vals = self.df_before[col].fillna("").astype(str)
-            # df_after may have extra rows from ADD_PRODUCT, limit to original index
-            after_vals = self.df_after.loc[self.df_before.index, col].fillna("").astype(str)
+        Rows the rule *added* are not changes -- they have no before state --
+        and are tracked separately in self.added_rows.
+        """
+        changed = pd.Series(False, index=self.before_aligned.index)
+
+        for col in self.df_after.columns:
+            before_vals = self.before_aligned[col].fillna("").astype(str)
+            after_vals = self.after_existing[col].fillna("").astype(str)
             changed = changed | (before_vals != after_vals)
-
-        # New columns with non-default values indicate changes
-        for col in new_cols:
-            if col in self.df_after.columns:
-                after_vals = self.df_after.loc[self.df_before.index, col]
-                has_value = after_vals.notna() & (after_vals != 0) & (after_vals != "") & (after_vals != 0.0)
-                changed = changed | has_value
 
         return changed
 

--- a/tests/test_rule_test_dialog.py
+++ b/tests/test_rule_test_dialog.py
@@ -101,6 +101,31 @@ class TestAddedRowsAreReported:
         assert len(dialog.added_rows) == 2
         assert dialog.matched_count == 2
 
+    def test_add_product_alone_explains_the_empty_preview(self, qtbot, analysis_df, no_modals):
+        """The preview table shows *before* rows, so an ADD_PRODUCT-only rule
+        has nothing to put in it. Rendering it blank reads as broken -- say why
+        it is empty and where the added rows are."""
+        dialog = _open(qtbot, _rule(
+            {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
+        ), analysis_df)
+        assert no_modals == []
+        assert dialog.preview_table.rowCount() == 1
+        assert "2 rows added by the rule" in dialog.preview_table.item(0, 0).text()
+        # The added rows still show up where they belong.
+        assert dialog.after_table.rowCount() == 2
+
+    def test_summary_percentage_never_exceeds_total_rows(self, qtbot, analysis_df, no_modals):
+        """Added rows have no denominator to belong to -- counting them in the
+        percentage rendered "4 rows affected (133.3% of 3 total rows)"."""
+        dialog = _open(qtbot, _rule(
+            {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
+            {"type": "ADD_TAG", "value": "bonus"},
+        ), analysis_df)
+        assert no_modals == []
+        assert dialog.matched_count == 4
+        assert dialog.changed_count == 2
+        assert "2 of 3 existing rows, 66.7%" in dialog.match_summary_label.text()
+
 
 class TestEngineOrderingAssumption:
     def test_added_rows_are_appended_not_interleaved(self, qtbot, analysis_df, no_modals):

--- a/tests/test_rule_test_dialog.py
+++ b/tests/test_rule_test_dialog.py
@@ -1,0 +1,116 @@
+"""RuleTestDialog before/after frame alignment.
+
+RuleEngine.apply() can add columns (CALCULATE/COPY_FIELD targets) and append
+rows (ADD_PRODUCT, concatenated with ignore_index). The dialog diffs
+df_before against df_after, so every one of those shape changes used to
+either raise or silently report nothing.
+"""
+import pandas as pd
+import pytest
+
+from gui.rule_test_dialog import RuleTestDialog
+
+
+@pytest.fixture
+def analysis_df():
+    """Analysis-shaped: Status_Note and Internal_Tags already exist.
+
+    analysis.py:1097 and :1103 initialise both on every real analysis, so a
+    fixture without them tests a frame production never produces.
+    """
+    return pd.DataFrame({
+        "Order_Number": ["1001", "1002", "1003"],
+        "SKU": ["A", "B", "A"],
+        "Quantity": [1, 2, 3],
+        "Total_Price": [10.0, 20.0, 30.0],
+        "Product_Name": ["Pa", "Pb", "Pa"],
+        "Warehouse_Name": ["Wa", "Wb", "Wa"],
+        "Order_Fulfillment_Status": ["Ready", "Not Ready", "Ready"],
+        "Status_Note": ["", "", ""],
+        "Internal_Tags": ["[]", "[]", "[]"],
+    })
+
+
+def _rule(*actions):
+    """Single-step rule matching the two 'Ready' rows."""
+    return {
+        "name": "t",
+        "enabled": True,
+        "steps": [{
+            "match": "ALL",
+            "conditions": [{
+                "field": "Order_Fulfillment_Status",
+                "operator": "equals",
+                "value": "Ready",
+            }],
+            "actions": list(actions),
+        }],
+    }
+
+
+def _open(qtbot, rule, df):
+    dialog = RuleTestDialog(rule, df)
+    qtbot.addWidget(dialog)
+    return dialog
+
+
+class TestNoCrashOnShapeChange:
+    def test_add_tag_is_unaffected(self, qtbot, analysis_df, no_modals):
+        """Baseline: passes today. Status_Note already exists, so nothing
+        about the frame's shape changes."""
+        dialog = _open(qtbot, _rule({"type": "ADD_TAG", "value": "hello"}), analysis_df)
+        assert no_modals == []
+        assert dialog.matched_count == 2
+
+    def test_calculate_target_column_does_not_crash(self, qtbot, analysis_df, no_modals):
+        """CALCULATE creates its target at rules.py:1190, so the column is in
+        df_after and not in df_before."""
+        dialog = _open(qtbot, _rule({
+            "type": "CALCULATE", "operation": "multiply",
+            "field1": "Quantity", "field2": "Total_Price",
+            "target": "Line_Total",
+        }), analysis_df)
+        assert no_modals == []
+        assert dialog.matched_count == 2
+
+    def test_copy_field_target_column_does_not_crash(self, qtbot, analysis_df, no_modals):
+        dialog = _open(qtbot, _rule({
+            "type": "COPY_FIELD", "source": "SKU", "target": "SKU_Copy",
+        }), analysis_df)
+        assert no_modals == []
+        assert dialog.matched_count == 2
+
+    def test_add_product_with_a_tag_does_not_crash(self, qtbot, analysis_df, no_modals):
+        """ADD_PRODUCT appends rows with ignore_index, so a boolean mask built
+        on df_before.index no longer aligns with df_after."""
+        dialog = _open(qtbot, _rule(
+            {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
+            {"type": "ADD_TAG", "value": "bonus"},
+        ), analysis_df)
+        assert no_modals == []
+
+
+class TestAddedRowsAreReported:
+    def test_add_product_alone_reports_the_added_rows(self, qtbot, analysis_df, no_modals):
+        """Two matched rows each spawn one product row. Reporting 0 tells the
+        user a working rule does nothing."""
+        dialog = _open(qtbot, _rule(
+            {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
+        ), analysis_df)
+        assert no_modals == []
+        assert len(dialog.added_rows) == 2
+        assert dialog.matched_count == 2
+
+
+class TestEngineOrderingAssumption:
+    def test_added_rows_are_appended_not_interleaved(self, qtbot, analysis_df, no_modals):
+        """_align_frames slices df_after positionally, which is only correct
+        while apply() appends. If the engine ever reorders or drops rows, this
+        fails here instead of silently mispairing rows in the preview."""
+        dialog = _open(qtbot, _rule(
+            {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
+        ), analysis_df)
+        n = len(dialog.df_before)
+        original = dialog.df_after.iloc[:n]
+        assert list(original["Order_Number"]) == list(dialog.df_before["Order_Number"])
+        assert list(original["SKU"]) == list(dialog.df_before["SKU"])

--- a/tests/test_rule_test_dialog.py
+++ b/tests/test_rule_test_dialog.py
@@ -83,7 +83,7 @@ class TestNoCrashOnShapeChange:
     def test_add_product_with_a_tag_does_not_crash(self, qtbot, analysis_df, no_modals):
         """ADD_PRODUCT appends rows with ignore_index, so a boolean mask built
         on df_before.index no longer aligns with df_after."""
-        dialog = _open(qtbot, _rule(
+        _open(qtbot, _rule(
             {"type": "ADD_PRODUCT", "sku": "B", "quantity": 1},
             {"type": "ADD_TAG", "value": "bonus"},
         ), analysis_df)


### PR DESCRIPTION
Fixes the **Test Rule** dialog crashing with a `KeyError` whenever a rule's actions change the *shape* of the DataFrame — adding columns (COPY_FIELD / CALCULATE targets) or appending rows (ADD_PRODUCT).

Spec: `docs/superpowers/specs/2026-08-13-rule-test-dialog-alignment-design.md`
Plan: `docs/superpowers/plans/2026-08-13-rule-test-dialog-alignment-plan.md`

## The bug

`RuleEngine.apply()` returns a frame that may have more columns and more rows than the one it was given. The dialog diffed before-vs-after as if neither could happen, so:

- a rule-created column `KeyError`ed the moment a populate method reached for it in `df_before`;
- an `ADD_PRODUCT`-only rule reported **0 rows affected** — a working rule silently claiming it did nothing, which is worse than the crash.

## The fix

One `_align_frames()` step between `apply()` and everything that diffs, exposing three attributes the populate methods read:

| | |
|---|---|
| `before_aligned` | `df_before.reindex(columns=df_after.columns)` — rule-created columns read as `NaN`, which is the truth |
| `after_existing` | `df_after.iloc[:n]` — the original rows, sliced **positionally** |
| `added_rows` | `df_after.iloc[n:]` — what the rule appended |

Positional slicing, not label alignment: `apply()` has no `drop`/`sort_values`/`reset_index`/`reindex` anywhere, its `concat` only ever appends, and label alignment is precisely what breaks today. That assumption is a test, not a comment — `test_added_rows_are_appended_not_interleaved` fails loudly if a future engine reorders.

Added rows are now **shown** (green-tinted, with a summary line and legend), not just counted.

`shopify_tool/rules.py` is deliberately untouched. The engine is correct; the dialog was wrong.

## Known ceiling, documented in the code

`_detect_changed_rows` branches: pre-existing columns get an exact string diff, brand-new columns get a "holds a real value" heuristic. That heuristic is inexact at both ends, and the `ponytail:` comment says so — a matched row whose CALCULATE result is legitimately `0`/`NaN` is indistinguishable from `rules.py`'s `df[target] = 0.0` seed, and a brand-new `Internal_Tags` seeded `"[]"` reads as changed for every row. Both are pre-existing behaviour, both are latent in production (`analysis.py` initialises `Internal_Tags` on every real analysis, so it always takes the exact path), and an exact count needs the engine to report which rows it wrote.

## Review

`superpowers:requesting-code-review` verified the root-cause analysis empirically against the real engine and found the `matched_count` (existing changed + added) had leaked into three places that only ever meant existing rows — a blank preview table for `ADD_PRODUCT`-only rules, a summary reading *"4 rows affected (133.3% of 3 total rows)"*, and an overstated log line. Split into `changed_count` / `matched_count`, with two regression tests.

It also found a **separate, pre-existing engine bug this PR does not fix**: `COPY_FIELD` with a numeric source into a new target raises `TypeError: Invalid value for dtype 'str'` at `rules.py:1104-1106` (`df[target] = ""` seeds str dtype, then a numeric assignment fails). The dialog swallows it into the same "Failed to test rule" box — i.e. a second, independent cause of the reported symptom. Filed separately; fixing the engine to cure a display bug was out of scope here.

## Gate

`QT_QPA_PLATFORM=offscreen python -m pytest` → **575 passed** (567 baseline + 8 new)
`ruff check . --exclude shared` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Jz6QX2v6S5pNkhk5xTgy