### PR TITLE
Phase 6 — Rule conditions: validation messages render below the row, not past the delete button

### DIFF
--- a/docs/superpowers/plans/2026-08-14-condition-validation-feedback-layout-plan.md
+++ b/docs/superpowers/plans/2026-08-14-condition-validation-feedback-layout-plan.md
@@ -1,0 +1,498 @@
+# Condition Validation Feedback Layout — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:executing-plans` to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Do not** use `subagent-driven-development` on this repo — the roadmap runner works
+> in-session by design (see `~/automation/claude-roadmap-runner/prompt.md`).
+
+**Goal:** Move a rule condition's validation message out of the horizontal condition row
+— where it lands to the right of the delete button and is unreadable — onto a full-width
+line beneath the row.
+
+**Architecture:** Each condition row's `QWidget` currently hosts the row's
+`QHBoxLayout` directly. Wrap it: the widget gets a `QVBoxLayout` holding the existing
+row layout on top and one long-lived, initially hidden `QLabel` beneath. The label is
+created once with the row instead of being built and destroyed on every value-widget
+swap, and it stops depending on a value widget existing.
+
+**Tech Stack:** PySide6 (Qt Widgets), pytest + pytest-qt (`qtbot`), pandas.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-condition-validation-feedback-layout-design.md`
+
+## Global Constraints
+
+- **Only `gui/settings/rules.py` and `tests/test_rules_page.py` change.** No engine
+  changes, no Rule Test dialog changes, no new files.
+- **Never hand-edit anything under `shared/`** — it is one-way synced from
+  `../packing-tool`.
+- **No hardcoded colours in stylesheets** — use `theme.*` tokens via
+  `get_theme_manager().get_current_theme()`. The one exception is the pre-existing
+  validation-tint literals (`#ffebee`, `#fff3e0`, `#1A1A1A`), which already carry a
+  `ponytail:` comment; carry that comment forward unchanged, do not add new literals.
+- **Two findings are explicitly out of scope** (design doc §5): the dead
+  `"is_empty"` vs `"is empty"` operator branch, and the hardcoded tint colours.
+  Do not fix either in this branch.
+- **Gate before finishing** (both must be clean):
+  ```bash
+  QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+  .venv/bin/ruff check . --exclude shared
+  ```
+  `python` and `ruff` are not on `PATH` on this machine — always go through
+  `.venv/bin/`. Run `./scripts/setup_venv.sh` first in a fresh worktree.
+- **Branch:** `worktree-validation-feedback-layout`. No direct commits to `main`; this
+  repo is PR-only.
+- Run `graphify update .` after the code changes land.
+
+---
+
+### Task 1: The feedback label moves below the condition row
+
+The structural fix. The row's `QWidget` gains a vertical wrapper; the feedback label
+becomes a permanent child of that wrapper, created with the row and reused for its
+lifetime instead of being deleted and rebuilt whenever the value widget is swapped.
+`condition_refs["value_layout"]` is renamed to `row_layout` — the misleading name is
+what caused the bug (design doc §3.3).
+
+**Files:**
+- Modify: `gui/settings/rules.py` — `add_condition_row()` (~677-687),
+  `_on_rule_condition_changed()` (~725-728 and ~800),
+  `_show_validation_feedback()` (~927-935)
+- Test: `tests/test_rules_page.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `condition_refs["row_layout"]` (`QHBoxLayout`, replaces the key
+  `"value_layout"`) and `condition_refs["feedback_label"]` (`QLabel`, always present
+  from row construction onward, never deleted before the row itself). Task 2 relies on
+  `"feedback_label"` being unconditionally present.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_rules_page.py` (the module already imports `pandas as pd`,
+`pytest`, and `RulesPage`, and defines the `analysis_df` fixture):
+
+```python
+class TestValidationFeedbackPlacement:
+    """The message has to land somewhere the user can actually read it."""
+
+    @staticmethod
+    def _rule(field="SKU", operator="matches regex", value="["):
+        return {
+            "name": "r", "level": "article",
+            "steps": [{
+                "conditions": [{"field": field, "operator": operator, "value": value}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+
+    @staticmethod
+    def _condition(page):
+        return page.rule_widgets[0]["steps"][0]["conditions"][0]
+
+    def test_message_sits_below_the_row_not_inside_it(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        cond = self._condition(page)
+
+        page._perform_validation(cond)
+
+        label = cond["feedback_label"]
+        assert label.text() == "Invalid regex syntax"
+        # Not one more cell in the horizontal row, past the delete button.
+        assert cond["row_layout"].indexOf(label) == -1
+        outer = cond["widget"].layout()
+        assert outer.itemAt(0).layout() is cond["row_layout"]
+        assert outer.itemAt(1).widget() is label
+
+    def test_changing_the_operator_drops_a_stale_message(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        cond = self._condition(page)
+        page._perform_validation(cond)
+        assert cond["feedback_label"].text()
+
+        cond["op"].setCurrentText("contains")
+
+        assert cond["feedback_label"].text() == ""
+        assert cond["feedback_label"].isHidden()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest \
+  tests/test_rules_page.py::TestValidationFeedbackPlacement -v
+```
+
+Expected: both FAIL with `KeyError`. The first on `cond["row_layout"]` (the key is still
+called `value_layout`); the second on `cond["feedback_label"]` after the operator
+change, because the current code deletes the label and the dict entry with it.
+
+- [ ] **Step 3: Wrap the row and give it a permanent label**
+
+In `add_condition_row()`, replace:
+
+```python
+        row_widget = QWidget()
+        row_widget.setLayout(row_layout)
+
+        condition_refs = {
+            "widget": row_widget,
+            "field": field_combo,
+            "op": op_combo,
+            "value_widget": None,
+            "value_layout": row_layout,
+            "level_combo": rule_widget_refs.get("level_combo"),
+        }
+```
+
+with:
+
+```python
+        # The row goes inside a vertical wrapper so its validation message can
+        # have a full-width line of its own underneath, instead of being
+        # appended as one more horizontal cell past the delete button. The
+        # wrapper takes over the row's padding -- a nested layout gets none of
+        # its own -- so the row's geometry is unchanged.
+        row_widget = QWidget()
+        outer_layout = QVBoxLayout(row_widget)
+        outer_layout.setSpacing(2)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout.addLayout(row_layout)
+
+        # One feedback label per condition row, alive for the row's whole
+        # lifetime. A hidden label is skipped by the layout, so a row with
+        # nothing to say keeps exactly its old height.
+        feedback_label = QLabel()
+        feedback_label.setWordWrap(True)
+        feedback_label.hide()
+        outer_layout.addWidget(feedback_label)
+
+        condition_refs = {
+            "widget": row_widget,
+            "field": field_combo,
+            "op": op_combo,
+            "value_widget": None,
+            "row_layout": row_layout,
+            "feedback_label": feedback_label,
+            "level_combo": rule_widget_refs.get("level_combo"),
+        }
+```
+
+Notes for the implementer:
+
+- `QVBoxLayout` and `QLabel` are already imported at the top of the file — do not add
+  imports.
+- **Do not set the wrapper's contents margins.** Qt derives a widget-installed layout's
+  margins from the style on install and on reparent, and it does so per widget, not per
+  layout class — so the new `QVBoxLayout` ends up with exactly the 9,9,9,9 the
+  `QHBoxLayout` has today (measured on the real page). Setting them explicitly is what
+  would change the geometry. A layout nested with `addLayout` gets no style margins, so
+  the explicit zero on `row_layout` documents the 0,0,0,0 it already has rather than
+  changing anything.
+- `setSpacing(2)` replaces the dead `margin-top: 2px` from the old label stylesheet
+  (dead because `_show_validation_feedback` overwrote that stylesheet on first show).
+- Do not move `row_layout.addWidget(delete_btn)` or the
+  `_on_rule_condition_changed(...)` call that follow — the value widget is inserted at
+  index 2 and depends on that ordering.
+
+- [ ] **Step 4: Stop deleting the label on every operator change**
+
+In `_on_rule_condition_changed()`, replace:
+
+```python
+        # Clean up validation feedback before removing widget
+        if "feedback_label" in condition_refs:
+            condition_refs["feedback_label"].deleteLater()
+            del condition_refs["feedback_label"]
+```
+
+with:
+
+```python
+        # Drop any message the previous operator left behind. The label belongs
+        # to the row, so it is reused rather than rebuilt.
+        condition_refs["feedback_label"].clear()
+        condition_refs["feedback_label"].hide()
+```
+
+Leave the `validation_timer` block that follows it untouched.
+
+- [ ] **Step 5: Point the value-widget insert at the renamed key**
+
+In `_on_rule_condition_changed()`, change:
+
+```python
+        condition_refs["value_layout"].insertWidget(2, new_widget, 1)
+```
+
+to:
+
+```python
+        condition_refs["row_layout"].insertWidget(2, new_widget, 1)
+```
+
+- [ ] **Step 6: Drop the lazy label construction**
+
+In `_show_validation_feedback()`, replace:
+
+```python
+        # Create feedback label if doesn't exist
+        if "feedback_label" not in condition_refs:
+            feedback_label = QLabel()
+            feedback_label.setWordWrap(True)
+            feedback_label.setStyleSheet(f"{font_css('caption')} margin-top: 2px;")
+            condition_refs["value_layout"].addWidget(feedback_label)
+            condition_refs["feedback_label"] = feedback_label
+
+        feedback_label = condition_refs["feedback_label"]
+```
+
+with:
+
+```python
+        feedback_label = condition_refs["feedback_label"]
+```
+
+Everything else in the function stays as it is for now — including the
+`if not value_widget: return` guard above it, which Task 2 deals with.
+
+- [ ] **Step 7: Confirm the old key is gone and the row's padding is unchanged**
+
+```bash
+rtk grep -rn "value_layout" gui/ tests/
+```
+
+Expected: no matches.
+
+Then confirm the wrapper inherited the padding the row used to carry, so no condition
+row visibly moved:
+
+```bash
+QT_QPA_PLATFORM=offscreen PYTHONPATH=. .venv/bin/python -c "
+import pandas as pd
+from PySide6.QtWidgets import QApplication
+app = QApplication([])
+from gui.settings.rules import RulesPage
+rule = {'name': 'r', 'level': 'article', 'steps': [{'conditions': [{'field': 'SKU', 'operator': 'equals', 'value': 'x'}], 'match': 'ALL', 'actions': [{'type': 'ADD_TAG', 'value': 'T'}]}]}
+page = RulesPage([rule], pd.DataFrame({'SKU': ['x'], 'Quantity': [1]}))
+cond = page.rule_widgets[0]['steps'][0]['conditions'][0]
+m = cond['widget'].layout().contentsMargins()
+print('wrapper margins:', m.left(), m.top(), m.right(), m.bottom())
+"
+```
+
+Expected: `wrapper margins: 9 9 9 9` — the same values the row layout carried before
+this change. Anything else means the margins were set explicitly somewhere; remove that.
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py -v
+```
+
+Expected: the two new tests PASS and every pre-existing test in the file still passes.
+
+- [ ] **Step 9: Commit**
+
+```bash
+rtk git add gui/settings/rules.py tests/test_rules_page.py
+rtk git commit -m "fix(rules): show condition validation messages below the row
+
+The feedback label was appended to the condition row's QHBoxLayout, so it
+rendered to the right of the delete button in whatever width was left.
+Wrap the row in a QVBoxLayout and give it one long-lived label underneath.
+Renames condition_refs[\"value_layout\"] to \"row_layout\" -- the misleading
+name is what put the label there in the first place."
+```
+
+---
+
+### Task 2: Feedback stops depending on a value widget existing
+
+`_show_validation_feedback()` returns early when there is no value widget, which gates
+the *message* on something only the *border* needs. `_check_field_resolvable()` reports
+a field the engine can never evaluate — a statement about the field combo — and a row
+whose operator needs no value input would swallow it silently. Guard only the border.
+
+The three near-identical styling branches collapse into a small lookup table in the
+same edit; that duplication is what let the coupling hide.
+
+**Files:**
+- Modify: `gui/settings/rules.py` — `_show_validation_feedback()` (~912-960)
+- Test: `tests/test_rules_page.py`
+
+**Interfaces:**
+- Consumes: `condition_refs["feedback_label"]` from Task 1 (always present).
+- Produces: no new names. `_show_validation_feedback(condition_refs, status, message)`
+  keeps its signature and its four statuses (`"error"`, `"warning"`, `"success"`,
+  `"clear"`); any other status value is now treated as `"clear"` rather than silently
+  doing nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TestValidationFeedbackPlacement` in `tests/test_rules_page.py`:
+
+```python
+    def test_unresolvable_field_reports_without_a_value_widget(self, qtbot, analysis_df):
+        """The 'never match' message is about the field, not the value box, so a
+        row with no value widget must still show it. No UI path reaches this
+        state today -- the empty-check branch that would create it is dead code
+        (design doc section 5, finding A) -- so the state is set directly here, to keep
+        the guard from being reintroduced when that branch is fixed."""
+        page = RulesPage([self._rule(field="item_count", operator="equals", value="2")], analysis_df)
+        qtbot.addWidget(page)
+        cond = self._condition(page)
+        cond["feedback_label"].clear()
+        cond["feedback_label"].hide()
+        cond["value_widget"] = None
+
+        assert page._check_field_resolvable(cond) is False
+
+        assert "never match" in cond["feedback_label"].text()
+        assert not cond["feedback_label"].isHidden()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest \
+  tests/test_rules_page.py::TestValidationFeedbackPlacement::test_unresolvable_field_reports_without_a_value_widget -v
+```
+
+Expected: FAIL on `assert "never match" in ""` — `_show_validation_feedback` returned
+early, so the label was never given text.
+
+- [ ] **Step 3: Guard only the border**
+
+In `_show_validation_feedback()`, replace the entire body after the docstring:
+
+```python
+        theme = get_theme_manager().get_current_theme()
+
+        value_widget = condition_refs.get("value_widget")
+        if not value_widget:
+            return
+
+        feedback_label = condition_refs["feedback_label"]
+
+        # ponytail: literal validation-tint background colors, not worth new
+        # ThemeTokens fields for ~2 call sites; revisit if more validation
+        # states are added.
+        if status == "error":
+            value_widget.setStyleSheet(f"border: 1px solid {theme.accent_red}; background-color: #ffebee; color: #1A1A1A;")
+            feedback_label.setStyleSheet(f"color: {theme.accent_red}; {font_css('caption')}")
+            feedback_label.setText(f"{message}")
+            feedback_label.show()
+
+        elif status == "warning":
+            value_widget.setStyleSheet(f"border: 1px solid {theme.accent_orange}; background-color: #fff3e0; color: #1A1A1A;")
+            feedback_label.setStyleSheet(f"color: {theme.accent_orange}; {font_css('caption')}")
+            feedback_label.setText(f"{message}")
+            feedback_label.show()
+
+        elif status == "success":
+            value_widget.setStyleSheet(f"border: 1px solid {theme.accent_green};")
+            feedback_label.setStyleSheet(f"color: {theme.accent_green}; {font_css('caption')}")
+            feedback_label.setText(f"{message}")
+            feedback_label.show()
+
+        elif status == "clear":
+            value_widget.setStyleSheet("")
+            feedback_label.hide()
+```
+
+with:
+
+```python
+        theme = get_theme_manager().get_current_theme()
+
+        # ponytail: literal validation-tint background colors, not worth new
+        # ThemeTokens fields for ~2 call sites; revisit if more validation
+        # states are added.
+        border_css = {
+            "error": f"border: 1px solid {theme.accent_red}; background-color: #ffebee; color: #1A1A1A;",
+            "warning": f"border: 1px solid {theme.accent_orange}; background-color: #fff3e0; color: #1A1A1A;",
+            "success": f"border: 1px solid {theme.accent_green};",
+        }
+        text_color = {
+            "error": theme.accent_red,
+            "warning": theme.accent_orange,
+            "success": theme.accent_green,
+        }
+        if status not in text_color:
+            status = "clear"
+
+        # The message describes the condition; only the tinted border needs a
+        # value widget. An operator that takes no value still has something to
+        # say -- most of all that its field will never match.
+        value_widget = condition_refs.get("value_widget")
+        if value_widget is not None:
+            value_widget.setStyleSheet(border_css.get(status, ""))
+
+        feedback_label = condition_refs["feedback_label"]
+        if status == "clear":
+            feedback_label.clear()
+            feedback_label.hide()
+            return
+
+        feedback_label.setStyleSheet(f"color: {text_color[status]}; {font_css('caption')}")
+        feedback_label.setText(message)
+        feedback_label.show()
+```
+
+Note: the docstring above this body still documents the four statuses correctly — leave
+it, but if you touch it, do not claim the message requires a value widget.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rules_page.py -v
+```
+
+Expected: all three new tests PASS, every pre-existing test in the file still passes.
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+```
+
+Expected: the whole suite passes (580 tests passed on `d7059cb`, plus the 3 added here)
+and ruff reports no issues. If a test outside `tests/test_rules_page.py` fails, do not
+paper over it — it means something else reads the renamed key; find it and fix the
+reference.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add gui/settings/rules.py tests/test_rules_page.py
+rtk git commit -m "fix(rules): validation feedback no longer needs a value widget
+
+_show_validation_feedback bailed out when there was no value widget, which
+gated the message on something only the border needs -- so an unresolvable
+field on a value-less condition reported nothing. Guard the border only, and
+collapse the three duplicated styling branches into a lookup table."
+```
+
+- [ ] **Step 7: Refresh the knowledge graph**
+
+```bash
+graphify update .
+```
+
+Commit the result only if it produces a tracked diff.
+
+---
+
+## Verification before calling this done
+
+- [ ] `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest` — full suite green, output
+      pasted into the completion note. No "should pass" claims without the run.
+- [ ] `.venv/bin/ruff check . --exclude shared` — clean.
+- [ ] `rtk grep -rn "value_layout" gui/ tests/` — no matches.
+- [ ] `rtk git diff origin/main --stat` — only `gui/settings/rules.py`,
+      `tests/test_rules_page.py`, and the two docs files. Nothing under `shared/`.
+- [ ] Neither out-of-scope finding from design doc §5 was "helpfully" fixed.

--- a/docs/superpowers/specs/2026-08-14-condition-validation-feedback-layout-design.md
+++ b/docs/superpowers/specs/2026-08-14-condition-validation-feedback-layout-design.md
@@ -1,0 +1,140 @@
+# Condition validation feedback — layout design
+
+**Date:** 2026-08-14
+**Status:** approved for implementation
+**Ticket:** Todoist `6hGfgP9C7355Gm83` — "Fix: rule condition validation feedback is
+unreadable (wrong layout)" (Phase 6, p3)
+**Deferred out of:** PR #275
+
+---
+
+## 1. The report
+
+> "incorrect REGEX doesn't flash"
+
+The user types an invalid regular expression into a rule condition and sees no usable
+error.
+
+## 2. What is actually wrong
+
+The validation *logic* is fine, and was verified headlessly before this design: an
+invalid pattern does set the red border on the `QLineEdit`, does produce the text
+`"Invalid regex syntax"`, and the 500 ms debounce timer does fire.
+
+**The message is placed where nobody can read it.** In `gui/settings/rules.py`,
+`condition_refs["value_layout"]` is the condition row's `QHBoxLayout` — the name says
+"value" but the object is the whole row. `_show_validation_feedback()` calls
+`addWidget(feedback_label)` on it, so the message is appended as the *last horizontal
+cell* of the row, to the right of the "X" delete button, squeezed into whatever width is
+left, word-wrapped (`setWordWrap(True)`) and carrying a `margin-top: 2px` styled for a
+vertical layout it is not in.
+
+Confirmed on the current tip of `main` (`d7059cb`) with a headless probe:
+
+```
+row layout children: ['WheelIgnoreComboBox', 'WheelIgnoreComboBox',
+                      'QLineEdit', 'QPushButton', 'QLabel']
+layout class: QHBoxLayout
+label index in row: 4 of 5
+text: 'Invalid regex syntax'
+```
+
+The label is index 4 — after the delete button. The same probe confirms the
+`_check_field_resolvable()` "this condition will never match" message lands in exactly
+the same dead spot.
+
+## 3. Decision
+
+**Wrap each condition row in a `QVBoxLayout`: the row on top, one feedback label
+beneath it, full width.**
+
+Two supporting decisions fall out of that:
+
+### 3.1 The row owns its feedback label for its whole lifetime
+
+Today the label is created lazily inside `_show_validation_feedback()` and destroyed in
+`_on_rule_condition_changed()` (`deleteLater()` + `del`) every time the value widget is
+swapped. That churn exists only because the label was parented to the value row.
+
+Once the label lives in the outer vertical layout it has no reason to be rebuilt.
+Create it once in `add_condition_row()`, hidden; clear and hide it on an operator change
+instead of deleting it. This removes two blocks of code and replaces "does the label
+exist?" with a flat invariant: **every condition row has exactly one feedback label**.
+
+A hidden `QLabel` is excluded from its layout, so a row with no message keeps its
+current height — no reserved blank line, and the row grows only while a message is up.
+Rows shifting when a message appears is normal form-validation behaviour and is
+preferred here over permanently reserving a line per condition.
+
+### 3.2 Feedback must not depend on a value widget existing
+
+`_show_validation_feedback()` currently opens with:
+
+```python
+value_widget = condition_refs.get("value_widget")
+if not value_widget:
+    return
+```
+
+That guard exists to style the value widget's border, but it gates the *message* too.
+It is a landmine: `_check_field_resolvable()` reports a field the engine can never
+evaluate, which is a statement about the field combo and has nothing to do with the
+value widget. A row with no value widget would silently swallow it.
+
+The guard does not misfire today — see §5 — but the whole point of this change is that
+the message belongs to the row, not to the value widget. Guard only the border styling.
+
+### 3.3 Rename `value_layout` → `row_layout`
+
+The misleading name is the direct cause of the bug: a previous author read
+`value_layout` and reasonably assumed appending to it put the widget under the value
+field. Two call sites after the fix. Rename it.
+
+## 4. Alternatives rejected
+
+| Alternative | Why not |
+|---|---|
+| Show the message as a tooltip on the value widget | The complaint is that the feedback is not noticed. Hiding it behind a hover makes that strictly worse. |
+| One shared message area per rule card | Loses attribution — a rule with four conditions cannot say *which* one is broken. |
+| Leave the label in the row but give it a stretch factor / minimum width | Still competes with three widgets and a button for one line of horizontal space, and long messages ("'item_count' is not available on an article rule…") need a full-width line. |
+| Reserve a permanent blank line under every row | Costs a line of vertical space per condition, forever, to avoid a shift the user only sees while typing an invalid value. |
+
+## 5. Adjacent findings — deliberately out of scope
+
+Both were found while verifying this design. Neither is a regression and neither belongs
+in this change.
+
+**A. The "hide the value widget" branch for empty-checks is dead code.**
+`gui/settings/fields.py` offers the operators `"is empty"` / `"is not empty"` (spaces),
+but `_on_rule_condition_changed()` tests `op in ["is_empty", "is_not_empty"]`
+(underscores), so the branch never runs and an empty-check condition still shows a
+pointless value box. **Not a correctness bug:** `shopify_tool/rules.py` maps
+`"is empty"` → `_op_is_empty`, so saved rules evaluate correctly. It is cosmetic, it
+predates this ticket, and fixing it would widen this diff and its test matrix. Worth its
+own small ticket.
+
+Note the interaction: because that branch is dead, `value_widget` is never `None` in
+practice today, which is why the §3.2 guard has not yet bitten anyone. Whoever fixes
+finding A must not reintroduce the coupling — §3.2 is what makes that fix safe.
+
+**B. Hardcoded validation tint colours.** `_show_validation_feedback()` hardcodes
+`#ffebee` / `#fff3e0` backgrounds and `#1A1A1A` text, against the repo's no-hardcoded-
+colours rule. This is already marked with a `ponytail:` comment explaining the
+trade-off (two call sites, not worth new `ThemeTokens` fields). Left as-is.
+
+## 6. Scope
+
+**In:** `gui/settings/rules.py` — `add_condition_row()`,
+`_on_rule_condition_changed()`, `_show_validation_feedback()`. Tests in
+`tests/test_rules_page.py`.
+
+**Out:** the rule engine, the Rule Test dialog, the two findings in §5, and any change
+to *what* the validators say — only *where* it is shown changes.
+
+## 7. How we will know it worked
+
+- The feedback label is not a child of the condition row's `QHBoxLayout`.
+- It sits below the row in the wrapper's `QVBoxLayout`, at full row width.
+- An unresolvable-field message appears even for a condition with no value widget.
+- Changing the operator drops a stale message from the previous operator.
+- `QT_QPA_PLATFORM=offscreen python -m pytest` and `ruff check . --exclude shared` pass.

--- a/gui/settings/rules.py
+++ b/gui/settings/rules.py
@@ -674,15 +674,32 @@ class RulesPage(SettingsPage):
         op_combo.setCurrentText(config.get("operator", CONDITION_OPERATORS[0]))
         initial_value = config.get("value", "")
 
+        # The row goes inside a vertical wrapper so its validation message can
+        # have a full-width line of its own underneath, instead of being
+        # appended as one more horizontal cell past the delete button. The
+        # wrapper takes over the row's padding -- a nested layout gets none of
+        # its own -- so the row's geometry is unchanged.
         row_widget = QWidget()
-        row_widget.setLayout(row_layout)
+        outer_layout = QVBoxLayout(row_widget)
+        outer_layout.setSpacing(2)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout.addLayout(row_layout)
+
+        # One feedback label per condition row, alive for the row's whole
+        # lifetime. A hidden label is skipped by the layout, so a row with
+        # nothing to say keeps exactly its old height.
+        feedback_label = QLabel()
+        feedback_label.setWordWrap(True)
+        feedback_label.hide()
+        outer_layout.addWidget(feedback_label)
 
         condition_refs = {
             "widget": row_widget,
             "field": field_combo,
             "op": op_combo,
             "value_widget": None,
-            "value_layout": row_layout,
+            "row_layout": row_layout,
+            "feedback_label": feedback_label,
             "level_combo": rule_widget_refs.get("level_combo"),
         }
 
@@ -722,10 +739,10 @@ class RulesPage(SettingsPage):
         field = condition_refs["field"].currentText()
         op = condition_refs["op"].currentText()
 
-        # Clean up validation feedback before removing widget
-        if "feedback_label" in condition_refs:
-            condition_refs["feedback_label"].deleteLater()
-            del condition_refs["feedback_label"]
+        # Drop any message the previous operator left behind. The label belongs
+        # to the row, so it is reused rather than rebuilt.
+        condition_refs["feedback_label"].clear()
+        condition_refs["feedback_label"].hide()
 
         # Cancel pending validation timer
         if "validation_timer" in condition_refs:
@@ -797,7 +814,7 @@ class RulesPage(SettingsPage):
                 new_widget.setText(str(initial_value))
 
         # Insert the new widget into the layout at the correct position
-        condition_refs["value_layout"].insertWidget(2, new_widget, 1)
+        condition_refs["row_layout"].insertWidget(2, new_widget, 1)
         condition_refs["value_widget"] = new_widget
 
         # Connect validation for QLineEdit widgets (QLineEdit is already imported globally)
@@ -920,44 +937,38 @@ class RulesPage(SettingsPage):
         """
         theme = get_theme_manager().get_current_theme()
 
-        value_widget = condition_refs.get("value_widget")
-        if not value_widget:
-            return
-
-        # Create feedback label if doesn't exist
-        if "feedback_label" not in condition_refs:
-            feedback_label = QLabel()
-            feedback_label.setWordWrap(True)
-            feedback_label.setStyleSheet(f"{font_css('caption')} margin-top: 2px;")
-            condition_refs["value_layout"].addWidget(feedback_label)
-            condition_refs["feedback_label"] = feedback_label
-
-        feedback_label = condition_refs["feedback_label"]
-
         # ponytail: literal validation-tint background colors, not worth new
         # ThemeTokens fields for ~2 call sites; revisit if more validation
         # states are added.
-        if status == "error":
-            value_widget.setStyleSheet(f"border: 1px solid {theme.accent_red}; background-color: #ffebee; color: #1A1A1A;")
-            feedback_label.setStyleSheet(f"color: {theme.accent_red}; {font_css('caption')}")
-            feedback_label.setText(f"{message}")
-            feedback_label.show()
+        border_css = {
+            "error": f"border: 1px solid {theme.accent_red}; background-color: #ffebee; color: #1A1A1A;",
+            "warning": f"border: 1px solid {theme.accent_orange}; background-color: #fff3e0; color: #1A1A1A;",
+            "success": f"border: 1px solid {theme.accent_green};",
+        }
+        text_color = {
+            "error": theme.accent_red,
+            "warning": theme.accent_orange,
+            "success": theme.accent_green,
+        }
+        if status not in text_color:
+            status = "clear"
 
-        elif status == "warning":
-            value_widget.setStyleSheet(f"border: 1px solid {theme.accent_orange}; background-color: #fff3e0; color: #1A1A1A;")
-            feedback_label.setStyleSheet(f"color: {theme.accent_orange}; {font_css('caption')}")
-            feedback_label.setText(f"{message}")
-            feedback_label.show()
+        # The message describes the condition; only the tinted border needs a
+        # value widget. An operator that takes no value still has something to
+        # say -- most of all that its field will never match.
+        value_widget = condition_refs.get("value_widget")
+        if value_widget is not None:
+            value_widget.setStyleSheet(border_css.get(status, ""))
 
-        elif status == "success":
-            value_widget.setStyleSheet(f"border: 1px solid {theme.accent_green};")
-            feedback_label.setStyleSheet(f"color: {theme.accent_green}; {font_css('caption')}")
-            feedback_label.setText(f"{message}")
-            feedback_label.show()
-
-        elif status == "clear":
-            value_widget.setStyleSheet("")
+        feedback_label = condition_refs["feedback_label"]
+        if status == "clear":
+            feedback_label.clear()
             feedback_label.hide()
+            return
+
+        feedback_label.setStyleSheet(f"color: {text_color[status]}; {font_css('caption')}")
+        feedback_label.setText(message)
+        feedback_label.show()
 
     def _check_field_resolvable(self, condition_refs):
         """Marks a field the engine will treat as no-match.

--- a/tests/test_rules_page.py
+++ b/tests/test_rules_page.py
@@ -224,4 +224,67 @@ class TestFilterAndReorder:
         )
         qtbot.addWidget(page)
         assert page.rule_widgets[0]["down_btn"].isEnabled() is False
-        assert page.rule_widgets[1]["down_btn"].isEnabled() is False
+
+
+class TestValidationFeedbackPlacement:
+    """The message has to land somewhere the user can actually read it."""
+
+    @staticmethod
+    def _rule(field="SKU", operator="matches regex", value="["):
+        return {
+            "name": "r", "level": "article",
+            "steps": [{
+                "conditions": [{"field": field, "operator": operator, "value": value}],
+                "match": "ALL",
+                "actions": [{"type": "ADD_TAG", "value": "T"}],
+            }],
+        }
+
+    @staticmethod
+    def _condition(page):
+        return page.rule_widgets[0]["steps"][0]["conditions"][0]
+
+    def test_message_sits_below_the_row_not_inside_it(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        cond = self._condition(page)
+
+        page._perform_validation(cond)
+
+        label = cond["feedback_label"]
+        assert label.text() == "Invalid regex syntax"
+        # Not one more cell in the horizontal row, past the delete button.
+        assert cond["row_layout"].indexOf(label) == -1
+        outer = cond["widget"].layout()
+        assert outer.itemAt(0).layout() is cond["row_layout"]
+        assert outer.itemAt(1).widget() is label
+
+    def test_changing_the_operator_drops_a_stale_message(self, qtbot, analysis_df):
+        page = RulesPage([self._rule()], analysis_df)
+        qtbot.addWidget(page)
+        cond = self._condition(page)
+        page._perform_validation(cond)
+        assert cond["feedback_label"].text()
+
+        cond["op"].setCurrentText("contains")
+
+        assert cond["feedback_label"].text() == ""
+        assert cond["feedback_label"].isHidden()
+
+    def test_unresolvable_field_reports_without_a_value_widget(self, qtbot, analysis_df):
+        """The 'never match' message is about the field, not the value box, so a
+        row with no value widget must still show it. No UI path reaches this
+        state today -- the empty-check branch that would create it is dead code
+        (design doc section 5, finding A) -- so the state is set directly here, to keep
+        the guard from being reintroduced when that branch is fixed."""
+        page = RulesPage([self._rule(field="item_count", operator="equals", value="2")], analysis_df)
+        qtbot.addWidget(page)
+        cond = self._condition(page)
+        cond["feedback_label"].clear()
+        cond["feedback_label"].hide()
+        cond["value_widget"] = None
+
+        assert page._check_field_resolvable(cond) is False
+
+        assert "never match" in cond["feedback_label"].text()
+        assert not cond["feedback_label"].isHidden()

--- a/tests/test_rules_page.py
+++ b/tests/test_rules_page.py
@@ -253,6 +253,7 @@ class TestValidationFeedbackPlacement:
 
         label = cond["feedback_label"]
         assert label.text() == "Invalid regex syntax"
+        assert not label.isHidden()
         # Not one more cell in the horizontal row, past the delete button.
         assert cond["row_layout"].indexOf(label) == -1
         outer = cond["widget"].layout()


### PR DESCRIPTION
## Problem

When a rule condition failed validation, the message was appended into the condition's **horizontal** row layout — so it rendered to the *right* of the delete button, squeezed into whatever width was left, and was effectively unreadable. It was also created lazily, only when a value widget existed, so a condition with no value box (the "field will never match at this level" case) showed nothing at all.

## Fix

Each condition row is now a `QVBoxLayout` wrapping the original `QHBoxLayout` plus a permanent `feedback_label` beneath it.

- `condition_refs["value_layout"]` → `condition_refs["row_layout"]` — the old name lied about what the layout was, which is what invited the bug.
- `_show_validation_feedback` no longer early-returns when there's no value widget. Only the border tint needs one; the message itself does not.
- The label is permanent rather than created/destroyed on every operator change, so it's owned by the row widget and dies with it.
- Task 2 rewrote the three styling branches into `border_css`/`text_color` lookup tables.

Wrapper margins are `(9, 9, 9, 9)` — identical to the old row layout, so idle row geometry is unchanged (verified 43px on both base and head).

## Tests

3 new tests in `TestValidationFeedbackPlacement` (`tests/test_rules_page.py`), each a real regression lock — all three fail against the old code:

- message sits below the row, not inside it, and is visible
- changing the operator drops a stale message
- an unresolvable field reports even with no value widget

Gate: **583 passed** (580 baseline + 3), `ruff check . --exclude shared` clean.

## Review notes

Reviewed via `superpowers:requesting-code-review` — verdict "ready to merge", no Critical or Important findings. The one-line visibility assert (`57375f6`) came from that review. Three minor items were flagged and deliberately not chased here:

- `_perform_validation`'s own `if not value_widget: return` guard is the sibling of the one this branch removed. It's latent only — the `is_empty` branch that would reach it is dead code (design doc §5, finding A) — and belongs with that ticket.
- A very long message can clip at minimum window width. The obvious `setHeightForWidth(True)` fix doesn't work, so it isn't a cheap change; the settings window's 1100px minimum keeps realistic messages on one line.
- The border-tint lookup table has no direct test (`error` was verified byte-identical by hand; `warning`/`success` aren't asserted).

Design: `docs/superpowers/specs/2026-08-14-condition-validation-feedback-layout-design.md`
Plan: `docs/superpowers/plans/2026-08-14-condition-validation-feedback-layout-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvvEJ5bm8N4N5CUCe2UZK9