### PR TITLE
Bug fix — Search filter crashed on any row with 2+ allocated lots

### DIFF
--- a/docs/superpowers/plans/2026-08-16-cell-render-consolidation-plan.md
+++ b/docs/superpowers/plans/2026-08-16-cell-render-consolidation-plan.md
@@ -1,0 +1,420 @@
+# Cell Render Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this
+> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> The runner's Stage B runs **in-session** — `executing-plans` will offer to switch to
+> `subagent-driven-development`; **decline it**.
+
+**Goal:** Route every DataFrame-cell-to-text rendering in the GUI through one function, which
+fixes a live crash in the main table's search box on lot-tracked analyses.
+
+**Architecture:** `gui/pandas_model.py` grows a module-level `cell_display_text(value) -> str`
+holding the list-before-`pd.isna` ordering that PR #276 established. Its three callers —
+`PandasModel.data()`, `FulfillmentFilterProxy._matches_text()`, and `gui/rule_test_dialog.py` —
+all call it instead of carrying their own copy. Net-negative diff; the only behaviour change is
+in the search filter, which stops crashing.
+
+**Tech Stack:** PySide6 (`QAbstractTableModel`, `QSortFilterProxyModel`), pandas, pytest.
+
+**Spec:** none. This is a bounded change to code that already exists here, so
+`superpowers:brainstorming`'s bounded path produces no spec doc — the design is inlined in the
+Context section below. (Same convention as the `rule-preview-fidelity` plan.)
+
+## Global Constraints
+
+- Windows-only product, developed on Linux. Run everything through `.venv/bin/python`; bare
+  `python` is not on PATH.
+- Gate before finishing: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest` and
+  `.venv/bin/ruff check . --exclude shared`.
+- Never hand-edit anything under `shared/`. This plan touches nothing there.
+- No hardcoded colors. This plan adds no styling.
+- No version bump — this matches the surrounding bug-fix PRs (#281–#284), none of which bumped.
+
+---
+
+## Context — what is wrong and why
+
+### The duplication
+
+`gui/rule_test_dialog.py:30-44` defines `_cell_text(value)`. Its own docstring says it "Mirrors
+gui/pandas_model.py:182-194" — a line-number reference, which this repo's history shows goes
+stale. The two copies share the `"N lots"` wording, the empty-list-is-blank rule, and the
+load-bearing ordering (list check **before** `pd.isna`).
+
+### The bug that duplication hid
+
+`FulfillmentFilterProxy._matches_text` (`gui/pandas_model.py:74`) is a **third** copy of the same
+idea, written wrong:
+
+```python
+hay = "" if pd.isna(cell) else str(cell)
+```
+
+`pd.isna()` on a list of 2+ elements returns an **array**, and `if <array>:` raises
+`ValueError: The truth value of an array with more than one element is ambiguous`. That is
+exactly the crash class PR #276 fixed — but #276 fixed it at one caller (`data()`) and left this
+sibling caller broken.
+
+**It is live in production, not theoretical:**
+
+- `gui/ui_manager.py:886` builds the model from **all** columns (`main_df = data_df.copy()`,
+  commented "visibility is handled by the view"), so `Lot_Details` is in the proxy's frame even
+  when the column is hidden.
+- `Lot_Details` is a standard analysis output column (`shopify_tool/analysis.py:1139`) holding
+  real `list[dict]` on any lot-tracked run.
+- The search box defaults to "All Columns" (`df_col = -1`, `gui/main_window_pyside.py:1207`), so
+  the scan reaches the `Lot_Details` cell.
+
+Reproduced against the real classes before this plan was written:
+
+| search text | result |
+|---|---|
+| `1001` (matches `Order_Number`, an earlier column) | 1 row — the loop short-circuits before `Lot_Details` |
+| `zzz` (matches nothing) | **`ValueError` — crash** |
+
+So it survives only while every scanned row matches on some column left of `Lot_Details`. Any
+search that narrows the table — i.e. the point of searching — walks a non-matching row into the
+list cell and raises. Single-lot and empty rows are safe; 2+ lots on one SKU line crash.
+
+The tag-filter path two lines up (`:58`) has the same shape but is **safe**: `Internal_Tags`
+holds a JSON *string* (`analysis.py:1103` sets `"[]"`), never a list. Verified — leave it alone.
+
+### Judgment call, so review does not re-litigate it
+
+**The filter will match a lot cell's displayed text (`"2 lots"`), not its raw `repr`.**
+
+Today an uncrashed single-lot row is searched as `str([{'expiry': '261230', 'batch': 'B1', ...}])`,
+so typing `qty_allocated` or a batch number matches a row whose visible cells contain no such
+text. That is not a feature anyone can use deliberately, the class docstring already promises
+"Matching is plain substring on the cell's display text", and on the multi-lot rows where batch
+search would actually matter it crashes instead.
+
+Known cost: batch/expiry text stops being searchable on single-lot rows. Accepted. If the user
+wants it back it is one line — `hay` becomes the tooltip join for list cells — but that would
+mean searching text the table does not show.
+
+### Deliberately out of scope
+
+- The `"N lots"` wording is column-agnostic — any list-valued column renders as lots. Only
+  `Lot_Details` holds lists today; fixing it needs column context threaded into the renderer, for
+  no present gain.
+- Multi-element `ndarray`/`Series` cells still raise from `pd.isna`. Nothing in the app puts them
+  in a frame; consolidating means the fix would now land in one place if that ever changes.
+- `gui/settings/rules.py:963-967` hardcoded colors (cross-repo, needs `shared/theme.py`).
+- `ColumnConfigPanel` list-stretch bug.
+
+---
+
+## File Structure
+
+- `gui/pandas_model.py` — gains `cell_display_text()` next to the existing `_format_lot()` helper;
+  `data()` and `_matches_text()` both call it. Owner of the rendering rule.
+- `gui/rule_test_dialog.py` — loses `_cell_text()`, imports the shared function. Pure consumer.
+- `tests/test_pandas_model.py` — already the home of this crash class (its module docstring
+  describes it). The new proxy regression tests append here.
+
+---
+
+### Task 1: Extract the shared renderer
+
+**Files:**
+- Modify: `gui/pandas_model.py` (add `cell_display_text` after `_format_lot` at `:89`; rewrite the
+  `DisplayRole`/`ToolTipRole` branch of `PandasModel.data()` at `:177-194`)
+- Test: `tests/test_pandas_model.py`
+
+**Interfaces:**
+- Produces: `cell_display_text(value) -> str` — module-level in `gui/pandas_model.py`. Public (no
+  leading underscore) because Task 3 imports it from another module. Total function, never raises
+  for `None`, scalars, `NaN`, or lists.
+
+This task is a pure extraction: the five existing tests in `tests/test_pandas_model.py` already
+pin every branch of `data()` and are the real gate. The two new tests below exist only because
+Task 3 makes this function a cross-module contract.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_pandas_model.py`. Match the file's existing style — plain asserts, a
+docstring only where the *why* is not obvious from the name.
+
+```python
+def test_cell_display_text_renders_empty_and_missing_as_blank():
+    assert cell_display_text(None) == ""
+    assert cell_display_text([]) == ""
+    assert cell_display_text(float("nan")) == ""
+
+
+def test_cell_display_text_counts_lots_without_raising():
+    """The list check must precede pd.isna(); see this module's docstring."""
+    lots = [
+        {"expiry": "261230", "expiry_dt": date(2026, 12, 30), "batch": "B1", "qty_allocated": 2.0},
+        {"expiry": "270101", "expiry_dt": date(2027, 1, 1), "batch": None, "qty_allocated": 1.0},
+    ]
+    assert cell_display_text(lots) == "2 lots"
+    assert cell_display_text(lots[:1]) == "1 lot"
+    assert cell_display_text("A1") == "A1"
+```
+
+Extend the existing import at the top of the file:
+
+```python
+from gui.pandas_model import PandasModel, cell_display_text
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_pandas_model.py -v`
+Expected: collection error — `ImportError: cannot import name 'cell_display_text'`.
+
+- [ ] **Step 3: Add the function**
+
+Insert directly after `_format_lot()` (which ends at `gui/pandas_model.py:88`):
+
+```python
+def cell_display_text(value) -> str:
+    """Render one DataFrame cell as the text the user sees in a table.
+
+    The list check MUST come before ``pd.isna()``: ``Lot_Details`` holds real
+    Python lists, and ``pd.isna()`` on a list returns an *array*, so a plain
+    ``if`` on it raises "truth value of an array is ambiguous". Every caller
+    that renders or searches cell text must go through here — a private copy
+    is how that crash got reintroduced in the filter proxy.
+    """
+    if isinstance(value, list):
+        if not value:
+            return ""
+        return f"{len(value)} lot{'s' if len(value) != 1 else ''}"
+    if pd.isna(value):
+        return ""
+    return str(value)
+```
+
+- [ ] **Step 4: Rewrite the `data()` branch to use it**
+
+Replace `gui/pandas_model.py:177-194` — the whole block from `if role in (...)` down to and
+including `return str(value)` — with:
+
+```python
+        if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.ToolTipRole):
+            try:
+                value = self._dataframe.iloc[row, col_index]
+            except IndexError:
+                return None
+
+            if role == Qt.ItemDataRole.ToolTipRole:
+                if isinstance(value, list) and value:
+                    return "\n".join(_format_lot(lot) for lot in value)
+                return None  # no tooltip for empty or plain scalar cells
+
+            return cell_display_text(value)
+```
+
+This is behaviour-identical to the original on all six paths (Display/ToolTip × non-empty list /
+empty list / scalar). Do not "improve" it further — the existing tests encode each one.
+
+- [ ] **Step 5: Run the full model test file**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_pandas_model.py -v`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/pandas_model.py tests/test_pandas_model.py
+git commit -m "refactor: extract cell_display_text() from PandasModel.data()"
+```
+
+---
+
+### Task 2: Fix the search-filter crash
+
+**Files:**
+- Modify: `gui/pandas_model.py:74` (inside `FulfillmentFilterProxy._matches_text`)
+- Test: `tests/test_pandas_model.py`
+
+**Interfaces:**
+- Consumes: `cell_display_text` from Task 1.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_pandas_model.py`. `FulfillmentFilterProxy` is not yet imported in this file
+— extend the import from Task 1 again:
+
+```python
+from gui.pandas_model import FulfillmentFilterProxy, PandasModel, cell_display_text
+```
+
+Add a helper next to the existing `_model()` helper:
+
+```python
+def _lot_proxy(lots):
+    """Proxy over a frame whose *last* column holds a lot list, as analysis emits it."""
+    proxy = FulfillmentFilterProxy()
+    proxy.setSourceModel(PandasModel(pd.DataFrame({"SKU": ["A1"], "Lot_Details": [lots]})))
+    return proxy
+
+
+_TWO_LOTS = [
+    {"expiry": "261230", "expiry_dt": date(2026, 12, 30), "batch": "B1", "qty_allocated": 2.0},
+    {"expiry": "270101", "expiry_dt": date(2027, 1, 1), "batch": None, "qty_allocated": 1.0},
+]
+```
+
+and the tests:
+
+```python
+def test_text_filter_over_a_multi_lot_row_does_not_raise():
+    """Regression: pd.isna(list) raised inside filterAcceptsRow.
+
+    The needle must match no earlier column, otherwise the column scan
+    short-circuits before it ever reaches the list cell -- which is why this
+    crash survived in production while ordinary searches looked fine.
+    """
+    proxy = _lot_proxy(_TWO_LOTS)
+    proxy.set_text_filter("zzz")
+    assert proxy.rowCount() == 0  # must not raise
+
+
+def test_text_filter_matches_a_lot_cell_by_its_displayed_text():
+    proxy = _lot_proxy(_TWO_LOTS)
+    proxy.set_text_filter("2 lots")
+    assert proxy.rowCount() == 1
+
+
+def test_text_filter_still_matches_plain_scalar_columns():
+    proxy = _lot_proxy(_TWO_LOTS)
+    proxy.set_text_filter("a1")  # case-insensitive by default
+    assert proxy.rowCount() == 1
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+`QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_pandas_model.py -k filter -v`
+
+Expected: `test_text_filter_over_a_multi_lot_row_does_not_raise` and
+`test_text_filter_matches_a_lot_cell_by_its_displayed_text` FAIL. The first fails with
+`ValueError: The truth value of an array with more than one element is ambiguous`, wrapped by
+PySide6 as an error calling the `filterAcceptsRow` override. The second fails on
+`assert 0 == 1`. The third passes already — it is there to prove the fix does not regress the
+normal path.
+
+- [ ] **Step 3: Make the fix**
+
+In `_matches_text`, replace:
+
+```python
+            hay = "" if pd.isna(cell) else str(cell)
+```
+
+with:
+
+```python
+            hay = cell_display_text(cell)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_pandas_model.py -v`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/pandas_model.py tests/test_pandas_model.py
+git commit -m "fix: search filter crashed on rows with 2+ allocated lots"
+```
+
+---
+
+### Task 3: Point the rule test dialog at the shared renderer
+
+**Files:**
+- Modify: `gui/rule_test_dialog.py` (delete `_cell_text` at `:30-44`; add the import; update the
+  three call sites at `:380`, `:476-477`, `:498`)
+- Test: `tests/test_rule_test_dialog.py` (existing, unchanged)
+
+**Interfaces:**
+- Consumes: `cell_display_text` from Task 1.
+
+A pure move — `_cell_text`'s body is character-identical to `cell_display_text`'s. The seventeen
+existing tests in `tests/test_rule_test_dialog.py` are the gate; add no new ones. (Note that file
+groups its tests in classes, unlike `tests/test_pandas_model.py` — you are adding nothing there,
+but do not let the two conventions bleed into each other.)
+
+- [ ] **Step 1: Delete the private copy**
+
+Remove `gui/rule_test_dialog.py:30-44` entirely — the `def _cell_text(value) -> str:` block and
+its docstring.
+
+- [ ] **Step 2: Import the shared function**
+
+`gui/rule_test_dialog.py:27` already reads `from gui.theme_manager import font_css,
+get_theme_manager`. Add above it:
+
+```python
+from gui.pandas_model import cell_display_text
+```
+
+**Keep `import pandas as pd` at `:13`.** It is still used at `:294` (`pd.Series(False, ...)`),
+verified before this plan was written — deleting it breaks the dialog. Ruff will confirm nothing
+went unused.
+
+- [ ] **Step 3: Update the three call sites**
+
+Rename `_cell_text(` to `cell_display_text(` at `:380`, `:476`, `:477` and `:498`:
+
+```bash
+.venv/bin/python - <<'PY'
+import pathlib
+p = pathlib.Path("gui/rule_test_dialog.py")
+p.write_text(p.read_text().replace("_cell_text(", "cell_display_text("))
+PY
+```
+
+Then confirm no stale references survive:
+
+Run: `grep -n "_cell_text" gui/rule_test_dialog.py`
+Expected: no output.
+
+- [ ] **Step 4: Run the dialog tests**
+
+Run: `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_rule_test_dialog.py -v`
+Expected: PASS, all pre-existing tests, no new failures.
+
+- [ ] **Step 5: Run the whole gate**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+.venv/bin/ruff check . --exclude shared
+```
+
+Expected: the full suite green — **675 tests: 670 on this branch's base (measured at
+`origin/main` before any of this work), plus the 5 added here**. Ruff clean. If the count
+differs, say so in the commit rather than adjusting the number to match.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/rule_test_dialog.py
+git commit -m "refactor: rule test dialog renders cells via the shared helper"
+```
+
+- [ ] **Step 7: Refresh the knowledge graph**
+
+```bash
+graphify update .
+```
+
+Per this repo's CLAUDE.md, run this immediately after the code changes land, not "eventually".
+Commit any resulting `graphify-out/` changes.
+
+---
+
+## Note for whoever reviews this at Stage C
+
+The one thing worth a second opinion is the judgment call in the Context section — the search
+filter now matches a lot cell's *displayed* text rather than its raw `repr`. Everything else is a
+move plus a one-line bug fix.
+
+Do not add the out-of-scope items listed above; they were considered and deferred on purpose.

--- a/gui/pandas_model.py
+++ b/gui/pandas_model.py
@@ -96,6 +96,9 @@ def cell_display_text(value) -> str:
     ``if`` on it raises "truth value of an array is ambiguous". Every caller
     that renders or searches cell text must go through here — a private copy
     is how that crash got reintroduced in the filter proxy.
+
+    Note the wording is column-agnostic: *any* list-valued cell renders as
+    "N lots". ``Lot_Details`` is the only such column today.
     """
     if isinstance(value, list):
         if not value:

--- a/gui/pandas_model.py
+++ b/gui/pandas_model.py
@@ -71,7 +71,7 @@ class FulfillmentFilterProxy(QSortFilterProxyModel):
         fold = (lambda s: s) if self._case_sensitive else str.casefold
         for c in col_indices:
             cell = df.iat[source_row, c]
-            hay = "" if pd.isna(cell) else str(cell)
+            hay = cell_display_text(cell)
             if self._needle in fold(hay):
                 return True
         return False

--- a/gui/pandas_model.py
+++ b/gui/pandas_model.py
@@ -88,6 +88,24 @@ def _format_lot(lot: dict) -> str:
     return f"{qty_str}x, {expiry_str}{batch_str}"
 
 
+def cell_display_text(value) -> str:
+    """Render one DataFrame cell as the text the user sees in a table.
+
+    The list check MUST come before ``pd.isna()``: ``Lot_Details`` holds real
+    Python lists, and ``pd.isna()`` on a list returns an *array*, so a plain
+    ``if`` on it raises "truth value of an array is ambiguous". Every caller
+    that renders or searches cell text must go through here — a private copy
+    is how that crash got reintroduced in the filter proxy.
+    """
+    if isinstance(value, list):
+        if not value:
+            return ""
+        return f"{len(value)} lot{'s' if len(value) != 1 else ''}"
+    if pd.isna(value):
+        return ""
+    return str(value)
+
+
 class PandasModel(QAbstractTableModel):
     """A Qt model to interface a pandas DataFrame with a QTableView.
 
@@ -179,19 +197,12 @@ class PandasModel(QAbstractTableModel):
             except IndexError:
                 return None
 
-            if isinstance(value, list):
-                if not value:
-                    return "" if role == Qt.ItemDataRole.DisplayRole else None
-                if role == Qt.ItemDataRole.DisplayRole:
-                    return f"{len(value)} lot{'s' if len(value) != 1 else ''}"
-                return "\n".join(_format_lot(lot) for lot in value)
-
             if role == Qt.ItemDataRole.ToolTipRole:
-                return None  # no tooltip for plain scalar cells
+                if isinstance(value, list) and value:
+                    return "\n".join(_format_lot(lot) for lot in value)
+                return None  # no tooltip for empty or plain scalar cells
 
-            if pd.isna(value):
-                return ""
-            return str(value)
+            return cell_display_text(value)
 
         if role == Qt.ItemDataRole.BackgroundRole:
             return self._row_bg_cache[row]

--- a/gui/rule_test_dialog.py
+++ b/gui/rule_test_dialog.py
@@ -24,24 +24,8 @@ from PySide6.QtWidgets import (
 )
 
 logger = logging.getLogger(__name__)
+from gui.pandas_model import cell_display_text
 from gui.theme_manager import font_css, get_theme_manager
-
-
-def _cell_text(value) -> str:
-    """Render one DataFrame cell the way the main analysis table renders it.
-
-    Mirrors gui/pandas_model.py:182-194, including its ordering: the list
-    check comes first because Lot_Details holds real lists, and pd.isna()
-    on a list returns an array, which makes a plain `if` raise
-    "truth value of an array is ambiguous".
-    """
-    if isinstance(value, list):
-        if not value:
-            return ""
-        return f"{len(value)} lot{'s' if len(value) != 1 else ''}"
-    if pd.isna(value):
-        return ""
-    return str(value)
 
 
 class RuleTestDialog(QDialog):
@@ -377,7 +361,7 @@ class RuleTestDialog(QDialog):
         for row_idx, (_, row) in enumerate(display_df.iterrows()):
             for col_idx, col_name in enumerate(display_cols):
                 value = row[col_name]
-                item = QTableWidgetItem(_cell_text(value))
+                item = QTableWidgetItem(cell_display_text(value))
                 self.preview_table.setItem(row_idx, col_idx, item)
 
         self.preview_table.resizeColumnsToContents()
@@ -473,8 +457,8 @@ class RuleTestDialog(QDialog):
                 # == "2 lots"), so an edit that swaps contents without changing
                 # the count would not tint. Unreachable today -- no action writes
                 # a list-valued column. Compare reprs if one ever does.
-                text_before = _cell_text(row_before[col_name])
-                text_after = _cell_text(row_after[col_name])
+                text_before = cell_display_text(row_before[col_name])
+                text_after = cell_display_text(row_after[col_name])
 
                 item = QTableWidgetItem(text_after)
 
@@ -495,7 +479,7 @@ class RuleTestDialog(QDialog):
         for offset, (_, row_added) in enumerate(added.iterrows()):
             row_idx = len(matched_after) + offset
             for col_idx, col_name in enumerate(display_cols):
-                item = QTableWidgetItem(_cell_text(row_added[col_name]))
+                item = QTableWidgetItem(cell_display_text(row_added[col_name]))
                 item.setBackground(QColor("#C8E6C9"))  # Green
                 item.setForeground(QColor("#000000"))
                 item.setToolTip("Added by rule")

--- a/tests/test_pandas_model.py
+++ b/tests/test_pandas_model.py
@@ -39,10 +39,12 @@ _TWO_LOTS = [
 ]
 
 
-def test_empty_lot_details_shows_blank_not_crash():
-    model = _model(None)
+@pytest.mark.parametrize("empty", [None, [], float("nan")])
+def test_empty_lot_details_shows_blank_and_no_tooltip(empty):
+    model = _model(empty)
     index = model.index(0, 1)
     assert model.data(index, Qt.ItemDataRole.DisplayRole) == ""
+    assert model.data(index, Qt.ItemDataRole.ToolTipRole) is None
 
 
 def test_single_lot_shows_count_and_tooltip_detail():

--- a/tests/test_pandas_model.py
+++ b/tests/test_pandas_model.py
@@ -13,7 +13,7 @@ import pytest
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
 
-from gui.pandas_model import PandasModel, cell_display_text
+from gui.pandas_model import FulfillmentFilterProxy, PandasModel, cell_display_text
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -24,6 +24,19 @@ def qapp():
 def _model(lot_details_value):
     df = pd.DataFrame({"SKU": ["A1"], "Lot_Details": [lot_details_value]})
     return PandasModel(df)
+
+
+def _lot_proxy(lots):
+    """Proxy over a frame whose *last* column holds a lot list, as analysis emits it."""
+    proxy = FulfillmentFilterProxy()
+    proxy.setSourceModel(PandasModel(pd.DataFrame({"SKU": ["A1"], "Lot_Details": [lots]})))
+    return proxy
+
+
+_TWO_LOTS = [
+    {"expiry": "261230", "expiry_dt": date(2026, 12, 30), "batch": "B1", "qty_allocated": 2.0},
+    {"expiry": "270101", "expiry_dt": date(2027, 1, 1), "batch": None, "qty_allocated": 1.0},
+]
 
 
 def test_empty_lot_details_shows_blank_not_crash():
@@ -86,3 +99,27 @@ def test_cell_display_text_counts_lots_without_raising():
     assert cell_display_text(lots) == "2 lots"
     assert cell_display_text(lots[:1]) == "1 lot"
     assert cell_display_text("A1") == "A1"
+
+
+def test_text_filter_over_a_multi_lot_row_does_not_raise():
+    """Regression: pd.isna(list) raised inside filterAcceptsRow.
+
+    The needle must match no earlier column, otherwise the column scan
+    short-circuits before it ever reaches the list cell -- which is why this
+    crash survived in production while ordinary searches looked fine.
+    """
+    proxy = _lot_proxy(_TWO_LOTS)
+    proxy.set_text_filter("zzz")
+    assert proxy.rowCount() == 0  # must not raise
+
+
+def test_text_filter_matches_a_lot_cell_by_its_displayed_text():
+    proxy = _lot_proxy(_TWO_LOTS)
+    proxy.set_text_filter("2 lots")
+    assert proxy.rowCount() == 1
+
+
+def test_text_filter_still_matches_plain_scalar_columns():
+    proxy = _lot_proxy(_TWO_LOTS)
+    proxy.set_text_filter("a1")  # case-insensitive by default
+    assert proxy.rowCount() == 1

--- a/tests/test_pandas_model.py
+++ b/tests/test_pandas_model.py
@@ -13,7 +13,7 @@ import pytest
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
 
-from gui.pandas_model import PandasModel
+from gui.pandas_model import PandasModel, cell_display_text
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -69,3 +69,20 @@ def test_plain_scalar_cell_still_renders_and_has_no_tooltip():
     index = model.index(0, 0)
     assert model.data(index, Qt.ItemDataRole.DisplayRole) == "A1"
     assert model.data(index, Qt.ItemDataRole.ToolTipRole) is None
+
+
+def test_cell_display_text_renders_empty_and_missing_as_blank():
+    assert cell_display_text(None) == ""
+    assert cell_display_text([]) == ""
+    assert cell_display_text(float("nan")) == ""
+
+
+def test_cell_display_text_counts_lots_without_raising():
+    """The list check must precede pd.isna(); see this module's docstring."""
+    lots = [
+        {"expiry": "261230", "expiry_dt": date(2026, 12, 30), "batch": "B1", "qty_allocated": 2.0},
+        {"expiry": "270101", "expiry_dt": date(2027, 1, 1), "batch": None, "qty_allocated": 1.0},
+    ]
+    assert cell_display_text(lots) == "2 lots"
+    assert cell_display_text(lots[:1]) == "1 lot"
+    assert cell_display_text("A1") == "A1"


### PR DESCRIPTION
## The bug

Typing in the analysis table's search box **crashes** on any lot-tracked analysis where at least one line has 2+ lots allocated.

`FulfillmentFilterProxy` built its search haystack as:

```python
hay = "" if pd.isna(cell) else str(cell)
```

`Lot_Details` cells hold real Python lists. `pd.isna()` on a 2+ element list returns a numpy **array**, and `if <array>:` raises `ValueError: The truth value of an array with more than one element is ambiguous`.

This is the same crash class as #276 — which fixed it at one caller (`PandasModel.data()`) and left this sibling caller broken. The column scan short-circuits on the first match, so it only fires once a search actually narrows the table far enough to reach the `Lot_Details` cell. That is why it survived in production: searching a term that matches an early column looks fine; searching one that doesn't, crashes.

Reproduced against the real classes, not argued: search `1001` → 1 row; search `zzz` → crash.

## The fix

One `cell_display_text(value) -> str` in `gui/pandas_model.py`, holding the load-bearing ordering (list check **before** `pd.isna`). All three copies now route through it:

| caller | was |
|---|---|
| `PandasModel.data()` | inline, correct |
| `FulfillmentFilterProxy` | inline, **wrong order → the crash** |
| `gui/rule_test_dialog.py::_cell_text` | private copy, correct |

Net-negative diff in the GUI code. `data()`'s Display/ToolTip restructure is behaviour-identical on all six paths (empty list, non-empty list, NaN, None, scalar × Display/ToolTip) — verified against the pre-change revision, and now pinned by tests.

## Accepted cost — please read before merging

The filter now matches a lot cell's **displayed** text (`"2 lots"`) rather than its raw `repr`. Batch numbers and expiry dates were previously in the search haystack via `str([{...}])`, and no longer are.

Batch/expiry exist **only** inside `Lot_Details` — there is no `Batch` or `Expiry_Date` column in the analysis frame — so this removes the only way to search a batch number anywhere in the table.

| dataset | before | after |
|---|---|---|
| analysis with any 2+-lot line | search **crashes** once it narrows | works; batch not searchable |
| analysis where every line is 1 lot | batch/expiry search worked | batch/expiry search returns 0 rows |

FIFO commonly draws a whole line from one lot, so the second row is a realistic dataset where a working (if accidental) capability goes away. Judged acceptable — a reliable crash is worse than an undiscoverable search, and the class docstring already promised display-text matching — but flagging it explicitly rather than burying it in the plan, because "I can't find a batch number any more" is the kind of thing that comes back as a bug report weeks later.

**If batch search matters**, the follow-up is one line: make the haystack for list cells the *tooltip* text (`"\n".join(_format_lot(lot) for lot in value)`) instead of the display text. That restores batch search *and* extends it to multi-lot rows, which never worked. Not a strict superset — `_format_lot` emits ISO `2026-12-30` where the old `repr` carried the raw `'261230'` — so it wants a moment's thought, not a drive-by change.

## Tests

7 new tests in `tests/test_pandas_model.py`, including the regression that reproduces the crash through the real `FulfillmentFilterProxy` + `PandasModel` pair. Verified they genuinely bite: reverting the one-line fix makes them fail with the real `ValueError`.

Gate: **677 passed**, `ruff check . --exclude shared` clean.

## Sibling sweep

Every `pd.isna(`/`pd.notna(` in `gui/` and `shopify_tool/` was checked for the same shape, since the premise here is that fixing one caller and leaving siblings is how this recurred. **No fourth broken copy exists.** The `Lot_Details` uses in `packing_lists.py` and `stock_export.py` are `Series.notna()`, which is element-wise and safe.

One thing worth a follow-up issue: the tag filter at `gui/pandas_model.py:58` has the same unguarded shape. It is **safe today** — `Internal_Tags` holds a serialized JSON string on every write path, verified — but `shopify_tool/barcode_processor.py:80-82` documents that it "is sometimes stored unserialized", and `tag_manager.py:78-80` already carries the same defensive list-check comment. Routing `:58` through `tag_manager.parse_tags` would close the class properly. Deliberately left out of this PR: `cell_display_text` is the wrong tool there (it would render a list as `"2 lots"` and break the quoted-token match).

## Plan

`docs/superpowers/plans/2026-08-16-cell-render-consolidation-plan.md` — 3 tasks, implemented as written, no deviations. No version bump, matching #281–#284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AF4nvLrs2e6FFvPjtZ7VSS