### PR TITLE
Bug fix — Packaging write-off: count each tag once per order, not per line item

### DIFF
--- a/docs/superpowers/plans/2026-08-14-packaging-writeoff-per-order-plan.md
+++ b/docs/superpowers/plans/2026-08-14-packaging-writeoff-per-order-plan.md
@@ -1,0 +1,253 @@
+# Plan — Packaging writeoff: count each tag once per order
+
+Spec: `docs/superpowers/specs/2026-08-14-packaging-writeoff-per-order-design.md`
+Branch: `worktree-packaging-writeoff-per-order`
+Todoist: `6hGq9FRQVpHFxf53`
+
+Three tasks. TDD: the tests land first and **must be observed failing** before the fix.
+
+Every code block below was executed against this branch's `6181bf6` base before being
+written down — but treat it as a verified draft, not gospel. If it does not behave as
+described, the code wins.
+
+---
+
+## Task 1 — Add `tests/test_sku_writeoff.py`, red
+
+The module has no tests today. Create the file with the cases below and **run it, and
+paste the failures into the commit or the Stage B report**. Cases 1 and 2 must fail;
+3-6 must pass on unfixed code (they pin behaviour the fix must not break).
+
+Shared fixture — a *multi-line* order is the point; a one-row-per-order fixture
+reproduces the exact blind spot that let this bug ship.
+
+```python
+import pandas as pd
+import pytest
+
+from shopify_tool.sku_writeoff import calculate_writeoff_quantities
+
+
+def _config(mappings, enabled=True):
+    return {
+        "version": 2,
+        "categories": {
+            "packaging": {
+                "tags": list(mappings),
+                "sku_writeoff": {"enabled": enabled, "mappings": mappings},
+            }
+        },
+    }
+
+
+BOX_ONLY = _config({"BOX": [{"sku": "PKG-BOX", "quantity": 1.0}]})
+```
+
+**Case 1 — the bug.** Order 1001 has three line items, order 1002 has one; both tagged
+`BOX`. Expect `2.0`, unfixed code gives `4.0`.
+
+```python
+def test_tag_counts_once_per_order_not_once_per_line_item():
+    df = pd.DataFrame({
+        "Order_Number": [1001, 1001, 1001, 1002],
+        "SKU": ["A", "B", "C", "A"],
+        "Order_Fulfillment_Status": ["Fulfillable"] * 4,
+        "Internal_Tags": ['["BOX"]'] * 4,
+    })
+    result = calculate_writeoff_quantities(df, BOX_ONLY)
+    row = result[result["SKU"] == "PKG-BOX"].iloc[0]
+    assert row["Writeoff_Quantity"] == 2.0
+    assert row["Order_Count"] == 2
+```
+
+**Case 2 — the dedup key is (order, tag), not (order, SKU).** One order, three lines, two
+distinct tags both mapping to `PKG-SEAL`. Expect `2.0`. Unfixed gives `6.0`; a
+dedupe-on-SKU fix would give `1.0` — this case is what separates the correct fix from
+the plausible wrong one, so **do not drop it**.
+
+```python
+def test_two_tags_mapping_to_same_sku_each_count_once():
+    cfg = _config({
+        "BOX": [{"sku": "PKG-SEAL", "quantity": 1.0}],
+        "BAG": [{"sku": "PKG-SEAL", "quantity": 1.0}],
+    })
+    df = pd.DataFrame({
+        "Order_Number": [1001, 1001, 1001],
+        "Order_Fulfillment_Status": ["Fulfillable"] * 3,
+        "Internal_Tags": ['["BOX", "BAG"]'] * 3,
+    })
+    result = calculate_writeoff_quantities(df, cfg)
+    assert result[result["SKU"] == "PKG-SEAL"].iloc[0]["Writeoff_Quantity"] == 2.0
+```
+
+**Case 3 — non-fulfillable orders are excluded** (passes unfixed; guards a real
+behaviour the spec says not to touch).
+
+```python
+def test_non_fulfillable_orders_are_excluded():
+    df = pd.DataFrame({
+        "Order_Number": [1001, 1002],
+        "Order_Fulfillment_Status": ["Fulfillable", "Not Fulfillable"],
+        "Internal_Tags": ['["BOX"]'] * 2,
+    })
+    result = calculate_writeoff_quantities(df, BOX_ONLY)
+    assert result[result["SKU"] == "PKG-BOX"].iloc[0]["Writeoff_Quantity"] == 1.0
+```
+
+**Case 4 — one tag mapping to several SKUs still applies all of them, once each.**
+
+```python
+def test_multiple_skus_per_tag_all_applied_once():
+    cfg = _config({"BOX": [
+        {"sku": "PKG-BOX", "quantity": 1.0},
+        {"sku": "PKG-TAPE", "quantity": 2.0},
+    ]})
+    df = pd.DataFrame({
+        "Order_Number": [1001, 1001],
+        "Order_Fulfillment_Status": ["Fulfillable"] * 2,
+        "Internal_Tags": ['["BOX"]'] * 2,
+    })
+    result = calculate_writeoff_quantities(df, cfg).set_index("SKU")
+    assert result.loc["PKG-BOX", "Writeoff_Quantity"] == 1.0
+    assert result.loc["PKG-TAPE", "Writeoff_Quantity"] == 2.0
+```
+
+**Case 5 — disabled category writes off nothing.**
+
+```python
+def test_disabled_category_produces_no_writeoff():
+    df = pd.DataFrame({
+        "Order_Number": [1001],
+        "Order_Fulfillment_Status": ["Fulfillable"],
+        "Internal_Tags": ['["BOX"]'],
+    })
+    cfg = _config({"BOX": [{"sku": "PKG-BOX", "quantity": 1.0}]}, enabled=False)
+    assert calculate_writeoff_quantities(df, cfg).empty
+```
+
+**Case 6 — degenerate inputs keep the documented empty shape.** Empty frame, and a frame
+with no `Internal_Tags` column.
+
+```python
+@pytest.mark.parametrize("df", [
+    pd.DataFrame(),
+    pd.DataFrame({"Order_Number": [1], "Order_Fulfillment_Status": ["Fulfillable"]}),
+])
+def test_degenerate_inputs_return_empty_with_correct_columns(df):
+    result = calculate_writeoff_quantities(df, BOX_ONLY)
+    assert result.empty
+    assert list(result.columns) == [
+        "SKU", "Writeoff_Quantity", "Tags_Applied", "Order_Count",
+    ]
+```
+
+---
+
+## Task 2 — Fix `calculate_writeoff_quantities`
+
+`shopify_tool/sku_writeoff.py`. Replace the row loop at **lines 152-180** (from the
+`# Process each row` comment through the `writeoff_accumulator[sku]["orders"].add(...)`
+line). Leave lines 128-150 (guards, mapping extraction, the Fulfillable pre-filter) and
+everything from line 182 (`# Convert to DataFrame`) onward untouched.
+
+The `has_status_col` local becomes unused once the loop is replaced — either keep using it
+or delete it, but do not leave it dangling; `ruff` will flag it.
+
+```python
+    # Internal_Tags is order-level, but rows_df has one row per order LINE
+    # (see tag_manager.expand_to_order_rows). Dedupe (order, tag) so each tag
+    # is counted once per order -- matching how analysis.py builds its tags
+    # breakdown. Accumulating per row multiplies every writeoff by the order's
+    # line count.
+    if "Order_Number" in rows_df.columns:
+        order_col = rows_df["Order_Number"].astype(str)
+    else:
+        logger.warning(
+            "Order_Number column missing - writeoff cannot deduplicate per order; "
+            "quantities will be counted per row"
+        )
+        order_col = pd.Series(
+            [f"row_{i}" for i in rows_df.index], index=rows_df.index
+        )
+
+    order_tags = (
+        pd.DataFrame({
+            "order": order_col,
+            "tag": rows_df["Internal_Tags"].fillna("[]").apply(parse_tags),
+        })
+        .explode("tag")
+        .dropna(subset=["tag"])
+        .drop_duplicates()
+    )
+
+    for pair in order_tags.itertuples(index=False):
+        if pair.tag not in writeoff_mappings:
+            continue
+
+        for mapping in writeoff_mappings[pair.tag]:
+            sku = mapping["sku"]
+
+            if sku not in writeoff_accumulator:
+                writeoff_accumulator[sku] = {
+                    "quantity": 0.0,
+                    "tags": set(),
+                    "orders": set(),
+                }
+
+            writeoff_accumulator[sku]["quantity"] += mapping["quantity"]
+            writeoff_accumulator[sku]["tags"].add(pair.tag)
+            writeoff_accumulator[sku]["orders"].add(pair.order)
+```
+
+### Verified behaviour of that snippet (measured on this base)
+
+| input | result |
+|---|---|
+| 2 orders (3 lines + 1 line), both `["BOX"]` | `1001/BOX`, `1002/BOX` — 2 pairs |
+| same rows, `["BOX","BAG"]` | 4 pairs — each order × each tag |
+| empty frame | 0 rows, columns `['order','tag']` intact |
+| no `Order_Number` column | falls back to `row_0..row_3`, warning logged |
+| `'[]'`, `None`, `'["BOX"]'`, `'[""]'` | only `BOX` and an **empty-string tag** survive |
+
+**On that empty-string tag:** `analysis.py` filters it out explicitly; here it needs no
+filter, because `if pair.tag not in writeoff_mappings: continue` already discards it. Do
+not add a length filter for symmetry — it is dead code. (Noted so review does not raise
+it as a finding.)
+
+**On the duplicated index:** `.explode()` repeats index labels (`0, 0, 3, 3`).
+`itertuples(index=False)` never reads the index, so this is fine — do not "fix" it with a
+`reset_index()`.
+
+**On `astype(str)`:** matches the old code's `str(order_number)`, so `Order_Count` keeps
+its exact current semantics. A NaN order number becomes `"nan"` — pre-existing behaviour,
+not a regression, out of scope.
+
+---
+
+## Task 3 — Green, then the full gate
+
+1. Re-run `tests/test_sku_writeoff.py`; all six cases pass.
+2. Full gate, from the worktree root:
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+```
+
+`main` was **634 passed** at `6181bf6`; expect 634 + the new cases, with **no test newly
+failing**. If any existing test breaks, stop — it means something depended on the inflated
+quantities, which the spec did not predict and which changes the story.
+
+3. `graphify update .` in the worktree.
+
+Commit spec, plan, test and fix together.
+
+---
+
+## Definition of done
+
+- [ ] Cases 1 and 2 observed failing before the fix, and reported as such.
+- [ ] All six pass after.
+- [ ] Full suite green, no pre-existing test regressed.
+- [ ] `ruff` clean (watch the `has_status_col` local).
+- [ ] Spec's ERP-reconciliation note carried into the PR body — the user must see it.

--- a/docs/superpowers/specs/2026-08-14-packaging-writeoff-per-order-design.md
+++ b/docs/superpowers/specs/2026-08-14-packaging-writeoff-per-order-design.md
@@ -1,0 +1,134 @@
+# Packaging writeoff: count each tag once per order, not once per line item
+
+Date: 2026-08-14
+Todoist: `6hGq9FRQVpHFxf53` (p2) — "Bug: Packaging categories do write off from all
+Internal Tags. It supposed to count only each unique tag from fulfillable order to
+formulate a writeoff."
+Milestone: `6hGqQ9fCPjM6qWjV` (p1) — "Revision, bug fixes, preparing for stable".
+
+## The bug, in one sentence
+
+`calculate_writeoff_quantities()` accumulates a tag's packaging quantity **once per
+DataFrame row**, but `Internal_Tags` is an *order-level* field replicated across every
+line of the order — so an order with three SKU lines writes off three boxes.
+
+## Evidence (measured, not read)
+
+Probe against `shopify_tool/sku_writeoff.py` at `6181bf6`, two fulfillable orders — order
+1001 with three line items, order 1002 with one, both tagged `BOX`, mapping
+`BOX → PKG-BOX ×1.0`:
+
+```
+       SKU  Writeoff_Quantity Tags_Applied  Order_Count
+0  PKG-BOX                4.0        [BOX]            2
+```
+
+**4.0 boxes for 2 orders.** Expected 2.0.
+
+Note `Order_Count` is already correct — it accumulates into a `set`. So the existing
+report is *internally self-contradictory*: it states two orders and four boxes on the
+same row. That inconsistency is the visible symptom the bug report describes.
+
+Second probe — one order (three lines) carrying two tags that both map to the same SKU
+(`BOX → PKG-SEAL ×1`, `BAG → PKG-SEAL ×1`):
+
+```
+        SKU  Writeoff_Quantity Tags_Applied  Order_Count
+0  PKG-SEAL                6.0   [BAG, BOX]            1
+```
+
+**6.0 for one order.** Expected 2.0 — two distinct tags applied once each. This case
+pins the dedup key: it must be **(order, tag)**, not (order, SKU). Deduping on SKU would
+give 1.0 here and be a *different* wrong answer.
+
+## Root cause
+
+`shopify_tool/sku_writeoff.py:153-180`. The loop is `for idx, row in rows_df.iterrows()`
+over a **line-item-level** DataFrame. `writeoff_accumulator[sku]["orders"]` is a set (so
+`Order_Count` self-corrects) but `["quantity"] += quantity` runs unconditionally on every
+row.
+
+That `Internal_Tags` is order-level is not an inference — it is documented in this repo,
+in `shopify_tool/tag_manager.py:132`:
+
+> `Internal_Tags` is order-level, not line-level, but `df` has one row per order line
+
+And `shopify_tool/analysis.py:1606-1637` already implements the correct reading for the
+stats panel, commented "counted per unique order", via parse → explode → `drop_duplicates`
+→ `value_counts`. **The writeoff module is the only consumer that gets this wrong.**
+
+## Blast radius — one function, three callers, no sibling bugs
+
+Every caller passes a line-item DataFrame, so all three are affected and all three are
+fixed by the single change:
+
+| caller | passes |
+|---|---|
+| `shopify_tool/stock_export.py:249` | `filtered_items` (line items, pre-filtered to Fulfillable) |
+| `shopify_tool/core.py:1555` | full `analysis_df` |
+| `gui/actions_handler.py:936` | `self.mw.analysis_results_df` |
+
+`grep parse_tags` across `shopify_tool/` and `gui/` returns exactly one other accumulating
+consumer — `analysis.py`, which already dedups. The rest (`tag_delegate.py`,
+`tag_management_panel.py`, `ui_manager.py`, `actions_handler.py:1718`) are display or edit
+paths where per-row parsing is correct. **No second instance of this bug exists.** One
+guard in the shared function is the root-cause fix.
+
+## The fix
+
+Deduplicate `(Order_Number, tag)` pairs before accumulating quantity. Reuse the
+established `analysis.py` idiom (parse → explode → `drop_duplicates`) rather than
+inventing a second one, so the two modules that must agree on "per unique order" stay
+visibly written the same way.
+
+`Tags_Applied` and `Order_Count` keep their current semantics — they are already correct
+and must not regress.
+
+## Fulfillable filtering — already correct, leave alone
+
+`sku_writeoff.py:146-150` pre-filters to `Order_Fulfillment_Status == "Fulfillable"` when
+the column is present. The bug report's phrase "from fulfillable order" is already
+satisfied; this is not part of the defect. Do not touch it — but do keep the behaviour
+under test so the fix cannot silently drop it.
+
+## Decisions taken without asking (reversible, noted for the record)
+
+- **Missing `Order_Number` column.** The existing fallback synthesizes `f"row_{idx}"` per
+  row, which post-fix means no deduplication happens at all. Kept as-is — it is the only
+  defensible reading when order identity is unavailable — but it now logs a warning, since
+  silently returning line-multiplied quantities is what caused this bug in the first place.
+- **No quantity scaling with order size.** One application per (order, tag), flat. The bug
+  report specifies "each unique tag from fulfillable order"; a large order needing two
+  boxes is a mapping-configuration concern, not this fix.
+- **No config-format or mapping-schema change.** `_extract_writeoff_mappings()` is not
+  touched.
+
+## Non-goals
+
+- Redesigning the writeoff UI or the mapping editor.
+- The Packing list & Stock Export settings redesign (Todoist `6h8v4VxRHVq7MrGV`) — separate
+  queued task.
+- Reconciling stock exports **already sent to the ERP**. See below.
+
+## Operational note for the release note — read this
+
+This bug has been over-writing off packaging materials in production for as long as the
+feature has shipped, by a factor equal to the average line-item count per order. ERP stock
+levels for packaging SKUs are therefore **understated**, and no code change corrects data
+already exported. Someone should decide whether a one-off reconciliation is warranted; the
+per-SKU inflation factor is recoverable from any past session's analysis file by comparing
+`Order_Count` against `Writeoff_Quantity` in the writeoff report, which is exactly the
+self-contradiction described above.
+
+Flagging, not fixing — a data-correction pass is the user's call, not this PR's.
+
+## Test coverage gap (the reason this survived)
+
+`shopify_tool/sku_writeoff.py` is 518 lines of stock-deduction arithmetic with **zero
+tests** — `tests/` contains no `test_sku_writeoff.py` and no test references the module.
+The module's own docstring examples encode the bug: every example uses a
+one-row-per-order DataFrame, the single shape where per-row and per-order accumulation
+agree. That is why reading the file does not reveal the defect and the probe does.
+
+This PR adds the missing test file. Its first case must use a **multi-line order**, or it
+reproduces the blind spot it exists to close.

--- a/shopify_tool/sku_writeoff.py
+++ b/shopify_tool/sku_writeoff.py
@@ -58,10 +58,18 @@ def calculate_writeoff_quantities(
     configured writeoff mappings for each tag, and accumulates SKU quantities
     that should be written off based on the tag applications.
 
-    The function processes each row in the DataFrame, extracts the tags, and
-    for each tag that has a writeoff mapping configured, adds the corresponding
-    SKU quantities to the accumulator. If multiple orders have the same tag,
-    the quantities are summed together.
+    Two contracts govern the count, and both matter:
+
+    1. **Each (order, tag) pair is applied exactly once.** Internal_Tags is an
+       order-level value that tag_manager.expand_to_order_rows replicates onto
+       every line of the order, so the frame has one row per order LINE.
+       Accumulating per row multiplies every writeoff by the order's line count.
+       The key is (order, tag), not (order, SKU) -- two different tags mapping
+       to the same SKU must each contribute.
+    2. **Only Fulfillable rows count** when Order_Fulfillment_Status is present.
+       When the column is absent, every row is considered.
+
+    If multiple orders carry the same tag, their quantities are summed.
 
     Args:
         analysis_df: Analysis DataFrame with Internal_Tags column.
@@ -120,7 +128,9 @@ def calculate_writeoff_quantities(
         - Disabled categories (enabled=False) are skipped
         - Quantity accumulation handles floats for partial units
         - If Internal_Tags column is missing, logs warning and returns empty
-        - Order numbers are tracked to count unique orders (uses row index if missing)
+        - Order numbers are tracked to count unique orders. If Order_Number is
+          missing, per-order dedup is impossible and each row counts separately
+          (logged as a warning) -- the pre-fix behaviour, kept as the fallback.
 
     Raises:
         Does not raise exceptions - logs warnings for invalid data and continues processing
@@ -208,7 +218,10 @@ def calculate_writeoff_quantities(
         })
 
     result_df = pd.DataFrame(rows)
-    logger.info(f"Calculated writeoffs for {len(result_df)} SKUs from {len(analysis_df)} orders")
+    logger.info(
+        f"Calculated writeoffs for {len(result_df)} SKUs "
+        f"from {order_tags['order'].nunique()} orders"
+    )
 
     return result_df
 

--- a/shopify_tool/sku_writeoff.py
+++ b/shopify_tool/sku_writeoff.py
@@ -149,35 +149,49 @@ def calculate_writeoff_quantities(
     else:
         rows_df = analysis_df
 
-    # Process each row
-    for idx, row in rows_df.iterrows():
-        tags = parse_tags(row.get("Internal_Tags"))
+    # Internal_Tags is order-level, but rows_df has one row per order LINE
+    # (see tag_manager.expand_to_order_rows). Dedupe (order, tag) so each tag
+    # is counted once per order -- matching how analysis.py builds its tags
+    # breakdown. Accumulating per row multiplies every writeoff by the order's
+    # line count.
+    if "Order_Number" in rows_df.columns:
+        order_col = rows_df["Order_Number"].astype(str)
+    else:
+        logger.warning(
+            "Order_Number column missing - writeoff cannot deduplicate per order; "
+            "quantities will be counted per row"
+        )
+        order_col = pd.Series(
+            [f"row_{i}" for i in rows_df.index], index=rows_df.index
+        )
 
-        # Get order number (use row index if Order_Number not present)
-        if "Order_Number" in analysis_df.columns:
-            order_number = row.get("Order_Number", f"row_{idx}")
-        else:
-            order_number = f"row_{idx}"
+    order_tags = (
+        pd.DataFrame({
+            "order": order_col,
+            "tag": rows_df["Internal_Tags"].fillna("[]").apply(parse_tags),
+        })
+        .explode("tag")
+        .dropna(subset=["tag"])
+        .drop_duplicates()
+    )
 
-        for tag in tags:
-            if tag not in writeoff_mappings:
-                continue
+    for pair in order_tags.itertuples(index=False):
+        if pair.tag not in writeoff_mappings:
+            continue
 
-            # Apply mappings for this tag
-            for mapping in writeoff_mappings[tag]:
-                sku = mapping["sku"]
-                quantity = mapping["quantity"]
+        for mapping in writeoff_mappings[pair.tag]:
+            sku = mapping["sku"]
 
-                if sku not in writeoff_accumulator:
-                    writeoff_accumulator[sku] = {
-                        "quantity": 0.0,
-                        "tags": set(),
-                        "orders": set()
-                    }
+            if sku not in writeoff_accumulator:
+                writeoff_accumulator[sku] = {
+                    "quantity": 0.0,
+                    "tags": set(),
+                    "orders": set(),
+                }
 
-                writeoff_accumulator[sku]["quantity"] += quantity
-                writeoff_accumulator[sku]["tags"].add(tag)
-                writeoff_accumulator[sku]["orders"].add(str(order_number))
+            writeoff_accumulator[sku]["quantity"] += mapping["quantity"]
+            writeoff_accumulator[sku]["tags"].add(pair.tag)
+            writeoff_accumulator[sku]["orders"].add(pair.order)
 
     # Convert to DataFrame
     if not writeoff_accumulator:

--- a/tests/test_sku_writeoff.py
+++ b/tests/test_sku_writeoff.py
@@ -20,16 +20,30 @@ BOX_ONLY = _config({"BOX": [{"sku": "PKG-BOX", "quantity": 1.0}]})
 
 
 def test_tag_counts_once_per_order_not_once_per_line_item():
+    # Last three rows are the untagged shapes that reach explode(): NaN, an
+    # empty array, and an array holding an empty string. None may contribute.
     df = pd.DataFrame({
-        "Order_Number": [1001, 1001, 1001, 1002],
-        "SKU": ["A", "B", "C", "A"],
-        "Order_Fulfillment_Status": ["Fulfillable"] * 4,
-        "Internal_Tags": ['["BOX"]'] * 4,
+        "Order_Number": [1001, 1001, 1001, 1002, 1003, 1004, 1005],
+        "SKU": ["A", "B", "C", "A", "A", "A", "A"],
+        "Order_Fulfillment_Status": ["Fulfillable"] * 7,
+        "Internal_Tags": ['["BOX"]'] * 4 + [None, "[]", '[""]'],
     })
     result = calculate_writeoff_quantities(df, BOX_ONLY)
     row = result[result["SKU"] == "PKG-BOX"].iloc[0]
     assert row["Writeoff_Quantity"] == 2.0
     assert row["Order_Count"] == 2
+    assert row["Tags_Applied"] == ["BOX"]
+
+
+def test_missing_order_number_falls_back_to_per_row_counting():
+    # No Order_Number means per-order dedup is impossible; each row counts
+    # separately (the pre-fix behaviour), and the caller is warned.
+    df = pd.DataFrame({
+        "Order_Fulfillment_Status": ["Fulfillable"] * 3,
+        "Internal_Tags": ['["BOX"]'] * 3,
+    })
+    result = calculate_writeoff_quantities(df, BOX_ONLY)
+    assert result[result["SKU"] == "PKG-BOX"].iloc[0]["Writeoff_Quantity"] == 3.0
 
 
 def test_two_tags_mapping_to_same_sku_each_count_once():

--- a/tests/test_sku_writeoff.py
+++ b/tests/test_sku_writeoff.py
@@ -1,0 +1,93 @@
+import pandas as pd
+import pytest
+
+from shopify_tool.sku_writeoff import calculate_writeoff_quantities
+
+
+def _config(mappings, enabled=True):
+    return {
+        "version": 2,
+        "categories": {
+            "packaging": {
+                "tags": list(mappings),
+                "sku_writeoff": {"enabled": enabled, "mappings": mappings},
+            }
+        },
+    }
+
+
+BOX_ONLY = _config({"BOX": [{"sku": "PKG-BOX", "quantity": 1.0}]})
+
+
+def test_tag_counts_once_per_order_not_once_per_line_item():
+    df = pd.DataFrame({
+        "Order_Number": [1001, 1001, 1001, 1002],
+        "SKU": ["A", "B", "C", "A"],
+        "Order_Fulfillment_Status": ["Fulfillable"] * 4,
+        "Internal_Tags": ['["BOX"]'] * 4,
+    })
+    result = calculate_writeoff_quantities(df, BOX_ONLY)
+    row = result[result["SKU"] == "PKG-BOX"].iloc[0]
+    assert row["Writeoff_Quantity"] == 2.0
+    assert row["Order_Count"] == 2
+
+
+def test_two_tags_mapping_to_same_sku_each_count_once():
+    cfg = _config({
+        "BOX": [{"sku": "PKG-SEAL", "quantity": 1.0}],
+        "BAG": [{"sku": "PKG-SEAL", "quantity": 1.0}],
+    })
+    df = pd.DataFrame({
+        "Order_Number": [1001, 1001, 1001],
+        "Order_Fulfillment_Status": ["Fulfillable"] * 3,
+        "Internal_Tags": ['["BOX", "BAG"]'] * 3,
+    })
+    result = calculate_writeoff_quantities(df, cfg)
+    assert result[result["SKU"] == "PKG-SEAL"].iloc[0]["Writeoff_Quantity"] == 2.0
+
+
+def test_non_fulfillable_orders_are_excluded():
+    df = pd.DataFrame({
+        "Order_Number": [1001, 1002],
+        "Order_Fulfillment_Status": ["Fulfillable", "Not Fulfillable"],
+        "Internal_Tags": ['["BOX"]'] * 2,
+    })
+    result = calculate_writeoff_quantities(df, BOX_ONLY)
+    assert result[result["SKU"] == "PKG-BOX"].iloc[0]["Writeoff_Quantity"] == 1.0
+
+
+def test_multiple_skus_per_tag_all_applied_once():
+    cfg = _config({"BOX": [
+        {"sku": "PKG-BOX", "quantity": 1.0},
+        {"sku": "PKG-TAPE", "quantity": 2.0},
+    ]})
+    df = pd.DataFrame({
+        "Order_Number": [1001, 1001],
+        "Order_Fulfillment_Status": ["Fulfillable"] * 2,
+        "Internal_Tags": ['["BOX"]'] * 2,
+    })
+    result = calculate_writeoff_quantities(df, cfg).set_index("SKU")
+    assert result.loc["PKG-BOX", "Writeoff_Quantity"] == 1.0
+    assert result.loc["PKG-TAPE", "Writeoff_Quantity"] == 2.0
+
+
+def test_disabled_category_produces_no_writeoff():
+    df = pd.DataFrame({
+        "Order_Number": [1001],
+        "Order_Fulfillment_Status": ["Fulfillable"],
+        "Internal_Tags": ['["BOX"]'],
+    })
+    cfg = _config({"BOX": [{"sku": "PKG-BOX", "quantity": 1.0}]}, enabled=False)
+    assert calculate_writeoff_quantities(df, cfg).empty
+
+
+@pytest.mark.parametrize("df", [
+    pd.DataFrame(),
+    pd.DataFrame({"Order_Number": [1], "Order_Fulfillment_Status": ["Fulfillable"]}),
+])
+def test_degenerate_inputs_return_empty_with_correct_columns(df):
+    result = calculate_writeoff_quantities(df, BOX_ONLY)
+    assert result.empty
+    assert list(result.columns) == [
+        "SKU", "Writeoff_Quantity", "Tags_Applied", "Order_Count",
+    ]


### PR DESCRIPTION
Fixes the packaging write-off counting each Internal Tag once per **line item** instead of once per **order**.

## The bug

`tag_manager.expand_to_order_rows()` deliberately replicates an order-level tag onto every line of that order — tag display, rule matching and the stats breakdown all depend on it. `calculate_writeoff_quantities()` read that frame row by row, so it treated each line's copy of the same tag as a separate application. Every write-off was multiplied by the order's line count.

The fix is entirely on the reading side: dedupe `(order, tag)` via `explode()` + `drop_duplicates()` before applying the mappings, matching the idiom `analysis.py` already uses for its tags breakdown. Nothing about how tags are stored or replicated changes.

The dedup key is `(order, tag)`, **not** `(order, SKU)` — two different tags mapping to the same SKU must each contribute. `test_two_tags_mapping_to_same_sku_each_count_once` pins that distinction; a dedupe-on-SKU fix would pass the headline test and fail this one.

## ⚠️ Two things that change what the ERP receives

**1. Packaging stock has been over-written-off for as long as this feature has shipped**, by roughly the average line-item count per order — worse for orders carrying two tags that map to the same SKU. This PR stops new over-write-offs. **It does not correct data already exported.** Whether a reconciliation pass against the ERP is worth running is your call; it was deliberately not attempted here.

**2. Fractional quantities now truncate to zero in a way they previously didn't** (pre-existing, surfaced by this fix, *not* changed in this PR). `stock_export.py:262` and `sku_writeoff.py:407` both do `.astype(int)` — truncation, not rounding. The mapping UI is a `QDoubleSpinBox` with min `0.01`, so fractional per-order quantities are a supported configuration. Line-count inflation used to mask this (0.5/order × 3 lines = 1.5 → 1); now a single-order session with a 0.5 mapping exports **0**. Quantities across the board just dropped by the average line-count factor, so this went from a rounding annoyance to a "packaging SKU silently missing from the export" case. `.round().astype(int)` is the whole fix if you want it — say so and it gets its own PR.

## Changes

- `shopify_tool/sku_writeoff.py` — the dedup, plus a docstring rewrite. The old docstring still described the per-row accumulation ("processes each row … adds the corresponding SKU quantities to the accumulator"); that sentence is what made the defect invisible on reading, so it now states the two contracts instead: one application per `(order, tag)`, and Fulfillable-only when the status column is present.
- `tests/test_sku_writeoff.py` — **new file, 8 cases.** 518 lines of stock arithmetic were previously untested. Covers the per-order dedup, the `(order, tag)` vs `(order, SKU)` key, the Fulfillable pre-filter, multi-SKU tags, disabled categories, the missing-`Order_Number` fallback, the untagged shapes that reach `explode()` (`NaN` / `[]` / `[""]`), and degenerate inputs.
- Spec and plan under `docs/superpowers/`.

## Verification

`QT_QPA_PLATFORM=offscreen python -m pytest` → **642 passed** (634 pre-existing + 8 new), no regressions. `ruff check . --exclude shared` clean. Reviewed by a fresh-context reviewer, which additionally confirmed all three callers (`stock_export.py:249`, `core.py:1555`, `gui/actions_handler.py:936`) are fixed by this one change and that no sibling function shares the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMCCaXGKdHU2Hj4WFmLWRW
