### PR TITLE
Stock export: pin "no zero quantity reaches the ERP file" (missed the #282 merge)

### DIFF
--- a/tests/test_stock_export.py
+++ b/tests/test_stock_export.py
@@ -270,3 +270,29 @@ class TestQuantityRounding:
         result = _read(out)
         packaging = result[result.iloc[:, COL_SKU] == "PKG-BOX"]
         assert packaging.iloc[0, COL_QTY] == 2
+
+    def test_no_zero_quantity_cell_ever_reaches_the_file(self, tmp_path):
+        # The warehouse ERP REJECTS a row whose quantity is 0, so this is a hard
+        # requirement of the file format, not a tidiness rule. Before the rounding
+        # fix a 0.5-per-order write-off truncated to 0 and was written as a 0 cell.
+        # A 0.4 rate still rounds to 0 -- that row must be absent, not zeroed.
+        config = {
+            "version": 2,
+            "categories": {
+                "packaging": {
+                    "tags": ["BOX"],
+                    "sku_writeoff": {
+                        "enabled": True,
+                        "mappings": {"BOX": [{"sku": "PKG-TAPE", "quantity": 0.4}]},
+                    },
+                }
+            },
+        }
+        df = _analysis_df([
+            {"Order_Number": "#1", "SKU": "A1", "Quantity": 1, "Internal_Tags": '["BOX"]'},
+        ])
+        out = tmp_path / "export.xls"
+        create_stock_export(df, str(out), apply_writeoff=True, tag_categories=config)
+        result = _read(out)
+        assert "PKG-TAPE" not in set(result.iloc[:, COL_SKU])
+        assert (result.iloc[:, COL_QTY] > 0).all()


### PR DESCRIPTION
Follow-up to #282. This one commit was pushed about four minutes after #282 was squash-merged, so it missed the merge — everything else from that branch is in `main`. Test-only; no production code changes.

## Why this test exists

You confirmed the warehouse ERP **rejects a row whose quantity is `0`**. That makes "no zero quantity ever reaches the export file" a hard requirement of the file format rather than a tidiness rule, and #282's row-dropping is what satisfies it.

It's also the actual symptom the truncation bug produced. Verified by probing the written `.xls` on both revisions with a 0.5-per-order write-off on one order:

```
pre-#282  (663fb0b)   PKG-BOX  ...  0.0   <- ERP rejects this
post-#282 (2f0233f)   PKG-BOX  ...  1.0
```

Only the packaging write-off path could emit it. The SKU-summary path's `.astype(int)` was followed by a `> 0` filter, so its truncated zeros were dropped; `stock_export.py:257` cast and appended with **no filter after the cast**, so the zero went straight into the file. That asymmetry is why the failure looked intermittent — only sessions with packaging write-offs produced a rejected import.

## What it asserts

`test_no_zero_quantity_cell_ever_reaches_the_file` drives `create_stock_export` with a 0.4-per-order mapping on one order — a rate that legitimately rounds to zero — and asserts at the **file** level that the row is absent and that no quantity cell is `<= 0`. Existing tests assert specific quantities on specific SKUs; this one pins the format-wide invariant, so any *future* path that emits a zero fails the suite instead of the ERP import.

Mutation-checked: removing the `df[QTY_COL] > 0` drop from `_finalize_export_df` fails this test (`assert 'PKG-TAPE' not in {'A1', 'PKG-TAPE'}`).

## Not chased, deliberately

Every number in an `.xls` is stored as an IEEE double — BIFF has no integer cell type — so quantities have always been written as `1.0` and displayed as `1` by the `General` format. That is unchanged and is not what the ERP objects to; it objects to the *value* zero. No cell-formatting or `xlwt` style work is needed.

## Verification

`QT_QPA_PLATFORM=offscreen python -m pytest` → **656 passed** on top of current `main`. `ruff check . --exclude shared` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fGRKao4ypWqw4oBxFcHrE
