### PR TITLE
Bug fix — ERP export: round fractional write-off quantities half-up instead of truncating to zero

### DIFF
--- a/docs/superpowers/plans/2026-08-14-erp-quantity-rounding-plan.md
+++ b/docs/superpowers/plans/2026-08-14-erp-quantity-rounding-plan.md
@@ -1,0 +1,450 @@
+# ERP Export Quantity Rounding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement
+> this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> (This plan's runner declines `subagent-driven-development` — stay in-session.)
+
+**Goal:** Stop the ERP stock export from truncating fractional quantities to zero, by rounding
+half-up at the single point every export path already funnels through.
+
+**Architecture:** All five export builders end at `_finalize_export_df()` in
+`shopify_tool/stock_export.py` — including the catch-all guard at `stock_export.py:275` that
+exists precisely to catch paths which skipped it. Put the quantity coercion there and the four
+scattered `.astype(int)` casts become deletable. Net negative diff, and the bug class dies on
+paths nobody reported.
+
+**Tech Stack:** pandas, pytest, xlwt (`.xls` writer).
+
+**Spec:** None — this is a bounded bug fix. The problem statement, the rejected alternatives,
+and the rounding-direction decision are recorded in the "Background" section below, which is
+the whole of what a spec would have carried.
+
+## Global Constraints
+
+- Python, PySide6 desktop app; Windows-only in production, developed on Linux.
+- Gate before finishing: `QT_QPA_PLATFORM=offscreen python -m pytest` and
+  `ruff check . --exclude shared` (use `.venv/bin/python`; bare `python` is not on PATH).
+- Never hand-edit anything under `shared/` — it is synced from `../packing-tool`.
+- The ERP column layout `["Артикул", "", "Мярка", "Брой", "Годност", "Партида"]` is positional
+  and MUST NOT be reordered or renamed.
+- `_finalize_export_df()` must stay idempotent — `create_stock_export()` calls it twice on some
+  paths.
+
+---
+
+## Background
+
+### The bug
+
+`Брой` (quantity) is measured in `Мярка = "брой"` — pieces. The ERP cannot represent a
+fraction, so the export has to convert to `int`. Four sites do that with `.astype(int)`, which
+**truncates**:
+
+| source | `.astype(int)` | correct |
+|---|---|---|
+| 0.5 (one order, 0.5/order mapping) | **0 — material vanishes** | 1 |
+| 1.5 (three orders, 0.5/order) | 1 | 2 |
+| 2.5 | 2 | 3 |
+
+Write-off quantities are genuinely fractional: the mapping UI is a `QDoubleSpinBox` with
+`setMinimum(0.01)` and `setDecimals(2)` (`gui/tag_categories_dialog.py:590-594`), because a
+per-order rate like 0.05 ("one roll of tape per 20 orders") is a sensible way to configure
+packaging. `calculate_writeoff_quantities()` returns `round(quantity, 2)` — a float, by design
+(`shopify_tool/sku_writeoff.py:191`).
+
+This was pre-existing, but PR #281 is what makes it bite. Before #281 the quantity was
+inflated by the line-item count per order, which masked the truncation. Now a single-order
+session with a 0.5/order mapping exports `0`.
+
+### Rounding direction: half-up, and NOT `Series.round()`
+
+**`.round()` is wrong here.** numpy rounds half to **even**, so it leaves the headline case
+broken. Verified in this repo's venv:
+
+```
+raw          [0.5, 1.5, 2.5, 0.4, 0.15, 3.0]
+astype(int)  [0,   1,   2,   0,   0,    3]     <- today: truncates
+.round()     [0,   2,   2,   0,   0,    3]     <- 0.5 still 0, 2.5 still 2
+floor(x+0.5) [1,   2,   3,   0,   0,    3]     <- half-up: correct
+```
+
+Any implementation that reaches for `.round()` reintroduces the bug it was meant to fix.
+
+**Rejected: `ceil`.** Never under-writes-off, but a 0.05/order tape mapping on a one-order
+session would write off a whole roll. Too aggressive.
+
+**Rejected: carrying the remainder across sessions.** Correct accounting, but needs persistent
+per-client per-SKU state. Out of proportion to the bug. Half-up is unbiased on average; the
+residual is under one piece per SKU per session.
+
+### Rows that round to zero are dropped, and logged
+
+A quantity below 0.5 still rounds to 0 (0.05/order × 3 orders = 0.15). Writing `Брой = 0` to
+the ERP is a meaningless row, so those rows are dropped — but with a `logger.warning` naming
+the SKU. A packaging material disappearing from an export with **no trace** is exactly the
+failure mode this milestone is hunting; the log is the load-bearing half of this decision.
+
+### Open question left for the user (does not block this plan)
+
+Half-up rounding is chosen from repo evidence — `Мярка = "брой"` means the ERP column is
+pieces, so integers are right. If the warehouse ERP in fact accepts decimal quantities, the
+better fix is to drop the int conversion entirely rather than round. Flag this in the PR body;
+do not attempt it.
+
+Historical over-write-off correction remains out of scope (already raised in PR #281's body).
+
+---
+
+## File Structure
+
+| file | responsibility | change |
+|---|---|---|
+| `shopify_tool/stock_export.py` | canonical ERP frame layout + export builders | add `_to_erp_quantity()`; call it in `_finalize_export_df()`; delete 3 `.astype(int)` |
+| `shopify_tool/sku_writeoff.py` | write-off calculation + write-off report | delete 1 `.astype(int)` |
+| `tests/test_stock_export.py` | export accuracy tests | add `TestQuantityRounding` |
+
+---
+
+### Task 1: Half-up quantity coercion in `_finalize_export_df`
+
+**Files:**
+- Modify: `shopify_tool/stock_export.py:25-42` (`_finalize_export_df`)
+- Test: `tests/test_stock_export.py`
+
+**Interfaces:**
+- Produces: `_to_erp_quantity(values: pd.Series) -> pd.Series` — module-private in
+  `shopify_tool.stock_export`. Returns an `int` Series, half-up rounded, non-negative.
+  Task 2 relies on `_finalize_export_df()` applying it to `QTY_COL` on every path.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the existing import at the top of `tests/test_stock_export.py` (line 9) to read:
+
+```python
+from shopify_tool.stock_export import (
+    _finalize_export_df,
+    _to_erp_quantity,
+    create_stock_export,
+    merge_session_stock_exports,
+)
+```
+
+Then append the class at the end of the file. `_analysis_df` and `_read` are the existing
+module-level helpers; `COL_SKU` / `COL_QTY` are the existing column-index constants.
+
+Verified already: `_empty_export_df()` is object-dtype, and `pd.to_numeric(...)` handles it
+without error; `ShopifyToolLogger` has `propagate=True`, so `caplog` captures its records.
+
+```python
+class TestQuantityRounding:
+    def test_rounds_half_up_not_half_to_even(self):
+        # pandas/numpy .round() is banker's rounding: 0.5 -> 0 and 2.5 -> 2, which
+        # leaves the exact bug this helper exists to fix. Half-up is required.
+        result = _to_erp_quantity(pd.Series([0.5, 1.5, 2.5, 3.5]))
+        assert list(result) == [1, 2, 3, 4]
+
+    def test_rounds_down_below_the_half(self):
+        result = _to_erp_quantity(pd.Series([0.4, 0.49, 1.2, 2.499]))
+        assert list(result) == [0, 0, 1, 2]
+
+    def test_whole_numbers_are_unchanged(self):
+        result = _to_erp_quantity(pd.Series([0.0, 1.0, 7.0, 100.0]))
+        assert list(result) == [0, 1, 7, 100]
+
+    def test_non_numeric_and_missing_become_zero(self):
+        result = _to_erp_quantity(pd.Series([1.6, None, "abc"]))
+        assert list(result) == [2, 0, 0]
+
+    def test_negative_quantities_clip_to_zero(self):
+        result = _to_erp_quantity(pd.Series([-3.0, -0.4]))
+        assert list(result) == [0, 0]
+
+    def test_finalize_rounds_the_quantity_column(self):
+        df = pd.DataFrame({"Артикул": ["A1", "A2"], "Брой": [1.5, 2.5]})
+        result = _finalize_export_df(df)
+        assert list(result["Брой"]) == [2, 3]
+
+    def test_finalize_drops_rows_that_round_to_zero(self):
+        df = pd.DataFrame({"Артикул": ["KEEP", "DROP"], "Брой": [1.0, 0.15]})
+        result = _finalize_export_df(df)
+        assert list(result["Артикул"]) == ["KEEP"]
+
+    def test_finalize_logs_the_sku_it_dropped(self, caplog):
+        df = pd.DataFrame({"Артикул": ["PKG-TAPE"], "Брой": [0.15]})
+        with caplog.at_level("WARNING", logger="ShopifyToolLogger"):
+            _finalize_export_df(df)
+        assert "PKG-TAPE" in caplog.text
+
+    def test_finalize_stays_idempotent(self):
+        df = pd.DataFrame({"Артикул": ["A1"], "Брой": [2.5]})
+        once = _finalize_export_df(df)
+        twice = _finalize_export_df(once)
+        assert list(twice["Брой"]) == [3]
+        assert list(once.columns) == list(twice.columns)
+        assert len(twice) == 1
+
+    def test_finalize_handles_an_empty_frame(self):
+        from shopify_tool.stock_export import _empty_export_df
+
+        result = _finalize_export_df(_empty_export_df())
+        assert result.empty
+        assert list(result.columns) == list(_empty_export_df().columns)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_stock_export.py::TestQuantityRounding -v
+```
+
+Expected: collection fails with `ImportError: cannot import name '_to_erp_quantity'`.
+
+- [ ] **Step 3: Add the helper**
+
+Insert into `shopify_tool/stock_export.py` immediately above `_finalize_export_df`:
+
+```python
+def _to_erp_quantity(values: pd.Series) -> pd.Series:
+    """Coerce a quantity column to the ERP's whole-piece integers, rounding half UP.
+
+    The ERP's Брой column is measured in Мярка="брой" -- pieces -- so it cannot carry a
+    fraction. Write-off quantities do arrive fractional (a per-order mapping rate such as
+    0.5 times the order count), so this conversion has to round rather than truncate:
+    a bare ``.astype(int)`` turned a 0.5-piece write-off into 0 and the material vanished
+    from the export with no trace.
+
+    Do NOT reach for ``Series.round()`` here -- numpy rounds half to EVEN, so 0.5 -> 0 and
+    2.5 -> 2, which is the very bug this function exists to fix.
+    """
+    numeric = pd.to_numeric(values, errors="coerce").fillna(0.0).clip(lower=0)
+    # Adding 0.5 and truncating is round-half-up, and .astype(int) truncates toward zero
+    # -- which equals floor only because clip(lower=0) guarantees a non-negative input.
+    return (numeric + 0.5).astype(int)
+```
+
+- [ ] **Step 4: Wire it into `_finalize_export_df`**
+
+Replace the final line of `_finalize_export_df` (currently
+`return df[STOCK_EXPORT_COLUMNS].reset_index(drop=True)`) with:
+
+```python
+    df = df[STOCK_EXPORT_COLUMNS].copy()
+    df[QTY_COL] = _to_erp_quantity(df[QTY_COL])
+    dropped = df.loc[df[QTY_COL] <= 0, "Артикул"]
+    if not dropped.empty:
+        logger.warning(
+            f"Dropped {len(dropped)} export row(s) whose quantity rounded to zero: "
+            f"{', '.join(map(str, dropped))}"
+        )
+    return df[df[QTY_COL] > 0].reset_index(drop=True)
+```
+
+Leave the rest of the function untouched — the `Колич` rename, the `Мярка` fill, and the
+`Годност`/`Партида`/`BLANK_COL` defaults all still run first.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_stock_export.py::TestQuantityRounding -v
+```
+
+Expected: 10 passed.
+
+- [ ] **Step 6: Run the whole suite**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+```
+
+Expected: 642 passed before this change; 652 after. **If an existing test now fails because a
+zero-quantity row is no longer exported, that is this change working** — read the test, confirm
+it was asserting the truncation behaviour, and update its expectation rather than weakening the
+helper. If a test fails for any other reason, stop and investigate before continuing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add shopify_tool/stock_export.py tests/test_stock_export.py
+rtk git commit -m "Stock export: round ERP quantities half-up instead of truncating"
+```
+
+---
+
+### Task 2: Delete the four `.astype(int)` truncations
+
+With Task 1 in place these casts are redundant, and each one truncates before the finalizer
+ever sees the value — so leaving any of them in keeps the bug alive on that path.
+
+**Files:**
+- Modify: `shopify_tool/stock_export.py:218`, `:257`, `:373`
+- Modify: `shopify_tool/sku_writeoff.py:420`
+- Test: `tests/test_stock_export.py`
+
+**Interfaces:**
+- Consumes: `_finalize_export_df()` from Task 1, which now owns the int conversion.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `TestQuantityRounding` in `tests/test_stock_export.py`:
+
+```python
+    def test_fractional_writeoff_on_a_single_order_is_not_lost(self, tmp_path):
+        # The headline bug: 0.5 boxes for one order truncated to 0 and the packaging
+        # material vanished from the export entirely.
+        config = {
+            "version": 2,
+            "categories": {
+                "packaging": {
+                    "tags": ["BOX"],
+                    "sku_writeoff": {
+                        "enabled": True,
+                        "mappings": {"BOX": [{"sku": "PKG-BOX", "quantity": 0.5}]},
+                    },
+                }
+            },
+        }
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out), apply_writeoff=True, tag_categories=config)
+        result = _read(out)
+        packaging = result[result.iloc[:, COL_SKU] == "PKG-BOX"]
+        assert len(packaging) == 1
+        assert packaging.iloc[0, COL_QTY] == 1
+
+    def test_fractional_writeoff_across_three_orders_rounds_up(self, tmp_path):
+        config = {
+            "version": 2,
+            "categories": {
+                "packaging": {
+                    "tags": ["BOX"],
+                    "sku_writeoff": {
+                        "enabled": True,
+                        "mappings": {"BOX": [{"sku": "PKG-BOX", "quantity": 0.5}]},
+                    },
+                }
+            },
+        }
+        # 3 orders x 0.5 = 1.5 -> 2. Truncation gave 1.
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+            {"Order_Number": "#2", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+            {"Order_Number": "#3", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out), apply_writeoff=True, tag_categories=config)
+        result = _read(out)
+        packaging = result[result.iloc[:, COL_SKU] == "PKG-BOX"]
+        assert packaging.iloc[0, COL_QTY] == 2
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_stock_export.py -k "fractional_writeoff" -v
+```
+
+Expected: both FAIL. The single-order case fails on `len(packaging) == 1` (the row is absent —
+`.astype(int)` truncated 0.5 to 0 at `stock_export.py:257` and Task 1's finalizer then dropped
+the zero row). The three-order case fails with `1 != 2`.
+
+- [ ] **Step 3: Delete the cast at `stock_export.py:257`**
+
+In `create_stock_export`, inside the `packaging_rows = _finalize_export_df(...)` block:
+
+```python
+                            QTY_COL: writeoff_df["Writeoff_Quantity"],
+```
+
+(was `writeoff_df["Writeoff_Quantity"].astype(int)`)
+
+- [ ] **Step 4: Delete the cast at `stock_export.py:218`**
+
+In the "Summarize quantities by SKU" branch, drop the `.astype(int)` line so the chain reads:
+
+```python
+            sku_summary = (
+                filtered_items.groupby("SKU")["Quantity"]
+                .sum()
+                .reset_index()
+            )
+```
+
+The `sku_summary[sku_summary["Quantity"] > 0]` filter on the next line now operates on floats,
+which is what it should have been doing — a 0.6 no longer truncates to 0 and gets filtered out
+before the finalizer can round it to 1.
+
+- [ ] **Step 5: Delete the cast at `stock_export.py:373`**
+
+Same edit in `merge_session_stock_exports`:
+
+```python
+    sku_summary = (
+        combined.groupby("SKU")["Quantity"]
+        .sum()
+        .reset_index()
+    )
+```
+
+Leave the `> 0` filter on the following line in place.
+
+- [ ] **Step 6: Delete the cast at `sku_writeoff.py:420`**
+
+In `generate_writeoff_report`:
+
+```python
+                QTY_COL: writeoff_df["Writeoff_Quantity"],
+```
+
+- [ ] **Step 7: Verify no `.astype(int)` remains on an export path**
+
+```bash
+rtk grep -n "astype(int)" shopify_tool/stock_export.py shopify_tool/sku_writeoff.py
+```
+
+Expected: no matches. (`set_decoder.py:206` is a different concern — `Component_Quantity` on
+set expansion, not an ERP export column. Leave it alone.)
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_stock_export.py tests/test_sku_writeoff.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Run the gate**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+```
+
+Expected: 654 passed, ruff clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+rtk git add shopify_tool/stock_export.py shopify_tool/sku_writeoff.py tests/test_stock_export.py
+rtk git commit -m "Stock export: remove the four .astype(int) quantity truncations"
+```
+
+- [ ] **Step 11: Refresh the knowledge graph**
+
+```bash
+graphify update .
+```
+
+---
+
+## Verification
+
+Manual check is not required — the ERP layout is asserted positionally by the existing tests in
+`tests/test_stock_export.py`, and `test_canonical_column_layout` still guards the column order.
+
+Definition of done:
+- `_to_erp_quantity` rounds half-up and is the only place an export quantity becomes an `int`.
+- No `.astype(int)` remains in `stock_export.py` or `sku_writeoff.py`.
+- A zero-rounding row is dropped **and** named in a `WARNING` log line.
+- Full suite green, `ruff check . --exclude shared` clean, `graphify update .` run.

--- a/docs/superpowers/plans/2026-08-14-erp-quantity-rounding-plan.md
+++ b/docs/superpowers/plans/2026-08-14-erp-quantity-rounding-plan.md
@@ -400,11 +400,16 @@ In `generate_writeoff_report`:
 - [ ] **Step 7: Verify no `.astype(int)` remains on an export path**
 
 ```bash
-rtk grep -n "astype(int)" shopify_tool/stock_export.py shopify_tool/sku_writeoff.py
+rtk grep -nE "astype\(int\)|int\(" shopify_tool/stock_export.py shopify_tool/sku_writeoff.py
 ```
 
-Expected: no matches. (`set_decoder.py:206` is a different concern — `Component_Quantity` on
-set expansion, not an ERP export column. Leave it alone.)
+Expected: only the `.astype(int)` inside `_to_erp_quantity` itself. **The `int(` half of this
+grep matters** — the first pass of this plan searched for the literal `astype(int)` only and
+missed two bare `int(qty)` calls in `_expand_lot_summary`, which truncate *before*
+`_finalize_export_df` runs and so cannot be recovered by it. Code review caught them.
+
+(`set_decoder.py:206` is a different concern — `Component_Quantity` on set expansion, not an
+ERP export column. Leave it alone.)
 
 - [ ] **Step 8: Run the tests to verify they pass**
 

--- a/shopify_tool/sku_writeoff.py
+++ b/shopify_tool/sku_writeoff.py
@@ -417,7 +417,7 @@ def generate_writeoff_report(
         export_df = _finalize_export_df(
             pd.DataFrame({
                 "Артикул": writeoff_df["SKU"],
-                QTY_COL: writeoff_df["Writeoff_Quantity"].astype(int),
+                QTY_COL: writeoff_df["Writeoff_Quantity"],
             })
         )
 

--- a/shopify_tool/stock_export.py
+++ b/shopify_tool/stock_export.py
@@ -241,7 +241,6 @@ def create_stock_export(
             sku_summary = (
                 filtered_items.groupby("SKU")["Quantity"]
                 .sum()
-                .astype(int)
                 .reset_index()
             )
             sku_summary = sku_summary[sku_summary["Quantity"] > 0]
@@ -280,7 +279,7 @@ def create_stock_export(
                     pd.DataFrame(
                         {
                             "Артикул": writeoff_df["SKU"],
-                            QTY_COL: writeoff_df["Writeoff_Quantity"].astype(int),
+                            QTY_COL: writeoff_df["Writeoff_Quantity"],
                         }
                     )
                 )
@@ -396,7 +395,6 @@ def merge_session_stock_exports(
     sku_summary = (
         combined.groupby("SKU")["Quantity"]
         .sum()
-        .astype(int)
         .reset_index()
     )
     sku_summary = sku_summary[sku_summary["Quantity"] > 0]

--- a/shopify_tool/stock_export.py
+++ b/shopify_tool/stock_export.py
@@ -120,7 +120,7 @@ def _expand_lot_summary(filtered_items: pd.DataFrame) -> pd.DataFrame:
             records.append(
                 {
                     "Артикул": sku,
-                    QTY_COL: int(qty),
+                    QTY_COL: qty,
                     "Годност": expiry,
                     "Партида": batch,
                 }
@@ -130,7 +130,7 @@ def _expand_lot_summary(filtered_items: pd.DataFrame) -> pd.DataFrame:
             records.append(
                 {
                     "Артикул": sku,
-                    QTY_COL: int(qty),
+                    QTY_COL: qty,
                     "Годност": "",
                     "Партида": "",
                 }
@@ -227,7 +227,6 @@ def create_stock_export(
                 f"Report '{report_name}': Using per-lot aggregation (FIFO lot tracking active)."
             )
             export_df = _expand_lot_summary(filtered_items)
-            export_df = export_df[export_df[QTY_COL] > 0].reset_index(drop=True)
             if export_df.empty:
                 logger.warning(
                     f"Report '{report_name}': No items with positive quantity after lot expansion."
@@ -238,11 +237,7 @@ def create_stock_export(
                 )
         else:
             # Summarize quantities by SKU
-            sku_summary = (
-                filtered_items.groupby("SKU")["Quantity"]
-                .sum()
-                .reset_index()
-            )
+            sku_summary = filtered_items.groupby("SKU")["Quantity"].sum().reset_index()
             sku_summary = sku_summary[sku_summary["Quantity"] > 0]
 
             if sku_summary.empty:
@@ -392,11 +387,7 @@ def merge_session_stock_exports(
     # unaffected by this function. Splitting the SAME SKU across multiple
     # rows here (one per distinct expiry/batch) previously contradicted this
     # function's own contract of "grouped by SKU... summed across sessions".
-    sku_summary = (
-        combined.groupby("SKU")["Quantity"]
-        .sum()
-        .reset_index()
-    )
+    sku_summary = combined.groupby("SKU")["Quantity"].sum().reset_index()
     sku_summary = sku_summary[sku_summary["Quantity"] > 0]
     if sku_summary.empty:
         return _empty_export_df()

--- a/shopify_tool/stock_export.py
+++ b/shopify_tool/stock_export.py
@@ -22,6 +22,24 @@ def _empty_export_df() -> pd.DataFrame:
     return pd.DataFrame(columns=STOCK_EXPORT_COLUMNS)
 
 
+def _to_erp_quantity(values: pd.Series) -> pd.Series:
+    """Coerce a quantity column to the ERP's whole-piece integers, rounding half UP.
+
+    The ERP's Брой column is measured in Мярка="брой" -- pieces -- so it cannot carry a
+    fraction. Write-off quantities do arrive fractional (a per-order mapping rate such as
+    0.5 times the order count), so this conversion has to round rather than truncate:
+    a bare ``.astype(int)`` turned a 0.5-piece write-off into 0 and the material vanished
+    from the export with no trace.
+
+    Do NOT reach for ``Series.round()`` here -- numpy rounds half to EVEN, so 0.5 -> 0 and
+    2.5 -> 2, which is the very bug this function exists to fix.
+    """
+    numeric = pd.to_numeric(values, errors="coerce").fillna(0.0).clip(lower=0)
+    # Adding 0.5 and truncating is round-half-up, and .astype(int) truncates toward zero
+    # -- which equals floor only because clip(lower=0) guarantees a non-negative input.
+    return (numeric + 0.5).astype(int)
+
+
 def _finalize_export_df(df: pd.DataFrame) -> pd.DataFrame:
     """Coerce a built export frame to the canonical ERP column layout.
 
@@ -39,7 +57,15 @@ def _finalize_export_df(df: pd.DataFrame) -> pd.DataFrame:
         if col not in df.columns:
             df[col] = ""
     df[BLANK_COL] = ""
-    return df[STOCK_EXPORT_COLUMNS].reset_index(drop=True)
+    df = df[STOCK_EXPORT_COLUMNS].copy()
+    df[QTY_COL] = _to_erp_quantity(df[QTY_COL])
+    dropped = df.loc[df[QTY_COL] <= 0, "Артикул"]
+    if not dropped.empty:
+        logger.warning(
+            f"Dropped {len(dropped)} export row(s) whose quantity rounded to zero: "
+            f"{', '.join(map(str, dropped))}"
+        )
+    return df[df[QTY_COL] > 0].reset_index(drop=True)
 
 
 def _expand_lot_summary(filtered_items: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_stock_export.py
+++ b/tests/test_stock_export.py
@@ -209,3 +209,53 @@ class TestQuantityRounding:
         result = _finalize_export_df(_empty_export_df())
         assert result.empty
         assert list(result.columns) == list(_empty_export_df().columns)
+
+    def test_fractional_writeoff_on_a_single_order_is_not_lost(self, tmp_path):
+        # The headline bug: 0.5 boxes for one order truncated to 0 and the packaging
+        # material vanished from the export entirely.
+        config = {
+            "version": 2,
+            "categories": {
+                "packaging": {
+                    "tags": ["BOX"],
+                    "sku_writeoff": {
+                        "enabled": True,
+                        "mappings": {"BOX": [{"sku": "PKG-BOX", "quantity": 0.5}]},
+                    },
+                }
+            },
+        }
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out), apply_writeoff=True, tag_categories=config)
+        result = _read(out)
+        packaging = result[result.iloc[:, COL_SKU] == "PKG-BOX"]
+        assert len(packaging) == 1
+        assert packaging.iloc[0, COL_QTY] == 1
+
+    def test_fractional_writeoff_across_three_orders_rounds_up(self, tmp_path):
+        config = {
+            "version": 2,
+            "categories": {
+                "packaging": {
+                    "tags": ["BOX"],
+                    "sku_writeoff": {
+                        "enabled": True,
+                        "mappings": {"BOX": [{"sku": "PKG-BOX", "quantity": 0.5}]},
+                    },
+                }
+            },
+        }
+        # 3 orders x 0.5 = 1.5 -> 2. Truncation gave 1.
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+            {"Order_Number": "#2", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+            {"Order_Number": "#3", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out), apply_writeoff=True, tag_categories=config)
+        result = _read(out)
+        packaging = result[result.iloc[:, COL_SKU] == "PKG-BOX"]
+        assert packaging.iloc[0, COL_QTY] == 2

--- a/tests/test_stock_export.py
+++ b/tests/test_stock_export.py
@@ -102,6 +102,17 @@ class TestLotAggregation:
         expiry_val = result.iloc[0, COL_EXPIRY]
         assert expiry_val == "" or pd.isna(expiry_val)
 
+    def test_fractional_lot_quantity_rounds_instead_of_truncating(self, tmp_path):
+        # The lot path built its rows with int(qty), which truncated BEFORE
+        # _finalize_export_df could round -- the finalizer cannot recover a
+        # fraction that was already thrown away.
+        lot_details = [{"expiry": "260601", "batch": "B1", "qty_allocated": 1.5}]
+        df = _analysis_df([{"Order_Number": "#1", "SKU": "A1", "Quantity": 1.5, "Lot_Details": lot_details}])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out))
+        result = _read(out)
+        assert result.iloc[0, COL_QTY] == 2
+
 
 class TestConfirmedBugs:
     def test_missing_order_number_does_not_drop_distinct_lot_allocations(self, tmp_path):

--- a/tests/test_stock_export.py
+++ b/tests/test_stock_export.py
@@ -6,7 +6,12 @@ back by column index rather than by header name.
 """
 import pandas as pd
 
-from shopify_tool.stock_export import create_stock_export, merge_session_stock_exports
+from shopify_tool.stock_export import (
+    _finalize_export_df,
+    _to_erp_quantity,
+    create_stock_export,
+    merge_session_stock_exports,
+)
 
 COL_SKU, COL_BLANK, COL_UNIT, COL_QTY, COL_EXPIRY, COL_BATCH = range(6)
 
@@ -149,3 +154,58 @@ class TestMergeSessionStockExportsBug:
         a1_rows = result[result.iloc[:, COL_SKU] == "A1"]
         assert len(a1_rows) == 1
         assert a1_rows.iloc[0, COL_QTY] == 5
+
+
+class TestQuantityRounding:
+    def test_rounds_half_up_not_half_to_even(self):
+        # pandas/numpy .round() is banker's rounding: 0.5 -> 0 and 2.5 -> 2, which
+        # leaves the exact bug this helper exists to fix. Half-up is required.
+        result = _to_erp_quantity(pd.Series([0.5, 1.5, 2.5, 3.5]))
+        assert list(result) == [1, 2, 3, 4]
+
+    def test_rounds_down_below_the_half(self):
+        result = _to_erp_quantity(pd.Series([0.4, 0.49, 1.2, 2.499]))
+        assert list(result) == [0, 0, 1, 2]
+
+    def test_whole_numbers_are_unchanged(self):
+        result = _to_erp_quantity(pd.Series([0.0, 1.0, 7.0, 100.0]))
+        assert list(result) == [0, 1, 7, 100]
+
+    def test_non_numeric_and_missing_become_zero(self):
+        result = _to_erp_quantity(pd.Series([1.6, None, "abc"]))
+        assert list(result) == [2, 0, 0]
+
+    def test_negative_quantities_clip_to_zero(self):
+        result = _to_erp_quantity(pd.Series([-3.0, -0.4]))
+        assert list(result) == [0, 0]
+
+    def test_finalize_rounds_the_quantity_column(self):
+        df = pd.DataFrame({"Артикул": ["A1", "A2"], "Брой": [1.5, 2.5]})
+        result = _finalize_export_df(df)
+        assert list(result["Брой"]) == [2, 3]
+
+    def test_finalize_drops_rows_that_round_to_zero(self):
+        df = pd.DataFrame({"Артикул": ["KEEP", "DROP"], "Брой": [1.0, 0.15]})
+        result = _finalize_export_df(df)
+        assert list(result["Артикул"]) == ["KEEP"]
+
+    def test_finalize_logs_the_sku_it_dropped(self, caplog):
+        df = pd.DataFrame({"Артикул": ["PKG-TAPE"], "Брой": [0.15]})
+        with caplog.at_level("WARNING", logger="ShopifyToolLogger"):
+            _finalize_export_df(df)
+        assert "PKG-TAPE" in caplog.text
+
+    def test_finalize_stays_idempotent(self):
+        df = pd.DataFrame({"Артикул": ["A1"], "Брой": [2.5]})
+        once = _finalize_export_df(df)
+        twice = _finalize_export_df(once)
+        assert list(twice["Брой"]) == [3]
+        assert list(once.columns) == list(twice.columns)
+        assert len(twice) == 1
+
+    def test_finalize_handles_an_empty_frame(self):
+        from shopify_tool.stock_export import _empty_export_df
+
+        result = _finalize_export_df(_empty_export_df())
+        assert result.empty
+        assert list(result.columns) == list(_empty_export_df().columns)


### PR DESCRIPTION
Fixes the ERP stock export truncating fractional write-off quantities to zero — the follow-up PR #281 forecast ("`.round().astype(int)` is the whole fix if you want it — say so and it gets its own PR"). It is **not** that fix; see below.

## The bug

`Брой` is measured in `Мярка = "брой"` — pieces — so the export has to convert to `int`. Four sites did that with a bare `.astype(int)`, which **truncates**. A packaging SKU mapped at 0.5 units per order, on a one-order session, exported quantity `0`: the material vanished from the write-off with no trace. After #281 removed the line-count inflation that used to mask this (0.5/order × 3 lines = 1.5 → 1), a single-order session hit it directly.

## `.round()` is NOT the fix

numpy rounds **half to even**: `0.5 → 0`, `2.5 → 2`. That leaves the exact headline case broken. This PR uses half-up — `clip(lower=0)`, `+ 0.5`, then truncate — and the `_to_erp_quantity` docstring says so, so the next person to "simplify" it back doesn't reintroduce the bug.

```
input        [0.4, 0.5, 1.5, 2.5, 0.05, 3.0]
astype(int)  [0,   0,   1,   2,   0,    3]   <- today: truncates
.round()     [0,   0,   2,   2,   0,    3]   <- banker's rounding, still broken
half-up      [0,   1,   2,   3,   0,    3]   <- this PR
```

## Where the fix lives

In `_finalize_export_df()`, the single choke point **all six** export call sites already funnel through (`_expand_lot_summary`, the non-lot SKU summary, the packaging rows, the catch-all guard, `merge_session_stock_exports`, and `generate_writeoff_report`). One new helper, then all four `.astype(int)` casts deleted — net negative diff, and it kills the bug on paths nobody reported.

**Rows that round to zero are dropped, but logged at WARNING with the SKU name.** The log is the load-bearing half: a packaging material disappearing from an export with no trace is precisely the failure class this milestone is hunting.

Rejected: `ceil` (a 0.05/order tape mapping on one order would write off a whole roll); carrying the remainder across sessions (needs persistent per-client per-SKU state, out of proportion to the bug).

## Confirmed: the ERP rejects a quantity of `0`

**The user confirmed the ERP "is not accepting any 0.0 numbers."** That settles the open question this PR originally carried — integer quantities stay, and dropping zero-quantity rows is a **hard requirement of the file format**, not a tidiness rule.

It also means the truncation bug had a louder symptom than "a material silently vanishes": it wrote a literal `0` into the export and the ERP refused it. Verified by probing the written `.xls` on both revisions with a 0.5-per-order write-off on one order:

```
pre-PR  (663fb0b)   PKG-BOX  ...  0.0   <- ERP rejects this
this PR (2f0233f)   PKG-BOX  ...  1.0
```

The packaging write-off path was the one that could emit it. Unlike the SKU-summary path, whose `.astype(int)` was followed by a `> 0` filter, `stock_export.py:257` cast and appended with no filter after it — so a truncated zero went straight into the file. `test_no_zero_quantity_cell_ever_reaches_the_file` now pins the contract at the file level, so any future path that emits a zero fails the suite rather than the ERP import.

(Note: every number in an `.xls` is stored as an IEEE double — there is no integer cell type in BIFF — so quantities have always been written as `1.0` and displayed as `1` by the `General` format. That is unchanged by this PR and is not what the ERP objects to; it objects to the *value* zero.)

**Still open from #281, unchanged:** whether a reconciliation pass against the ERP for the historical over-write-off is worth running. This PR stops new truncation; it does not correct data already exported.

## Changes

- `shopify_tool/stock_export.py` — `_to_erp_quantity()` (half-up, non-negative clip, non-numeric → 0), wired into `_finalize_export_df()`, which now also drops-and-logs zero rows. Three `.astype(int)` casts and two bare `int(qty)` calls deleted; one dead positive-quantity filter deleted.
- `shopify_tool/sku_writeoff.py` — the fourth `.astype(int)` deleted.
- `tests/test_stock_export.py` — **14 new tests**: half-up vs half-to-even, sub-half, whole numbers, non-numeric/missing, negatives, drop-and-log, idempotency, empty frames, the two headline integration cases (0.5/order on 1 and on 3 orders), the lot-path fraction, and the file-level "no zero cell" contract.

## Code review

A fresh-context reviewer independently reproduced the pre-fix failures, mutation-tested the guard (plain truncation → 6 failures; banker's `.round()` → 4 failures, so neither regression can slip through), and grepped every call site to confirm no export path bypasses the finalizer. Its one blocking finding is fixed in `2f0233f`:

**The lot path still truncated.** `_expand_lot_summary` built its rows with bare `int(qty)`, *before* the finalizer ran — so the finalizer couldn't recover the fraction, and the `if qty > 0` guards testing the raw float meant `0.4` passed, truncated to `0`, and was then dropped with a warning claiming it "rounded to zero". Reachability is low (lot quantities are normally integer piece counts) but it was live, and it violated the plan's own definition of done. The plan's Step 7 grep searched for the literal `astype(int)`, which is why it missed them; that grep is now `astype\(int\)|int\(` so the DoD verifies itself.

Two things the review noted and this PR deliberately does **not** change:

- **`±inf` / int64 overflow.** `float('inf')` raises, and `1e19` overflows to a negative and is dropped with the same misleading "rounded to zero" warning. Not a regression — the old `.astype(int)` raised on inf too — and it needs a hand-edited `tag_categories.json` on the file server to reach. Documented rather than clamped; say the word and it's a one-line `.replace([inf, -inf], 0)`.
- **`_finalize_export_df`'s missing-column default changed meaning.** `if QTY_COL not in df.columns: df[QTY_COL] = 0` used to yield zero-quantity rows; it now drops every row. Latent — no live caller reaches that branch.

## Verification

`QT_QPA_PLATFORM=offscreen python -m pytest` → **656 passed** (642 before this task, +14), no regressions and no existing test weakened. `ruff check . --exclude shared` clean. `graphify update .` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fGRKao4ypWqw4oBxFcHrE
