### PR TITLE
Repeat detection counts packed orders — and stops re-analysis destroying fulfilment dates

### DIFF
--- a/docs/superpowers/plans/2026-08-18-repeat-detection-packing-sync-plan.md
+++ b/docs/superpowers/plans/2026-08-18-repeat-detection-packing-sync-plan.md
@@ -1,0 +1,1030 @@
+# Repeat Detection: Union of Analysis History and Packed Orders — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mark an order "Repeat" when it was seen at least N days ago in *either* SFT's analysis history *or* Packing Tool's completed orders, and stop re-analysis from destroying the original fulfilment date.
+
+**Architecture:** Packing Tool records completed order numbers into the `packing_progress` block it already writes into SFT's `session_info.json`; SFT reads them back from the per-client `session_index.json` it already caches, unions them with `fulfillment_history.csv` (earliest date per order wins), and feeds the union to the existing `_detect_repeated_orders`, which does not change. The union is used for detection only and is never written back to `fulfillment_history.csv`.
+
+**Tech Stack:** Python 3, pandas, pytest. PySide6 is not involved — no GUI code changes.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-repeat-detection-packing-sync-design.md`
+
+## Global Constraints
+
+- Two repos. Tasks 1–3 are in `shopify-fulfillment-tool`; Task 4 is in `../packing-tool`. They ship as **two separate PRs**.
+- **Never hand-edit `shared/`** in `shopify-fulfillment-tool` — it is one-way synced from `../packing-tool`. This plan does not change `shared/` in either repo.
+- Order numbers are **strings** and are **not numeric** (`#11019512`, and `#BG1086` for CLIENT_WATERDROP). Never coerce them to int. No normalisation is needed — the format is already identical on both sides.
+- Reading the packing signal is **best-effort**: any failure logs and yields an empty result. Analysis must never fail because Packing Tool data is missing or malformed.
+- Gate for `shopify-fulfillment-tool`, run from the worktree root:
+  `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest` and `.venv/bin/ruff check . --exclude shared`
+- Gate for `packing-tool`: `python -m pytest` (see its own `CLAUDE.md`).
+- Baseline before this plan: **727 passed** on `worktree-repeat-detection-packing-sync`.
+- Every commit ends with these two trailers, verbatim:
+
+```
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011ryEQFDt4aqFcUeFFhkz9c
+```
+
+- `python` and `ruff` are **not** on PATH on this machine. Always use `.venv/bin/python` and `.venv/bin/ruff`.
+- After the last task in a repo, run `graphify update .` in that repo.
+
+---
+
+## File Structure
+
+| File | Repo | Responsibility |
+|---|---|---|
+| `shopify_tool/core.py` | SFT | Modify: extract `_merge_fulfillment_history`, fix the clobber, wire the union into the analysis call |
+| `shopify_tool/packed_orders.py` | SFT | **Create**: read Packing Tool's completed orders; union them with analysis history |
+| `tests/test_core.py` | SFT | Modify: regression test pinning the preserved `Execution_Date` |
+| `tests/test_packed_orders.py` | SFT | **Create**: loader and union tests |
+| `src/session_manager.py` | packing-tool | Modify: `update_session_metadata` records order numbers under a lock |
+| `src/main.py` | packing-tool | Modify: pass packed order numbers at the one `'completed'` call site |
+| `tests/test_session_metadata_orders.py` | packing-tool | **Create**: writer tests |
+
+---
+
+## Task 1: Stop re-analysis destroying the original fulfilment date
+
+Independent of everything else — fixes a live data-loss bug and ships value on its own.
+
+**Files:**
+- Modify: `shopify_tool/core.py` (the history write in `_save_results_and_reports`, currently at `:1041-1049`)
+- Test: `tests/test_core.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `shopify_tool.core._merge_fulfillment_history(history_df: pd.DataFrame, newly_fulfilled: pd.DataFrame) -> pd.DataFrame` — used by no later task, but Task 3's reviewer will compare it against the union helper.
+
+**Why extract a helper for a one-word fix:** the current merge is buried inside `_save_results_and_reports`, which takes 13 arguments and performs Excel/JSON/session file IO. There is no seam to test the merge through. A four-line pure helper makes a permanent-data-loss path unit-testable; that is the reason to extract it, and the only reason.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_core.py`:
+
+```python
+class TestFulfillmentHistoryMerge:
+    """The merge must preserve each order's ORIGINAL Execution_Date.
+
+    fulfillment_history.csv is the only record of when an order was first
+    fulfilled. Overwriting that date loses it permanently and silently
+    clears the order's "Repeat" flag.
+    """
+
+    def test_reanalysis_preserves_original_execution_date(self):
+        from shopify_tool.core import _merge_fulfillment_history
+
+        history = pd.DataFrame({
+            "Order_Number": ["#11014590", "#11014599"],
+            "Execution_Date": ["2025-11-27", "2025-11-27"],
+        })
+        # A re-analysis today finds #11014590 still Fulfillable.
+        newly_fulfilled = pd.DataFrame({
+            "Order_Number": ["#11014590"],
+            "Execution_Date": ["2026-08-18"],
+        })
+
+        merged = _merge_fulfillment_history(history, newly_fulfilled)
+        dates = dict(zip(merged["Order_Number"], merged["Execution_Date"]))
+
+        assert dates["#11014590"] == "2025-11-27", (
+            "re-analysis overwrote the original fulfilment date"
+        )
+        assert dates["#11014599"] == "2025-11-27"
+
+    def test_genuinely_new_order_is_added(self):
+        from shopify_tool.core import _merge_fulfillment_history
+
+        history = pd.DataFrame({
+            "Order_Number": ["#11014590"],
+            "Execution_Date": ["2025-11-27"],
+        })
+        newly_fulfilled = pd.DataFrame({
+            "Order_Number": ["#99999"],
+            "Execution_Date": ["2026-08-18"],
+        })
+
+        merged = _merge_fulfillment_history(history, newly_fulfilled)
+        dates = dict(zip(merged["Order_Number"], merged["Execution_Date"]))
+
+        assert dates["#99999"] == "2026-08-18"
+        assert dates["#11014590"] == "2025-11-27"
+
+    def test_empty_history_accepts_all_new_orders(self):
+        from shopify_tool.core import _merge_fulfillment_history
+
+        history = pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+        newly_fulfilled = pd.DataFrame({
+            "Order_Number": ["#1", "#2"],
+            "Execution_Date": ["2026-08-18", "2026-08-18"],
+        })
+
+        merged = _merge_fulfillment_history(history, newly_fulfilled)
+        assert set(merged["Order_Number"]) == {"#1", "#2"}
+```
+
+`tests/test_core.py` already imports pandas as `pd`; confirm before adding.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_core.py::TestFulfillmentHistoryMerge -v
+```
+
+Expected: FAIL — `ImportError: cannot import name '_merge_fulfillment_history'`.
+
+- [ ] **Step 3: Add the helper**
+
+Add to `shopify_tool/core.py`, immediately above `_save_results_and_reports`:
+
+```python
+def _merge_fulfillment_history(
+    history_df: pd.DataFrame, newly_fulfilled: pd.DataFrame
+) -> pd.DataFrame:
+    """Merge newly fulfilled orders into history, keeping the ORIGINAL date.
+
+    keep="first" is load-bearing. `newly_fulfilled` is concatenated after
+    `history_df` and carries today's date, so keep="last" would overwrite
+    each order's original Execution_Date on every re-analysis -- destroying
+    the only record of when it was first fulfilled, and silently clearing
+    its "Repeat" flag.
+    """
+    return pd.concat([history_df, newly_fulfilled]).drop_duplicates(
+        subset=["Order_Number"], keep="first"
+    )
+```
+
+- [ ] **Step 4: Call it from the write path**
+
+In `_save_results_and_reports`, replace:
+
+```python
+        updated_history = pd.concat([history_df, newly_fulfilled]).drop_duplicates(
+            subset=["Order_Number"], keep="last"
+        )
+```
+
+with:
+
+```python
+        updated_history = _merge_fulfillment_history(history_df, newly_fulfilled)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_core.py -v
+```
+
+Expected: PASS, including the three new tests.
+
+- [ ] **Step 6: Run the full suite**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+```
+
+Expected: 730 passed. If anything else fails, a pre-existing test encoded the old clobber behaviour — read it before changing it, and say so in the commit.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shopify_tool/core.py tests/test_core.py
+git commit -F - <<'EOF'
+Fix: re-analysis destroyed each order's original fulfilment date
+
+The history merge used drop_duplicates(keep="last"). newly_fulfilled is
+concatenated after history_df and carries today's date, so every
+re-analysis overwrote the original Execution_Date of every order still
+Fulfillable. fulfillment_history.csv is the only record of that date, so
+the loss was permanent -- and _detect_repeated_orders then saw a fresh
+date and silently dropped the order's "Repeat" flag.
+
+Extracted the merge into _merge_fulfillment_history so the path has a
+test seam at all; it previously sat inside a 13-argument function that
+also does Excel and session file IO.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011ryEQFDt4aqFcUeFFhkz9c
+EOF
+```
+
+---
+
+## Task 2: Read Packing Tool's completed orders
+
+**Files:**
+- Create: `shopify_tool/packed_orders.py`
+- Test: `tests/test_packed_orders.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - `load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame` — columns `["Order_Number", "Execution_Date"]`, `Execution_Date` as `YYYY-MM-DD` strings. Returns an empty frame with those columns on any failure. Never raises.
+  - `union_history_with_packed(history_df: pd.DataFrame, packed_df: pd.DataFrame) -> pd.DataFrame` — same columns; earliest date per order wins. Used by Task 3.
+
+**Shape of the data being read.** Confirmed against live server data. Each client has `Sessions/CLIENT_<ID>/session_index.json` containing a JSON **list** of session entries. An entry that has been packed carries:
+
+```json
+{
+  "session_name": "2026-07-26_2",
+  "packing_progress": {
+    "ALL_ORDERS_ALMADERM": {
+      "started_at": "2026-07-26T18:25:33.932024+00:00",
+      "status": "completed",
+      "updated_at": "2026-07-26T18:41:02.115000+00:00",
+      "completed_orders": ["#11019512", "#11019513"]
+    }
+  }
+}
+```
+
+`completed_orders` is written by Task 4. Entries written before Task 4 ships have a `packing_progress` block with **no** `completed_orders` key — that is the normal case at first run, not an error.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_packed_orders.py`:
+
+```python
+import json
+
+import pandas as pd
+import pytest
+
+from shopify_tool.packed_orders import load_packed_orders, union_history_with_packed
+
+
+class _FakeProfileManager:
+    """Minimal stand-in exposing only what load_packed_orders uses."""
+
+    def __init__(self, sessions_root):
+        self._sessions_root = sessions_root
+
+    def get_sessions_root(self):
+        return self._sessions_root
+
+
+def _write_index(tmp_path, client_id, entries):
+    client_dir = tmp_path / f"CLIENT_{client_id}"
+    client_dir.mkdir(parents=True, exist_ok=True)
+    (client_dir / "session_index.json").write_text(
+        json.dumps(entries), encoding="utf-8"
+    )
+    return _FakeProfileManager(tmp_path)
+
+
+class TestLoadPackedOrders:
+    def test_reads_completed_orders_with_packing_date(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-26_2",
+                "packing_progress": {
+                    "ALL_ORDERS": {
+                        "started_at": "2026-07-26T18:25:33+00:00",
+                        "updated_at": "2026-07-28T09:10:00+00:00",
+                        "status": "completed",
+                        "completed_orders": ["#11019512", "#11019513"],
+                    }
+                },
+            }
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+
+        assert list(df.columns) == ["Order_Number", "Execution_Date"]
+        assert dict(zip(df["Order_Number"], df["Execution_Date"])) == {
+            "#11019512": "2026-07-28",
+            "#11019513": "2026-07-28",
+        }
+
+    def test_falls_back_to_started_at_when_no_updated_at(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-26_2",
+                "packing_progress": {
+                    "ALL_ORDERS": {
+                        "started_at": "2026-07-26T18:25:33+00:00",
+                        "status": "completed",
+                        "completed_orders": ["#A"],
+                    }
+                },
+            }
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert df.iloc[0]["Execution_Date"] == "2026-07-26"
+
+    def test_collects_across_sessions_and_packing_lists(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-01_1",
+                "packing_progress": {
+                    "LIST_A": {"updated_at": "2026-07-01T10:00:00+00:00",
+                               "completed_orders": ["#A"]},
+                    "LIST_B": {"updated_at": "2026-07-01T11:00:00+00:00",
+                               "completed_orders": ["#B"]},
+                },
+            },
+            {
+                "session_name": "2026-07-02_1",
+                "packing_progress": {
+                    "LIST_C": {"updated_at": "2026-07-02T10:00:00+00:00",
+                               "completed_orders": ["#C"]},
+                },
+            },
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert set(df["Order_Number"]) == {"#A", "#B", "#C"}
+
+    def test_same_order_packed_twice_keeps_earliest(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "2026-07-05_1", "packing_progress": {
+                "L": {"updated_at": "2026-07-05T10:00:00+00:00",
+                      "completed_orders": ["#A"]}}},
+            {"session_name": "2026-07-01_1", "packing_progress": {
+                "L": {"updated_at": "2026-07-01T10:00:00+00:00",
+                      "completed_orders": ["#A"]}}},
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert len(df) == 1
+        assert df.iloc[0]["Execution_Date"] == "2026-07-01"
+
+    # --- degradation: each of these must return empty, not raise ---
+
+    def test_entry_without_completed_orders_key_is_skipped(self, tmp_path):
+        """The normal case before Task 4 ships -- not an error."""
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-26_2",
+                "packing_progress": {
+                    "ALL_ORDERS": {
+                        "started_at": "2026-07-26T18:25:33+00:00",
+                        "status": "in_progress",
+                    }
+                },
+            }
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert df.empty
+        assert list(df.columns) == ["Order_Number", "Execution_Date"]
+
+    def test_entry_without_packing_progress_is_skipped(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "2026-07-26_1", "status": "active"}
+        ])
+        assert load_packed_orders(pm, "ALMADERM").empty
+
+    def test_missing_index_file_returns_empty(self, tmp_path):
+        assert load_packed_orders(_FakeProfileManager(tmp_path), "NOSUCH").empty
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        client_dir = tmp_path / "CLIENT_ALMADERM"
+        client_dir.mkdir(parents=True)
+        (client_dir / "session_index.json").write_text("{not json", encoding="utf-8")
+
+        assert load_packed_orders(_FakeProfileManager(tmp_path), "ALMADERM").empty
+
+    def test_unparseable_timestamp_is_skipped_without_raising(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "s", "packing_progress": {
+                "L": {"updated_at": "not-a-date", "completed_orders": ["#A"]}}},
+        ])
+        assert load_packed_orders(pm, "ALMADERM").empty
+
+    def test_client_id_is_case_insensitive(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "s", "packing_progress": {
+                "L": {"updated_at": "2026-07-01T10:00:00+00:00",
+                      "completed_orders": ["#A"]}}},
+        ])
+        assert not load_packed_orders(pm, "almaderm").empty
+
+
+class TestUnionHistoryWithPacked:
+    def test_order_in_both_sources_keeps_earlier_date(self):
+        history = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-10"]})
+        packed = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+
+        out = union_history_with_packed(history, packed)
+        assert len(out) == 1
+        assert out.iloc[0]["Execution_Date"] == "2026-07-01"
+
+    def test_order_in_both_sources_keeps_earlier_date_when_history_is_earlier(self):
+        history = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+        packed = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-10"]})
+
+        out = union_history_with_packed(history, packed)
+        assert len(out) == 1
+        assert out.iloc[0]["Execution_Date"] == "2026-07-01"
+
+    def test_packed_only_order_is_included(self):
+        history = pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+        packed = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+
+        out = union_history_with_packed(history, packed)
+        assert set(out["Order_Number"]) == {"#A"}
+
+    def test_history_only_order_survives_empty_packed(self):
+        """The no-cliff guarantee: the analysis signal keeps working when
+        Packing Tool has contributed nothing yet."""
+        history = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+        packed = pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+
+        out = union_history_with_packed(history, packed)
+        assert dict(zip(out["Order_Number"], out["Execution_Date"])) == {"#A": "2026-07-01"}
+
+    def test_both_empty_returns_empty_with_expected_columns(self):
+        empty = pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+        out = union_history_with_packed(empty, empty)
+        assert out.empty
+        assert list(out.columns) == ["Order_Number", "Execution_Date"]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_packed_orders.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'shopify_tool.packed_orders'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `shopify_tool/packed_orders.py`:
+
+```python
+"""Read the orders Packing Tool has finished packing.
+
+Packing Tool records the order numbers it completed into the
+`packing_progress` block of each session's `session_info.json`, which this
+repo mirrors into the per-client `session_index.json` cache. Reading that
+one file per client avoids walking the session tree on the network share.
+
+Everything here is best-effort by contract: a missing file, malformed JSON
+or an old-format entry yields an empty result and a log line. Repeat
+detection then degrades to using analysis history alone. An analysis must
+never fail because the packing signal is unavailable -- the warehouse can
+still ship.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+COLUMNS = ["Order_Number", "Execution_Date"]
+
+INDEX_FILENAME = "session_index.json"
+
+
+def _empty() -> pd.DataFrame:
+    return pd.DataFrame(columns=COLUMNS)
+
+
+def load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
+    """Order numbers Packing Tool has completed, with the date packed.
+
+    Args:
+        profile_manager: provides get_sessions_root()
+        client_id: client identifier, case-insensitive
+
+    Returns:
+        DataFrame with columns [Order_Number, Execution_Date] (dates as
+        YYYY-MM-DD strings), earliest date per order. Empty on any failure.
+    """
+    if not profile_manager or not client_id:
+        return _empty()
+
+    try:
+        sessions_root = Path(profile_manager.get_sessions_root())
+        index_path = sessions_root / f"CLIENT_{client_id.upper()}" / INDEX_FILENAME
+        if not index_path.exists():
+            logger.debug(f"No session index for packed orders: {index_path}")
+            return _empty()
+        entries = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError, AttributeError):
+        logger.exception("Could not read packed orders; repeat detection will use analysis history only")
+        return _empty()
+
+    if not isinstance(entries, list):
+        logger.warning("Session index is not a list; ignoring packed orders")
+        return _empty()
+
+    rows = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        progress = entry.get("packing_progress")
+        if not isinstance(progress, dict):
+            continue
+        for block in progress.values():
+            if not isinstance(block, dict):
+                continue
+            orders = block.get("completed_orders")
+            if not orders:
+                # Written before completed_orders existed, or nothing packed.
+                continue
+            packed_date = _to_date(block.get("updated_at") or block.get("started_at"))
+            if packed_date is None:
+                continue
+            rows.extend(
+                {"Order_Number": str(o), "Execution_Date": packed_date}
+                for o in orders
+                if o
+            )
+
+    if not rows:
+        return _empty()
+
+    df = pd.DataFrame(rows, columns=COLUMNS)
+    df = df.sort_values("Execution_Date").drop_duplicates(
+        subset=["Order_Number"], keep="first"
+    )
+    logger.info(f"Loaded {len(df)} packed orders for repeat detection ({client_id})")
+    return df.reset_index(drop=True)
+
+
+def _to_date(timestamp) -> str | None:
+    """ISO timestamp -> 'YYYY-MM-DD', or None if unparseable."""
+    if not timestamp:
+        return None
+    parsed = pd.to_datetime(timestamp, errors="coerce", utc=True)
+    if pd.isna(parsed):
+        return None
+    return parsed.strftime("%Y-%m-%d")
+
+
+def union_history_with_packed(
+    history_df: pd.DataFrame, packed_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Combine analysis history with packed orders, earliest date per order.
+
+    An order is a repeat if it was seen at least N days ago in EITHER
+    source, so the earliest sighting is the one that matters. The result is
+    for detection only -- it must never be written to
+    fulfillment_history.csv, which is this repo's own record of what it
+    analyzed.
+    """
+    frames = [f for f in (history_df, packed_df) if f is not None and not f.empty]
+    if not frames:
+        return _empty()
+
+    combined = pd.concat(frames, ignore_index=True)[COLUMNS]
+    combined = combined.sort_values("Execution_Date").drop_duplicates(
+        subset=["Order_Number"], keep="first"
+    )
+    return combined.reset_index(drop=True)
+```
+
+**Note on `sort_values` for date strings:** `YYYY-MM-DD` sorts correctly lexicographically, so no datetime conversion is needed here. `_to_date` guarantees that format; `fulfillment_history.csv` uses it too (verified in live data).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_packed_orders.py -v
+```
+
+Expected: PASS, all of them.
+
+- [ ] **Step 5: Re-confirm the fake matches the real ProfileManager API**
+
+A fake that drifts from the real API gives green tests over broken production code:
+
+```bash
+grep -n "def get_sessions_root" shopify_tool/profile_manager.py
+```
+
+Expected: one match at `:1423`, `def get_sessions_root(self) -> Path:` (verified while
+writing this plan). If it has moved or been renamed, fix `packed_orders.py` **and**
+`_FakeProfileManager` together, then re-run Step 4.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+.venv/bin/ruff check . --exclude shared
+git add shopify_tool/packed_orders.py tests/test_packed_orders.py
+git commit -F - <<'EOF'
+Add packed-orders reader for repeat detection
+
+Reads the order numbers Packing Tool completed from the per-client
+session_index.json this repo already caches, rather than walking
+*/packing/*/packing_state.json across the network share.
+
+Best-effort by contract: a missing file, malformed JSON, an unparseable
+timestamp or an entry predating completed_orders all yield an empty frame
+and a log line, so an analysis never fails because the packing signal is
+unavailable.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011ryEQFDt4aqFcUeFFhkz9c
+EOF
+```
+
+---
+
+## Task 3: Feed the union into repeat detection
+
+**Files:**
+- Modify: `shopify_tool/core.py` (around `:1216-1252`)
+- Test: `tests/test_analysis.py` (verify unchanged), `tests/test_packed_orders.py` (already covers the union)
+
+**Interfaces:**
+- Consumes: `load_packed_orders`, `union_history_with_packed` from Task 2.
+- Produces: nothing for later tasks.
+
+**The critical constraint:** `history_df` feeds **two** consumers in `run_full_analysis` — `_run_analysis_and_rules` (detection) and `_save_results_and_reports` (the CSV write-back). Only the **detection** one gets the union. Passing the union to the writer would write packing-derived rows into `fulfillment_history.csv`, changing what that file means and letting one tool's data silently become the other's.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `shopify_tool/core.py`, with the other `shopify_tool` imports:
+
+```python
+from shopify_tool.packed_orders import load_packed_orders, union_history_with_packed
+```
+
+Match the existing import style in that file — check whether siblings use `from shopify_tool.x import` or `from .x import` and follow it.
+
+- [ ] **Step 2: Build the union and pass it to analysis only**
+
+In `run_full_analysis`, after the `history_df = _load_history_data(...)` block (Step 3, around `:1218`), add:
+
+```python
+        # Repeat detection also counts orders Packing Tool has already packed.
+        # Detection only -- history_df below is what gets written back to
+        # fulfillment_history.csv, and must stay this repo's own record.
+        packed_df = load_packed_orders(profile_manager, client_id)
+        detection_history_df = union_history_with_packed(history_df, packed_df)
+```
+
+Then change the analysis call (around `:1251`) from:
+
+```python
+            _run_analysis_and_rules(orders_df, stock_df, history_df, config)
+```
+
+to:
+
+```python
+            _run_analysis_and_rules(orders_df, stock_df, detection_history_df, config)
+```
+
+**Leave the `history_df` argument to `_save_results_and_reports` (around `:1262`) exactly as it is.**
+
+- [ ] **Step 3: Verify the write-back still receives the un-unioned frame**
+
+```bash
+grep -n "detection_history_df\|history_df," shopify_tool/core.py | sed -n '1,40p'
+```
+
+Confirm by eye: `_run_analysis_and_rules` gets `detection_history_df`; `_save_results_and_reports` gets `history_df`. This is the single most important line in the task — a reviewer should be able to check it in one glance.
+
+- [ ] **Step 4: Run the existing repeat-detection tests unmodified**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/test_analysis.py::TestRepeatDetection -v
+```
+
+Expected: PASS, with **no edits** to those tests. They are the proof the analysis path is unchanged. If one fails, stop — the union changed behaviour for the analysis-only case, which it must not.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest
+```
+
+Expected: 745 passed (727 baseline + 3 from Task 1 + 15 from Task 2).
+
+- [ ] **Step 6: Lint, update the graph, and commit**
+
+```bash
+.venv/bin/ruff check . --exclude shared
+graphify update .
+git add shopify_tool/core.py
+git commit -F - <<'EOF'
+Count packed orders when detecting repeats
+
+run_full_analysis now unions Packing Tool's completed orders into the
+frame handed to _detect_repeated_orders, so an order counts as a repeat
+if it was seen >= N days ago in either source.
+
+_detect_repeated_orders is unchanged -- it already takes an
+[Order_Number, Execution_Date] frame, so the union needs no new parameter
+and no second code path.
+
+The union is detection-only. _save_results_and_reports still receives the
+un-unioned history_df: fulfillment_history.csv stays this repo's own
+record of what it analyzed.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011ryEQFDt4aqFcUeFFhkz9c
+EOF
+```
+
+---
+
+## Task 4: Packing Tool records the order numbers it packed
+
+**Repo: `../packing-tool`.** Separate branch, separate PR. Until this ships, Tasks 1–3 run correctly and simply find no packed orders.
+
+**Files:**
+- Modify: `src/session_manager.py:671-714` (`update_session_metadata`)
+- Modify: `src/main.py:1767` (the one `'completed'` call site)
+- Test: `tests/test_session_metadata_orders.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `completed_orders: list[str]` inside `session_info.json`'s `packing_progress[<list name>]`, which Task 2's `load_packed_orders` reads.
+
+**Two pre-verified constraints:**
+
+1. **The new parameter must be optional.** `tests/test_metadata_utils.py:81` calls `update_session_metadata(str(tmp_path), "DHL_Orders", "in_progress")` with exactly three positional arguments. A required fourth breaks it.
+2. **Only the `'completed'` call site passes orders.** `src/main.py:1438` and `:2346` fire at list-load time with `'in_progress'` — nothing is packed yet. Leave both unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_session_metadata_orders.py`:
+
+```python
+import json
+
+from session_manager import SessionManager
+
+
+def _mgr():
+    return SessionManager(
+        client_id="ALMADERM",
+        profile_manager=None,
+        lock_manager=None,
+        worker_id="worker_001",
+        worker_name="test",
+    )
+
+
+def _seed_session_info(tmp_path):
+    (tmp_path / "session_info.json").write_text(
+        json.dumps({"session_name": "2026-08-18_1", "client_id": "ALMADERM"}),
+        encoding="utf-8",
+    )
+
+
+def _read(tmp_path):
+    return json.loads((tmp_path / "session_info.json").read_text(encoding="utf-8"))
+
+
+def test_completed_orders_are_recorded(tmp_path):
+    _seed_session_info(tmp_path)
+
+    _mgr().update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed",
+        completed_orders=["#11019512", "#11019513"],
+    )
+
+    block = _read(tmp_path)["packing_progress"]["ALL_ORDERS"]
+    assert block["completed_orders"] == ["#11019512", "#11019513"]
+    assert block["status"] == "completed"
+
+
+def test_call_without_orders_still_works(tmp_path):
+    """Pre-existing three-argument callers must keep working."""
+    _seed_session_info(tmp_path)
+
+    _mgr().update_session_metadata(str(tmp_path), "ALL_ORDERS", "in_progress")
+
+    block = _read(tmp_path)["packing_progress"]["ALL_ORDERS"]
+    assert block["status"] == "in_progress"
+    assert "completed_orders" not in block
+
+
+def test_orders_are_merged_not_replaced_across_calls(tmp_path):
+    """A resumed session must not lose orders packed before the resume."""
+    _seed_session_info(tmp_path)
+    mgr = _mgr()
+
+    mgr.update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#A"]
+    )
+    mgr.update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#B"]
+    )
+
+    block = _read(tmp_path)["packing_progress"]["ALL_ORDERS"]
+    assert sorted(block["completed_orders"]) == ["#A", "#B"]
+
+
+def test_other_keys_in_session_info_are_preserved(tmp_path):
+    _seed_session_info(tmp_path)
+
+    _mgr().update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#A"]
+    )
+
+    data = _read(tmp_path)
+    assert data["session_name"] == "2026-08-18_1"
+    assert data["client_id"] == "ALMADERM"
+
+
+def test_missing_session_info_does_not_raise(tmp_path):
+    _mgr().update_session_metadata(
+        str(tmp_path), "ALL_ORDERS", "completed", completed_orders=["#A"]
+    )
+    assert not (tmp_path / "session_info.json").exists()
+```
+
+Check `SessionManager.__init__`'s real signature before running — adjust `_mgr()` to match if it differs.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+python -m pytest tests/test_session_metadata_orders.py -v
+```
+
+Expected: FAIL — `update_session_metadata() got an unexpected keyword argument 'completed_orders'`.
+
+- [ ] **Step 3: Extend `update_session_metadata`**
+
+In `src/session_manager.py`, change the signature and body. Add `completed_orders` as an **optional keyword argument**, merge rather than replace, and take the same lock SFT uses on this file:
+
+```python
+    def update_session_metadata(
+        self,
+        session_path: str,
+        packing_list_name: str,
+        status: str,
+        completed_orders: list[str] | None = None,
+    ):
+        """
+        Update Shopify session metadata with packing progress.
+
+        Updates session_info.json with packing status for tracking.
+        This is a non-critical operation - failures are logged but don't stop execution.
+
+        Args:
+            session_path: Path to Shopify session
+            packing_list_name: Name of packing list
+            status: Status ('in_progress', 'completed', 'paused')
+            completed_orders: Order numbers packed in this session, if any.
+                The Shopify tool reads these back for repeat-order detection.
+                Merged with any already recorded, so resuming a session does
+                not drop orders packed before the resume.
+        """
+        session_info_file = Path(session_path) / SESSION_INFO_FILE
+
+        if not session_info_file.exists():
+            logger.warning(f"session_info.json not found: {session_path}")
+            return
+
+        try:
+            # The Shopify tool guards this same file with an exclusive lock on
+            # the sidecar .lock (its SessionManager._locked_session_info). Take
+            # the same lock: without it, its read-modify-write and ours can
+            # interleave and silently drop one side's changes.
+            lock_path = session_info_file.with_name(SESSION_INFO_FILE + ".lock")
+            with open(lock_path, "a+") as lock_handle, locked_file(lock_handle):
+                with open(session_info_file, 'r', encoding='utf-8') as f:
+                    session_info = json.load(f)
+
+                if 'packing_progress' not in session_info:
+                    session_info['packing_progress'] = {}
+
+                block = session_info['packing_progress'].setdefault(
+                    packing_list_name, {'started_at': get_current_timestamp()}
+                )
+                block['status'] = status
+                block['updated_at'] = get_current_timestamp()
+
+                if completed_orders:
+                    merged = list(block.get('completed_orders', []))
+                    merged.extend(o for o in completed_orders if o not in merged)
+                    block['completed_orders'] = merged
+
+                atomic_write_json(
+                    session_info_file, session_info, indent=2, ensure_ascii=False
+                )
+
+            logger.info(f"Updated session metadata: {packing_list_name} -> {status}")
+
+        except Exception as e:
+            logger.warning(f"Could not update session metadata: {e}")
+```
+
+Add the import at the top of `src/session_manager.py` if not already present:
+
+```python
+from shared.file_lock import locked_file
+```
+
+`locked_file` is a `@contextmanager` taking an already-open file handle (verified in
+`shared/file_lock.py:26`). It raises `FileLockError` if the lock is not acquired within
+5 seconds; the surrounding `except Exception` turns that into a warning, so a contended
+lock degrades to "metadata not updated" and never interrupts packing. That is the right
+trade here — the packer must keep working — but it means a lost update is still possible
+under sustained contention. Acceptable: the analysis signal covers those orders.
+
+**Behaviour change to note in review:** the original only set `started_at` on first write and only set `updated_at` on subsequent writes. The version above always sets `updated_at`, which `load_packed_orders` prefers when dating packed orders. `started_at` is still written once, on creation.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+python -m pytest tests/test_session_metadata_orders.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Confirm the pre-existing three-argument test still passes**
+
+```bash
+python -m pytest tests/test_metadata_utils.py -v
+```
+
+Expected: PASS, unmodified. It pins that `update_session_metadata` writes a timezone-aware timestamp — `get_current_timestamp()` is still used, so this must stay green.
+
+- [ ] **Step 6: Pass the order numbers at the `'completed'` call site**
+
+In `src/main.py` around `:1767`, change:
+
+```python
+                            _sess_mgr.update_session_metadata(
+                                _cur_sess_path, _cur_pack_list, 'completed'
+                            )
+```
+
+to:
+
+```python
+                            _sess_mgr.update_session_metadata(
+                                _cur_sess_path,
+                                _cur_pack_list,
+                                'completed',
+                                completed_orders=list(
+                                    _logic_ref.session_packing_state.get(
+                                        'completed_orders', []
+                                    )
+                                ) if _logic_ref else None,
+                            )
+```
+
+`_logic_ref` is bound to `self.logic` at `:1679`, in scope here. `packer_logic._load_session_state()` normalises `session_packing_state['completed_orders']` to a list of order-number **strings** in all three of its format branches, so no format handling is needed here.
+
+**Do not touch `:1438` or `:2346`** — both fire with `'in_progress'` before anything is packed.
+
+- [ ] **Step 7: Run the full packing-tool suite**
+
+```bash
+python -m pytest
+```
+
+Expected: all pass. Record the count for the PR body.
+
+- [ ] **Step 8: Update the graph and commit**
+
+```bash
+graphify update .
+git add src/session_manager.py src/main.py tests/test_session_metadata_orders.py
+git commit -F - <<'EOF'
+Record packed order numbers for the Shopify tool's repeat detection
+
+update_session_metadata now accepts the order numbers packed in a session
+and stores them in the packing_progress block it already writes into the
+Shopify tool's session_info.json. That tool reads them back to flag an
+order as a repeat when it was actually packed, not merely analyzed.
+
+The parameter is optional: the two 'in_progress' call sites fire before
+anything is packed and are unchanged, and the existing three-argument
+test keeps passing.
+
+Orders are merged rather than replaced, so resuming a session does not
+drop orders packed before the resume.
+
+Also takes the sidecar .lock around the read-modify-write. The Shopify
+tool already guards this same file that way; without it the two tools'
+updates can interleave and silently drop one side's changes -- which now
+costs order numbers, not just a status field.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_011ryEQFDt4aqFcUeFFhkz9c
+EOF
+```
+
+---
+
+## Self-review notes for the implementer
+
+- **Grep for stragglers after every edit.** The "Files" table above is a best
+  effort, not proof of the full surface area. After Task 3, run
+  `grep -rn "history_df" shopify_tool/` and confirm every call site got the
+  frame it should have.
+- **Run the full suite after every task, not just the task's own tests.** A
+  pre-existing test can encode an assumption a change deliberately breaks;
+  that has happened on this repo before.
+- **Do not "fix" `_detect_repeated_orders`.** Its docstring contains a
+  visible "Wait, correction based on user requirement:" mid-sentence and some
+  confusing worked examples. It is ugly and it is out of scope — the function's
+  behaviour is pinned by `TestRepeatDetection` and must not change in this plan.

--- a/docs/superpowers/specs/2026-08-18-repeat-detection-packing-sync-design.md
+++ b/docs/superpowers/specs/2026-08-18-repeat-detection-packing-sync-design.md
@@ -191,7 +191,16 @@ def load_packed_orders(profile_manager, client_id) -> pd.DataFrame:
 
 Reads the client's `session_index.json` via the existing session-listing path,
 walks each entry's `packing_progress` blocks, and emits one row per completed
-order number dated by that block's `updated_at` (falling back to `started_at`).
+order number dated by that block's `started_at` (falling back to `updated_at`).
+
+**Why `started_at`.** A packing list left open across days carries one
+`updated_at` for the whole block, so dating by it re-dates every order already
+packed in that list to the later day -- an order packed Monday reads as "packed
+today" on Tuesday, never gets flagged `Repeat`, and ships a second time.
+`started_at` is the stable lower bound the earliest-wins union wants. It errs
+the other way, flagging an order packed on day 2 of a list a day early, but that
+badge reads "already packed" and is still true; `Repeat` is advisory in the GUI,
+not a shipping block.
 
 **Best-effort by contract.** A missing file, malformed JSON, an unreachable
 server or an old-format entry logs and yields an empty frame. Repeat detection

--- a/docs/superpowers/specs/2026-08-18-repeat-detection-packing-sync-design.md
+++ b/docs/superpowers/specs/2026-08-18-repeat-detection-packing-sync-design.md
@@ -1,0 +1,279 @@
+# Repeat detection: union of analysis history and Packing Tool's packed orders
+
+Date: 2026-08-18
+Roadmap: Phase 7, subtask `6h8v4Vj4P6qXHh93`
+Status: approved (semantics chosen by the user 2026-08-18)
+
+## Problem
+
+"Repeat" marks an order the warehouse has already seen, so staff can catch a
+duplicate shipment. Today it is derived from one source, and that source has two
+independent defects.
+
+### Defect 1 — the flag is destroyed by re-analysis (data loss)
+
+`shopify_tool/core.py:1047`:
+
+```python
+updated_history = pd.concat([history_df, newly_fulfilled]).drop_duplicates(
+    subset=["Order_Number"], keep="last"
+)
+```
+
+`newly_fulfilled` is concatenated *after* the loaded history and carries today's
+date, so `keep="last"` makes today's row win. Every re-analysis **overwrites the
+order's original `Execution_Date` with today**, for every order still
+`Fulfillable`.
+
+`_detect_repeated_orders` flags an order when its `Execution_Date` is older than
+the cutoff, so the flag disappears on the next run. The loss is permanent —
+`fulfillment_history.csv` is the only record of the first-fulfillment date, and
+it has just been rewritten.
+
+Verified in the interpreter against the real file's schema
+(`Order_Number,Execution_Date`):
+
+| `keep` | resulting `Execution_Date` for an order first seen 2025-11-27 |
+|---|---|
+| `"last"` (today) | `2026-08-18` — original date gone |
+| `"first"` (fix) | `2025-11-27` — preserved |
+
+`keep="first"` still admits genuinely new orders (confirmed: an order absent from
+history is inserted with today's date).
+
+### Defect 2 — analysis is not fulfilment
+
+The history records that an order was *analyzed as Fulfillable*, not that it was
+ever picked, packed and shipped. An order analyzed and then cancelled counts as
+history forever. This is the gap the roadmap item names: the authoritative record
+of what physically left the warehouse lives in Packing Tool.
+
+## Decision: union semantics
+
+**Repeat = the order was seen at least N days ago in *either* SFT's analysis
+history *or* Packing Tool's completed orders.** (N = `repeat_detection_days`,
+default 1, unchanged.)
+
+Chosen by the user over two alternatives:
+
+- *Packing Tool only* (the roadmap item's literal wording) — cleanest semantics,
+  but no per-order packing history exists today, so nothing would flag as Repeat
+  until packing history accumulates, and orders shipped without going through
+  Packing Tool would never flag at all.
+- *Fix the clobber only* — one line, fixes the reported symptom, but leaves
+  Defect 2 and defers the cross-repo item.
+
+Repeat is a duplicate-shipment warning: a false negative (missing a genuine
+repeat) is worse than a false positive. The union minimises the failure that
+matters and has no migration cliff — the analysis signal keeps working from day
+one while the packing signal accumulates behind it.
+
+## Transport: extend the channel that already exists
+
+No new file and no directory walk are needed. The plumbing is already in place:
+
+```
+Packing Tool                     shared file server                SFT
+──────────────────────────────────────────────────────────────────────────────
+update_session_metadata()  ──►  <session>/session_info.json
+  (src/session_manager.py:672)     ["packing_progress"][list]
+                                          │
+                                          ▼
+                                  CLIENT_<id>/session_index.json  ──►  SFT reads
+                                    (SFT-owned per-client cache)       (cached)
+```
+
+Packing Tool already writes a `packing_progress` block into SFT's
+`session_info.json` on every status change, and SFT already mirrors that into a
+per-client `session_index.json` which `list_client_sessions()` reads instead of
+walking the session tree. Confirmed present in live server data:
+
+```json
+"packing_progress": {
+  "ALL_ORDERS_ALMADERM": {"started_at": "...", "status": "in_progress"}
+}
+```
+
+The change is to carry the completed order numbers in that same block. SFT then
+reads one already-cached file per client.
+
+Alternatives rejected:
+
+- **SFT walks `*/packing/*/packing_state.json`.** Needs no Packing Tool change,
+  but costs one network read per (session × packing list) on a slow UNC share,
+  unbounded backwards in time. `session_registry_manager.py`'s own docstring
+  records that a full scan took 15–20 minutes; the registry exists specifically
+  to avoid this.
+- **A new per-client `packed_orders.json`.** Clean, but a new file, a new
+  writer and a migration, to carry data an existing block can hold.
+
+### Order-number format
+
+No normalisation is needed. Verified identical across all three surfaces in live
+data: `completed[].order_number` in `packing_state.json`, `orders[].order_number`
+in SFT's packing-list JSON, and `Order_Number` in `fulfillment_history.csv` all
+spell it `#11019512`. Order numbers are **not** numeric — `CLIENT_WATERDROP` uses
+`#BG1086` — so nothing may coerce them to int.
+
+## Components
+
+### 1. Packing Tool — record completed order numbers
+
+`src/session_manager.py::update_session_metadata()` gains the packed order
+numbers and writes them into the `packing_progress[packing_list_name]` block it
+already maintains:
+
+```json
+"packing_progress": {
+  "ALL_ORDERS_ALMADERM": {
+    "started_at": "...",
+    "status": "completed",
+    "updated_at": "...",
+    "completed_orders": ["#11019512", "#11019513"]
+  }
+}
+```
+
+The caller passes the order numbers; `update_session_metadata` stays a dumb
+writer. Verified call sites in `src/main.py`:
+
+| line | status | change |
+|---|---|---|
+| 1438 | `'in_progress'` (list loaded) | none — nothing packed yet |
+| 2346 | `'in_progress'` (list loaded) | none — nothing packed yet |
+| 1767 | `'completed'` (session end) | pass the packed order numbers |
+
+At line 1767 the numbers are in scope as
+`_logic_ref.session_packing_state.get('completed_orders', [])` — `_logic_ref` is
+bound to `self.logic` at line 1679. `packer_logic._load_session_state()`
+normalises that key to a **list of order-number strings** in all three of its
+format branches (new `completed[]` dicts, a legacy `completed` string list, and
+the old top-level `completed_orders`), so the caller needs no format handling.
+
+**The new parameter must be optional.** `tests/test_metadata_utils.py:81` calls
+`update_session_metadata(path, name, status)` with exactly three positional
+arguments; a required fourth breaks it.
+
+**Known limitation, accepted.** A session abandoned without reaching the
+session-end path records no order numbers, even though `packing_state.json` on
+disk still holds them. No reconciliation is built for this: the analysis signal
+already covers those orders, which is the point of the union.
+
+`shared/` is not touched — it is one-way synced from packing-tool and neither
+side needs a change there.
+
+### 2. Packing Tool — close the lost-update window on `session_info.json`
+
+`update_session_metadata()` does an unlocked read–modify–write of
+`session_info.json`, while SFT guards the same file with `_locked_session_info()`
+(an exclusive lock on the sidecar `session_info.json.lock`, which is already
+present on the server). A concurrent SFT update and Packing Tool update can
+therefore lose one another's changes.
+
+This is pre-existing, but it sits directly in the path this design writes more
+data through, and a lost update now silently costs Repeat flags. Both repos
+already ship `shared/file_lock.py::locked_file()`, so the fix is to take the same
+lock around the existing read–modify–write. Separable from the rest if review
+disagrees.
+
+### 3. SFT — `shopify_tool/packed_orders.py` (new)
+
+One public function:
+
+```python
+def load_packed_orders(profile_manager, client_id) -> pd.DataFrame:
+    """Order numbers Packing Tool has completed, with the date they were packed.
+
+    Returns a DataFrame with columns [Order_Number, Execution_Date], empty on
+    any failure. Never raises.
+    """
+```
+
+Reads the client's `session_index.json` via the existing session-listing path,
+walks each entry's `packing_progress` blocks, and emits one row per completed
+order number dated by that block's `updated_at` (falling back to `started_at`).
+
+**Best-effort by contract.** A missing file, malformed JSON, an unreachable
+server or an old-format entry logs and yields an empty frame. Repeat detection
+then degrades to exactly today's behaviour. Analysis must never fail because the
+packing signal is unavailable — the warehouse can still ship.
+
+### 4. SFT — `core.py` wiring
+
+Two changes, both at the existing call sites:
+
+1. `keep="last"` → `keep="first"` at line 1047 (Defect 1).
+2. Between `history_df = _load_history_data(...)` (line 1218) and
+   `_run_analysis_and_rules(orders_df, stock_df, history_df, config)` (line
+   1252), build the union and pass **that** to analysis:
+
+```python
+detection_history_df = union_history_with_packed(history_df, packed_df)
+```
+
+`_run_analysis_and_rules` receives `detection_history_df`; the write-back path
+(line 1262) keeps the original `history_df`.
+
+**The union is for detection only and is never persisted.**
+`fulfillment_history.csv` remains SFT's own record of what it analyzed. Writing
+packing-derived rows into it would change the file's meaning and let one
+tool's data silently become the other's.
+
+Union rule: concatenate, sort by `Execution_Date` ascending, then
+`drop_duplicates(subset=["Order_Number"], keep="first")` — **earliest date per
+order wins**. Consistent with the `keep="first"` fix, and correct for the
+purpose: the earliest sighting is what makes an order a repeat.
+
+### 5. `_detect_repeated_orders` — unchanged
+
+It already takes a `[Order_Number, Execution_Date]` frame and applies the cutoff.
+Feeding it a unioned frame needs no new parameter, no new branch, and no second
+code path. Its existing tests keep passing unmodified.
+
+## Data flow
+
+```
+fulfillment_history.csv ──┐
+  (analysis signal)       ├──► detection_history_df ──► _detect_repeated_orders
+session_index.json ───────┘      (earliest date wins)         │
+  packing_progress[].              detection only,            ▼
+  completed_orders                 never written back    System_note = "Repeat"
+
+fulfillment_history.csv ◄── updated_history (keep="first")  ← history_df only
+```
+
+## Testing
+
+Unit, `QT_QPA_PLATFORM=offscreen python -m pytest`, no GUI needed.
+
+**Defect 1 (regression pin).** No existing test covers the history write-back, so
+the clobber is currently unpinned. Add one asserting an order already in history
+keeps its original `Execution_Date` after a re-analysis that finds it
+`Fulfillable` — this test must fail on `keep="last"`.
+
+**`load_packed_orders`.** Fixture `session_index.json` files: a well-formed one
+with two entries; one with a `packing_progress` block predating this change (no
+`completed_orders` key); a malformed one; and a missing file. The last three must
+each return an empty frame and log, not raise.
+
+**Union.** An order in both sources with different dates keeps the earlier one.
+An order only in packing history is flagged when old enough. An order only in
+analysis history is still flagged — this is the no-cliff guarantee and is the
+test most worth having.
+
+**Fixture warning.** Per the lesson from PR #288, each test's fixture must be
+able to produce the failure it claims to catch: the union tests need genuinely
+differing dates across the two sources, not the same date in both.
+
+Existing `TestRepeatDetection` in `tests/test_analysis.py` must pass unmodified —
+it is the proof the analysis path is unchanged.
+
+## Out of scope
+
+- Retroactive backfill of packing history. Sessions completed before this ships
+  have no `completed_orders` recorded; they contribute nothing. Acceptable
+  because the analysis signal covers them.
+- Session Browser completion sync and the 30-day archive — Phase 7 subtask
+  `6h8v4VvC2G5XjrqV`, a separate cycle. This design deliberately keeps the
+  registry (`registry_index.json`) untouched so that item stays free to change it.
+- The `Repeat` rendering in `pandas_model.py` and the column config. Unchanged.

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from . import analysis, packing_lists, stock_export
 from .csv_utils import normalize_sku
+from .packed_orders import load_packed_orders, union_history_with_packed
 from .rules import RuleEngine
 from .session_manager import SessionManagerError
 from .utils import get_persistent_data_path
@@ -1233,6 +1234,12 @@ def run_full_analysis(
             stock_file_path, orders_file_path, client_id, profile_manager, config
         )
 
+        # Repeat detection also counts orders Packing Tool has already packed.
+        # Detection only -- history_df below is what gets written back to
+        # fulfillment_history.csv, and must stay this repo's own record.
+        packed_df = load_packed_orders(profile_manager, client_id)
+        detection_history_df = union_history_with_packed(history_df, packed_df)
+
         # Step 4: Run analysis and apply rules
         logger.info("Step 4: Running analysis and applying rules...")
 
@@ -1263,7 +1270,7 @@ def run_full_analysis(
             )
 
         final_df, summary_present_df, summary_missing_df, stats = (
-            _run_analysis_and_rules(orders_df, stock_df, history_df, config)
+            _run_analysis_and_rules(orders_df, stock_df, detection_history_df, config)
         )
 
         # Step 5: Save results and reports

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -848,16 +848,29 @@ def _run_analysis_and_rules(
 def _merge_fulfillment_history(
     history_df: pd.DataFrame, newly_fulfilled: pd.DataFrame
 ) -> pd.DataFrame:
-    """Merge newly fulfilled orders into history, keeping the ORIGINAL date.
+    """Merge newly fulfilled orders into history, keeping the EARLIEST date.
 
-    keep="first" is load-bearing. `newly_fulfilled` is concatenated after
-    `history_df` and carries today's date, so keep="last" would overwrite
-    each order's original Execution_Date on every re-analysis -- destroying
-    the only record of when it was first fulfilled, and silently clearing
-    its "Repeat" flag.
+    `newly_fulfilled` carries today's date, so a plain keep="last" would
+    overwrite each order's original Execution_Date on every re-analysis --
+    destroying the only record of when it was first fulfilled, and silently
+    clearing its "Repeat" flag.
+
+    Sort on the parsed date before deduping rather than relying on
+    concatenation order: a legacy history file can hold duplicate
+    Order_Numbers, or a row with a blank/unparseable Execution_Date, and
+    positional keep="first" would preserve that unusable row forever (the
+    old keep="last" at least healed it on the next fulfilment). NaT sorts
+    last, so today's date wins over a date nothing can read.
     """
-    return pd.concat([history_df, newly_fulfilled]).drop_duplicates(
-        subset=["Order_Number"], keep="first"
+    combined = pd.concat([history_df, newly_fulfilled])
+    sort_key = pd.to_datetime(
+        combined["Execution_Date"], errors="coerce", format="mixed"
+    )
+    combined = combined.assign(_sort_key=sort_key).sort_values(
+        "_sort_key", na_position="last"
+    )
+    return combined.drop_duplicates(subset=["Order_Number"], keep="first").drop(
+        columns="_sort_key"
     )
 
 

--- a/shopify_tool/core.py
+++ b/shopify_tool/core.py
@@ -844,6 +844,22 @@ def _run_analysis_and_rules(
     return final_df, summary_present_df, summary_missing_df, stats
 
 
+def _merge_fulfillment_history(
+    history_df: pd.DataFrame, newly_fulfilled: pd.DataFrame
+) -> pd.DataFrame:
+    """Merge newly fulfilled orders into history, keeping the ORIGINAL date.
+
+    keep="first" is load-bearing. `newly_fulfilled` is concatenated after
+    `history_df` and carries today's date, so keep="last" would overwrite
+    each order's original Execution_Date on every re-analysis -- destroying
+    the only record of when it was first fulfilled, and silently clearing
+    its "Repeat" flag.
+    """
+    return pd.concat([history_df, newly_fulfilled]).drop_duplicates(
+        subset=["Order_Number"], keep="first"
+    )
+
+
 def _save_results_and_reports(
     final_df: pd.DataFrame,
     summary_present_df: pd.DataFrame,
@@ -1044,9 +1060,7 @@ def _save_results_and_reports(
 
     if not newly_fulfilled.empty:
         newly_fulfilled["Execution_Date"] = datetime.now().astimezone().strftime("%Y-%m-%d")
-        updated_history = pd.concat([history_df, newly_fulfilled]).drop_duplicates(
-            subset=["Order_Number"], keep="last"
-        )
+        updated_history = _merge_fulfillment_history(history_df, newly_fulfilled)
 
         # Determine history path (same logic as load)
         if profile_manager and client_id:

--- a/shopify_tool/packed_orders.py
+++ b/shopify_tool/packed_orders.py
@@ -74,11 +74,16 @@ def _load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
             if not isinstance(orders, list) or not orders:
                 # Written before completed_orders existed, or nothing packed.
                 continue
-            packed_date = _to_date(block.get("updated_at") or block.get("started_at"))
+            # Fall back per-parse, not per-value: a block whose updated_at is
+            # garbage still has a usable started_at, and `a or b` on the raw
+            # values would pick the garbage and drop the whole block.
+            packed_date = _to_date(block.get("updated_at")) or _to_date(
+                block.get("started_at")
+            )
             if packed_date is None:
                 continue
             rows.extend(
-                {"Order_Number": str(o), "Execution_Date": packed_date}
+                {"Order_Number": o, "Execution_Date": packed_date}
                 for o in orders
                 if isinstance(o, str) and o
             )

--- a/shopify_tool/packed_orders.py
+++ b/shopify_tool/packed_orders.py
@@ -1,0 +1,124 @@
+"""Read the orders Packing Tool has finished packing.
+
+Packing Tool records the order numbers it completed into the
+`packing_progress` block of each session's `session_info.json`, which this
+repo mirrors into the per-client `session_index.json` cache. Reading that
+one file per client avoids walking the session tree on the network share.
+
+Everything here is best-effort by contract: a missing file, malformed JSON
+or an old-format entry yields an empty result and a log line. Repeat
+detection then degrades to using analysis history alone. An analysis must
+never fail because the packing signal is unavailable -- the warehouse can
+still ship.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+COLUMNS = ["Order_Number", "Execution_Date"]
+
+INDEX_FILENAME = "session_index.json"
+
+
+def _empty() -> pd.DataFrame:
+    return pd.DataFrame(columns=COLUMNS)
+
+
+def load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
+    """Order numbers Packing Tool has completed, with the date packed.
+
+    Args:
+        profile_manager: provides get_sessions_root()
+        client_id: client identifier, case-insensitive
+
+    Returns:
+        DataFrame with columns [Order_Number, Execution_Date] (dates as
+        YYYY-MM-DD strings), earliest date per order. Empty on any failure.
+    """
+    if not profile_manager or not client_id:
+        return _empty()
+
+    try:
+        sessions_root = Path(profile_manager.get_sessions_root())
+        index_path = sessions_root / f"CLIENT_{client_id.upper()}" / INDEX_FILENAME
+        if not index_path.exists():
+            logger.debug(f"No session index for packed orders: {index_path}")
+            return _empty()
+        entries = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError, AttributeError):
+        logger.exception("Could not read packed orders; repeat detection will use analysis history only")
+        return _empty()
+
+    if not isinstance(entries, list):
+        logger.warning("Session index is not a list; ignoring packed orders")
+        return _empty()
+
+    rows = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        progress = entry.get("packing_progress")
+        if not isinstance(progress, dict):
+            continue
+        for block in progress.values():
+            if not isinstance(block, dict):
+                continue
+            orders = block.get("completed_orders")
+            if not orders:
+                # Written before completed_orders existed, or nothing packed.
+                continue
+            packed_date = _to_date(block.get("updated_at") or block.get("started_at"))
+            if packed_date is None:
+                continue
+            rows.extend(
+                {"Order_Number": str(o), "Execution_Date": packed_date}
+                for o in orders
+                if o
+            )
+
+    if not rows:
+        return _empty()
+
+    df = pd.DataFrame(rows, columns=COLUMNS)
+    df = df.sort_values("Execution_Date").drop_duplicates(
+        subset=["Order_Number"], keep="first"
+    )
+    logger.info(f"Loaded {len(df)} packed orders for repeat detection ({client_id})")
+    return df.reset_index(drop=True)
+
+
+def _to_date(timestamp) -> str | None:
+    """ISO timestamp -> 'YYYY-MM-DD', or None if unparseable."""
+    if not timestamp:
+        return None
+    parsed = pd.to_datetime(timestamp, errors="coerce", utc=True)
+    if pd.isna(parsed):
+        return None
+    return parsed.strftime("%Y-%m-%d")
+
+
+def union_history_with_packed(
+    history_df: pd.DataFrame, packed_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Combine analysis history with packed orders, earliest date per order.
+
+    An order is a repeat if it was seen at least N days ago in EITHER
+    source, so the earliest sighting is the one that matters. The result is
+    for detection only -- it must never be written to
+    fulfillment_history.csv, which is this repo's own record of what it
+    analyzed.
+    """
+    frames = [f for f in (history_df, packed_df) if f is not None and not f.empty]
+    if not frames:
+        return _empty()
+
+    combined = pd.concat(frames, ignore_index=True)[COLUMNS]
+    combined = combined.sort_values("Execution_Date").drop_duplicates(
+        subset=["Order_Number"], keep="first"
+    )
+    return combined.reset_index(drop=True)

--- a/shopify_tool/packed_orders.py
+++ b/shopify_tool/packed_orders.py
@@ -1,9 +1,17 @@
 """Read the orders Packing Tool has finished packing.
 
 Packing Tool records the order numbers it completed into the
-`packing_progress` block of each session's `session_info.json`, which this
-repo mirrors into the per-client `session_index.json` cache. Reading that
-one file per client avoids walking the session tree on the network share.
+`packing_progress` block of each session's `session_info.json`. This module
+reads them from the per-client `session_index.json` cache, which is one
+network read instead of a walk of the session tree.
+
+**Freshness caveat.** That index is SFT-owned and is refreshed only by SFT's
+own writes (`SessionManager._upsert_index_entry`) or by its directory-count
+staleness check. Packing Tool writing `session_info.json` triggers neither,
+so a session's `completed_orders` reach the index only if SFT happens to
+rewrite that session afterwards. Until that transport is fixed, this module
+under-reports rather than over-reports: it can miss packed orders, never
+invent them.
 
 Everything here is best-effort by contract: a missing file, malformed JSON
 or an old-format entry yields an empty result and a log line. Repeat
@@ -43,16 +51,22 @@ def load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
     if not profile_manager or not client_id:
         return _empty()
 
+    # Broad by design: every value below comes from a file another tool
+    # writes, and no shape it can take may abort the analysis.
     try:
-        sessions_root = Path(profile_manager.get_sessions_root())
-        index_path = sessions_root / f"CLIENT_{client_id.upper()}" / INDEX_FILENAME
-        if not index_path.exists():
-            logger.debug(f"No session index for packed orders: {index_path}")
-            return _empty()
-        entries = json.loads(index_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, TypeError, AttributeError):
+        return _load_packed_orders(profile_manager, client_id)
+    except Exception:
         logger.exception("Could not read packed orders; repeat detection will use analysis history only")
         return _empty()
+
+
+def _load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
+    sessions_root = Path(profile_manager.get_sessions_root())
+    index_path = sessions_root / f"CLIENT_{client_id.upper()}" / INDEX_FILENAME
+    if not index_path.exists():
+        logger.debug(f"No session index for packed orders: {index_path}")
+        return _empty()
+    entries = json.loads(index_path.read_text(encoding="utf-8"))
 
     if not isinstance(entries, list):
         logger.warning("Session index is not a list; ignoring packed orders")
@@ -69,7 +83,9 @@ def load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
             if not isinstance(block, dict):
                 continue
             orders = block.get("completed_orders")
-            if not orders:
+            # A bare string is iterable and would yield one row per
+            # character, so the list check is load-bearing, not defensive.
+            if not isinstance(orders, list) or not orders:
                 # Written before completed_orders existed, or nothing packed.
                 continue
             packed_date = _to_date(block.get("updated_at") or block.get("started_at"))
@@ -78,7 +94,7 @@ def load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
             rows.extend(
                 {"Order_Number": str(o), "Execution_Date": packed_date}
                 for o in orders
-                if o
+                if isinstance(o, str) and o
             )
 
     if not rows:
@@ -93,10 +109,17 @@ def load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
 
 
 def _to_date(timestamp) -> str | None:
-    """ISO timestamp -> 'YYYY-MM-DD', or None if unparseable."""
-    if not timestamp:
+    """ISO timestamp -> 'YYYY-MM-DD', or None if unparseable.
+
+    Deliberately NOT utc=True. The stamp carries the warehouse's local
+    offset, and `analysis._detect_repeated_orders` compares against a naive
+    local `datetime.now()`. Normalising to UTC would date orders packed
+    after midnight-minus-offset to the previous day, flagging a fresh order
+    as a repeat on the same working day.
+    """
+    if not isinstance(timestamp, str) or not timestamp:
         return None
-    parsed = pd.to_datetime(timestamp, errors="coerce", utc=True)
+    parsed = pd.to_datetime(timestamp, errors="coerce")
     if pd.isna(parsed):
         return None
     return parsed.strftime("%Y-%m-%d")
@@ -112,13 +135,29 @@ def union_history_with_packed(
     for detection only -- it must never be written to
     fulfillment_history.csv, which is this repo's own record of what it
     analyzed.
+
+    Returns `history_df` untouched if it cannot be unioned, so the
+    backward-compatibility branch in `_detect_repeated_orders` still sees
+    the shape it expects.
     """
+    if history_df is not None and not history_df.empty:
+        missing = [c for c in COLUMNS if c not in history_df.columns]
+        if missing:
+            # Legacy history file. _detect_repeated_orders handles this
+            # shape itself; unioning here would only break it.
+            logger.debug(f"History missing {missing}; skipping packed-order union")
+            return history_df
+
     frames = [f for f in (history_df, packed_df) if f is not None and not f.empty]
     if not frames:
         return _empty()
 
-    combined = pd.concat(frames, ignore_index=True)[COLUMNS]
-    combined = combined.sort_values("Execution_Date").drop_duplicates(
-        subset=["Order_Number"], keep="first"
+    combined = pd.concat(frames, ignore_index=True).reindex(columns=COLUMNS)
+    # Sort on parsed dates, not the strings: a legacy row in another format
+    # ("27/11/2025") would otherwise sort wrong and win "earliest".
+    order = pd.to_datetime(combined["Execution_Date"], errors="coerce", format="mixed")
+    combined = combined.assign(_sort_key=order).sort_values(
+        "_sort_key", na_position="last"
     )
-    return combined.reset_index(drop=True)
+    combined = combined.drop_duplicates(subset=["Order_Number"], keep="first")
+    return combined.drop(columns="_sort_key").reset_index(drop=True)

--- a/shopify_tool/packed_orders.py
+++ b/shopify_tool/packed_orders.py
@@ -2,16 +2,15 @@
 
 Packing Tool records the order numbers it completed into the
 `packing_progress` block of each session's `session_info.json`. This module
-reads them from the per-client `session_index.json` cache, which is one
-network read instead of a walk of the session tree.
+reads them through `SessionManager.list_client_sessions()`, which serves the
+per-client `session_index.json` cache -- one network read instead of a walk
+of the session tree.
 
-**Freshness caveat.** That index is SFT-owned and is refreshed only by SFT's
-own writes (`SessionManager._upsert_index_entry`) or by its directory-count
-staleness check. Packing Tool writing `session_info.json` triggers neither,
-so a session's `completed_orders` reach the index only if SFT happens to
-rewrite that session afterwards. Until that transport is fixed, this module
-under-reports rather than over-reports: it can miss packed orders, never
-invent them.
+Going through that method rather than reading the index file directly is
+load-bearing, not stylistic: it is the only path that runs
+`SessionManager._index_is_stale()`, which rebuilds the index when a session
+directory is newer than it. Packing Tool's writes are exactly that case, so
+a raw index read would report the packed orders as empty forever.
 
 Everything here is best-effort by contract: a missing file, malformed JSON
 or an old-format entry yields an empty result and a log line. Repeat
@@ -20,17 +19,15 @@ never fail because the packing signal is unavailable -- the warehouse can
 still ship.
 """
 
-import json
 import logging
-from pathlib import Path
 
 import pandas as pd
+
+from .session_manager import SessionManager
 
 logger = logging.getLogger(__name__)
 
 COLUMNS = ["Order_Number", "Execution_Date"]
-
-INDEX_FILENAME = "session_index.json"
 
 
 def _empty() -> pd.DataFrame:
@@ -61,21 +58,10 @@ def load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
 
 
 def _load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
-    sessions_root = Path(profile_manager.get_sessions_root())
-    index_path = sessions_root / f"CLIENT_{client_id.upper()}" / INDEX_FILENAME
-    if not index_path.exists():
-        logger.debug(f"No session index for packed orders: {index_path}")
-        return _empty()
-    entries = json.loads(index_path.read_text(encoding="utf-8"))
-
-    if not isinstance(entries, list):
-        logger.warning("Session index is not a list; ignoring packed orders")
-        return _empty()
+    entries = SessionManager(profile_manager).list_client_sessions(client_id)
 
     rows = []
     for entry in entries:
-        if not isinstance(entry, dict):
-            continue
         progress = entry.get("packing_progress")
         if not isinstance(progress, dict):
             continue

--- a/shopify_tool/packed_orders.py
+++ b/shopify_tool/packed_orders.py
@@ -74,11 +74,21 @@ def _load_packed_orders(profile_manager, client_id: str) -> pd.DataFrame:
             if not isinstance(orders, list) or not orders:
                 # Written before completed_orders existed, or nothing packed.
                 continue
-            # Fall back per-parse, not per-value: a block whose updated_at is
-            # garbage still has a usable started_at, and `a or b` on the raw
+            # started_at, not updated_at. A packing list left open across
+            # days carries ONE updated_at for the whole block, so dating by
+            # it re-dates every order already packed in that list to the
+            # later day: an order packed Monday looks "packed today" on
+            # Tuesday, never gets flagged Repeat, and ships a second time.
+            # started_at is the stable lower bound the earliest-wins union
+            # below actually wants. The cost is the opposite error -- an
+            # order packed on day 2 is flagged a day early -- which is a
+            # badge reading "already packed", and that is still true.
+            #
+            # Fall back per-parse, not per-value: a block whose started_at is
+            # garbage still has a usable updated_at, and `a or b` on the raw
             # values would pick the garbage and drop the whole block.
-            packed_date = _to_date(block.get("updated_at")) or _to_date(
-                block.get("started_at")
+            packed_date = _to_date(block.get("started_at")) or _to_date(
+                block.get("updated_at")
             )
             if packed_date is None:
                 continue

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -240,12 +240,8 @@ class SessionManager:
             return []
 
         entries = self._read_index(client_sessions_dir)
-        if entries is None:
+        if entries is None or self._index_is_stale(client_sessions_dir, entries):
             entries = self._rebuild_index(client_sessions_dir)
-        else:
-            actual_count = sum(1 for item in client_sessions_dir.iterdir() if item.is_dir())
-            if actual_count != len(entries):
-                entries = self._rebuild_index(client_sessions_dir)
 
         sessions = []
         for entry in entries:
@@ -342,6 +338,49 @@ class SessionManager:
             logger.exception("Failed to read session index, treating as missing")
             return None
 
+    def _index_is_stale(self, client_sessions_dir: Path, entries: list[dict]) -> bool:
+        """True if the index no longer reflects the session directories.
+
+        Comparing counts alone only notices sessions appearing or
+        disappearing. It misses every change made inside an existing
+        session -- including the ones another tool makes: Packing Tool
+        writes `completed_orders` into a session's session_info.json, which
+        leaves the count identical, so a count-only check would serve that
+        session's stale entry forever.
+
+        session_info.json is written as temp-file + rename (see
+        shared.atomic_write), so any write to it bumps its session
+        directory's mtime. Every writer in this class updates the index
+        *after* the session_info.json write it mirrors, which leaves the
+        index newer than the directory it describes and does not trigger a
+        rebuild.
+
+        ponytail: mtime comparison assumes the PCs writing to the share
+        agree on the clock. Skew only costs extra rebuilds (the pre-index
+        behaviour), never wrong data, and clears itself once the stamps
+        pass; record a per-entry mtime in the index if that ever shows up
+        on the UNC share.
+        """
+        try:
+            index_mtime = (client_sessions_dir / self.INDEX_FILENAME).stat().st_mtime
+        except OSError:
+            return True
+
+        count = 0
+        newest_session_mtime = 0.0
+        # scandir, not iterdir: on Windows the directory listing already
+        # carries the timestamps, so DirEntry.stat() costs no extra network
+        # round trip on the share.
+        with os.scandir(client_sessions_dir) as it:
+            for item in it:
+                if not item.is_dir():
+                    continue
+                count += 1
+                with contextlib.suppress(OSError):
+                    newest_session_mtime = max(newest_session_mtime, item.stat().st_mtime)
+
+        return count != len(entries) or newest_session_mtime > index_mtime
+
     def _write_index(self, client_sessions_dir: Path, entries: list[dict]) -> None:
         index_path = client_sessions_dir / self.INDEX_FILENAME
         atomic_write_json(index_path, entries)
@@ -360,8 +399,8 @@ class SessionManager:
         return entries
 
     def _rebuild_index(self, client_sessions_dir: Path) -> list[dict]:
-        """Full scan + persist. Called when no index exists yet, or the
-        directory count no longer matches the index (see list_client_sessions).
+        """Full scan + persist. Called when no index exists yet, or the index
+        no longer reflects the session directories (see _index_is_stale).
 
         Scan and write both happen under the index lock: an unlocked scan
         could read a stale snapshot, then overwrite a concurrent

--- a/shopify_tool/session_manager.py
+++ b/shopify_tool/session_manager.py
@@ -348,12 +348,13 @@ class SessionManager:
         leaves the count identical, so a count-only check would serve that
         session's stale entry forever.
 
-        session_info.json is written as temp-file + rename (see
-        shared.atomic_write), so any write to it bumps its session
-        directory's mtime. Every writer in this class updates the index
-        *after* the session_info.json write it mirrors, which leaves the
-        index newer than the directory it describes and does not trigger a
-        rebuild.
+        Packing Tool writes session_info.json as temp-file + rename (see
+        shared.atomic_write) and takes the sidecar .lock first, so its
+        writes bump the session directory's mtime. This class's own writers
+        overwrite session_info.json in place (plain open(..., "w"), which
+        leaves the directory mtime alone) and update the index *afterwards*,
+        so the index stays newer than the directory it describes and never
+        triggers a rebuild of our own making.
 
         ponytail: mtime comparison assumes the PCs writing to the share
         agree on the clock. Skew only costs extra rebuilds (the pre-index

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -88,6 +88,43 @@ class TestFulfillmentHistoryMerge:
         assert dates["#99999"] == "2026-08-18"
         assert dates["#11014590"] == "2025-11-27"
 
+    def test_unreadable_history_date_is_healed_by_this_runs_date(self):
+        """A blank Execution_Date is not a date to preserve. Positional
+        keep="first" pinned it forever; the earliest PARSED date must win,
+        and NaT is not earliest."""
+        from shopify_tool.core import _merge_fulfillment_history
+
+        history = pd.DataFrame({
+            "Order_Number": ["#11014590"],
+            "Execution_Date": [None],
+        })
+        newly_fulfilled = pd.DataFrame({
+            "Order_Number": ["#11014590"],
+            "Execution_Date": ["2026-08-18"],
+        })
+
+        merged = _merge_fulfillment_history(history, newly_fulfilled)
+        assert len(merged) == 1
+        assert merged.iloc[0]["Execution_Date"] == "2026-08-18"
+
+    def test_duplicate_history_rows_keep_the_earliest_date(self):
+        """Legacy history files hold more than one row per order; whichever
+        row came first in the file is not necessarily the earliest."""
+        from shopify_tool.core import _merge_fulfillment_history
+
+        history = pd.DataFrame({
+            "Order_Number": ["#A", "#A"],
+            "Execution_Date": ["2026-03-01", "2025-11-27"],
+        })
+        newly_fulfilled = pd.DataFrame({
+            "Order_Number": ["#A"],
+            "Execution_Date": ["2026-08-18"],
+        })
+
+        merged = _merge_fulfillment_history(history, newly_fulfilled)
+        assert len(merged) == 1
+        assert merged.iloc[0]["Execution_Date"] == "2025-11-27"
+
     def test_empty_history_accepts_all_new_orders(self):
         from shopify_tool.core import _merge_fulfillment_history
 
@@ -133,7 +170,8 @@ class TestPackedOrdersAreDetectionOnly:
         ok, _msg, final_df, _stats = core.run_full_analysis(
             str(stock_csv), str(orders_csv), str(tmp_path / "out"), ",", ",",
             {
-                "analysis": {"repeat_detection_days": 1},
+                # core reads this from "settings", not "analysis".
+                "settings": {"repeat_detection_days": 1},
                 "column_mappings": {
                     "orders": _ORDERS_MAPPING,
                     "stock": {"Артикул": "SKU", "Име": "Product_Name", "Наличност": "Stock"},

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,3 +39,63 @@ class TestInventoryMemoryStockReconstruction:
         history_df = pd.DataFrame({"Order_Number": [], "Execution_Date": []})
         final_df, *_ = analysis.run_analysis(stock_df, orders_df, history_df)
         assert final_df.iloc[0]["Warehouse_Name"] == "Widget A1"
+
+
+class TestFulfillmentHistoryMerge:
+    """The merge must preserve each order's ORIGINAL Execution_Date.
+
+    fulfillment_history.csv is the only record of when an order was first
+    fulfilled. Overwriting that date loses it permanently and silently
+    clears the order's "Repeat" flag.
+    """
+
+    def test_reanalysis_preserves_original_execution_date(self):
+        from shopify_tool.core import _merge_fulfillment_history
+
+        history = pd.DataFrame({
+            "Order_Number": ["#11014590", "#11014599"],
+            "Execution_Date": ["2025-11-27", "2025-11-27"],
+        })
+        # A re-analysis today finds #11014590 still Fulfillable.
+        newly_fulfilled = pd.DataFrame({
+            "Order_Number": ["#11014590"],
+            "Execution_Date": ["2026-08-18"],
+        })
+
+        merged = _merge_fulfillment_history(history, newly_fulfilled)
+        dates = dict(zip(merged["Order_Number"], merged["Execution_Date"]))
+
+        assert dates["#11014590"] == "2025-11-27", (
+            "re-analysis overwrote the original fulfilment date"
+        )
+        assert dates["#11014599"] == "2025-11-27"
+
+    def test_genuinely_new_order_is_added(self):
+        from shopify_tool.core import _merge_fulfillment_history
+
+        history = pd.DataFrame({
+            "Order_Number": ["#11014590"],
+            "Execution_Date": ["2025-11-27"],
+        })
+        newly_fulfilled = pd.DataFrame({
+            "Order_Number": ["#99999"],
+            "Execution_Date": ["2026-08-18"],
+        })
+
+        merged = _merge_fulfillment_history(history, newly_fulfilled)
+        dates = dict(zip(merged["Order_Number"], merged["Execution_Date"]))
+
+        assert dates["#99999"] == "2026-08-18"
+        assert dates["#11014590"] == "2025-11-27"
+
+    def test_empty_history_accepts_all_new_orders(self):
+        from shopify_tool.core import _merge_fulfillment_history
+
+        history = pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+        newly_fulfilled = pd.DataFrame({
+            "Order_Number": ["#1", "#2"],
+            "Execution_Date": ["2026-08-18", "2026-08-18"],
+        })
+
+        merged = _merge_fulfillment_history(history, newly_fulfilled)
+        assert set(merged["Order_Number"]) == {"#1", "#2"}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -99,3 +99,86 @@ class TestFulfillmentHistoryMerge:
 
         merged = _merge_fulfillment_history(history, newly_fulfilled)
         assert set(merged["Order_Number"]) == {"#1", "#2"}
+
+
+
+class TestPackedOrdersAreDetectionOnly:
+    """The single most important line in Task 3: the packed-order union feeds
+    repeat DETECTION only. It must never reach fulfillment_history.csv, which
+    is this repo's own record of what it analyzed.
+
+    Uses real CSV inputs on purpose -- passing None file paths puts
+    _save_results_and_reports in "test mode", which skips the history
+    write-back entirely and would make this test vacuous.
+    """
+
+    def _run(self, tmp_path, monkeypatch, packed_df):
+        monkeypatch.setattr(core, "load_packed_orders", lambda _pm, _cid: packed_df)
+        # Legacy mode writes history via get_persistent_data_path; keep it in
+        # tmp_path so the test never touches the real app-data directory.
+        history_path = tmp_path / "fulfillment_history.csv"
+        monkeypatch.setattr(core, "get_persistent_data_path", lambda _name: history_path)
+
+        orders_csv = tmp_path / "orders.csv"
+        pd.DataFrame([
+            {"Name": "#PACKED", "Lineitem sku": "A1", "Lineitem quantity": 1, "Shipping Method": "Standard"},
+            {"Name": "#FRESH", "Lineitem sku": "A1", "Lineitem quantity": 1, "Shipping Method": "Standard"},
+        ]).to_csv(orders_csv, index=False)
+
+        stock_csv = tmp_path / "stock.csv"
+        pd.DataFrame([
+            {"Артикул": "A1", "Име": "Widget", "Наличност": 100},
+        ]).to_csv(stock_csv, index=False)
+
+        ok, _msg, final_df, _stats = core.run_full_analysis(
+            str(stock_csv), str(orders_csv), str(tmp_path / "out"), ",", ",",
+            {
+                "analysis": {"repeat_detection_days": 1},
+                "column_mappings": {
+                    "orders": _ORDERS_MAPPING,
+                    "stock": {"Артикул": "SKU", "Име": "Product_Name", "Наличност": "Stock"},
+                },
+            },
+        )
+        assert ok, _msg
+        return final_df, history_path
+
+    def test_packed_order_is_flagged_repeat_without_entering_history(
+        self, tmp_path, monkeypatch
+    ):
+        import datetime
+
+        yesterday = (
+            datetime.datetime.now().astimezone() - datetime.timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+        packed = pd.DataFrame(
+            {"Order_Number": ["#PACKED"], "Execution_Date": [yesterday]}
+        )
+
+        final_df, history_path = self._run(tmp_path, monkeypatch, packed)
+
+        # Detection saw the packed order...
+        assert final_df[final_df["Order_Number"] == "#PACKED"].iloc[0]["System_note"] == "Repeat"
+        assert final_df[final_df["Order_Number"] == "#FRESH"].iloc[0]["System_note"] != "Repeat"
+
+        # ...but the written history carries TODAY's date for #PACKED, from
+        # this run's own fulfilment -- not the packed frame's yesterday. If
+        # the union had leaked into the write-back, yesterday would be here.
+        written = pd.read_csv(history_path)
+        today = datetime.datetime.now().astimezone().strftime("%Y-%m-%d")
+        assert set(written["Order_Number"]) == {"#PACKED", "#FRESH"}
+        assert set(written["Execution_Date"].astype(str)) == {today}
+
+    def test_packed_order_absent_from_this_run_never_reaches_history(
+        self, tmp_path, monkeypatch
+    ):
+        """An order Packing Tool packed but that is not in today's export must
+        not be written into this repo's history at all."""
+        packed = pd.DataFrame(
+            {"Order_Number": ["#LONG_GONE"], "Execution_Date": ["2026-01-01"]}
+        )
+
+        _final_df, history_path = self._run(tmp_path, monkeypatch, packed)
+
+        written = pd.read_csv(history_path)
+        assert "#LONG_GONE" not in set(written["Order_Number"])

--- a/tests/test_packed_orders.py
+++ b/tests/test_packed_orders.py
@@ -76,6 +76,25 @@ class TestLoadPackedOrders:
         df = load_packed_orders(pm, "ALMADERM")
         assert df.iloc[0]["Execution_Date"] == "2026-07-26"
 
+    def test_falls_back_to_started_at_when_updated_at_is_unparseable(self, tmp_path):
+        """`updated_at or started_at` on the raw values picks the garbage and
+        drops the whole block; the fallback has to be per-parse."""
+        pm = _write_sessions(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-26_2",
+                "packing_progress": {
+                    "ALL_ORDERS": {
+                        "started_at": "2026-07-26T18:25:33+00:00",
+                        "updated_at": "not-a-date",
+                        "completed_orders": ["#A"],
+                    }
+                },
+            }
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert df.iloc[0]["Execution_Date"] == "2026-07-26"
+
     def test_collects_across_sessions_and_packing_lists(self, tmp_path):
         pm = _write_sessions(tmp_path, "ALMADERM", [
             {

--- a/tests/test_packed_orders.py
+++ b/tests/test_packed_orders.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pandas as pd
 
@@ -15,18 +16,28 @@ class _FakeProfileManager:
         return self._sessions_root
 
 
-def _write_index(tmp_path, client_id, entries):
+def _write_sessions(tmp_path, client_id, entries):
+    """Write each entry as a real session directory's session_info.json.
+
+    Deliberately writes no session_index.json. These fixtures used to
+    hand-write the index, which assumed the very link that was broken:
+    Packing Tool writes session_info.json and nothing else, so a test that
+    seeds the index proves nothing about whether its writes are visible.
+    """
     client_dir = tmp_path / f"CLIENT_{client_id}"
     client_dir.mkdir(parents=True, exist_ok=True)
-    (client_dir / "session_index.json").write_text(
-        json.dumps(entries), encoding="utf-8"
-    )
+    for entry in entries:
+        session_dir = client_dir / entry["session_name"]
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / "session_info.json").write_text(
+            json.dumps(entry), encoding="utf-8"
+        )
     return _FakeProfileManager(tmp_path)
 
 
 class TestLoadPackedOrders:
     def test_reads_completed_orders_with_packing_date(self, tmp_path):
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {
                 "session_name": "2026-07-26_2",
                 "packing_progress": {
@@ -49,7 +60,7 @@ class TestLoadPackedOrders:
         }
 
     def test_falls_back_to_started_at_when_no_updated_at(self, tmp_path):
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {
                 "session_name": "2026-07-26_2",
                 "packing_progress": {
@@ -66,7 +77,7 @@ class TestLoadPackedOrders:
         assert df.iloc[0]["Execution_Date"] == "2026-07-26"
 
     def test_collects_across_sessions_and_packing_lists(self, tmp_path):
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {
                 "session_name": "2026-07-01_1",
                 "packing_progress": {
@@ -89,7 +100,7 @@ class TestLoadPackedOrders:
         assert set(df["Order_Number"]) == {"#A", "#B", "#C"}
 
     def test_same_order_packed_twice_keeps_earliest(self, tmp_path):
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {"session_name": "2026-07-05_1", "packing_progress": {
                 "L": {"updated_at": "2026-07-05T10:00:00+00:00",
                       "completed_orders": ["#A"]}}},
@@ -106,7 +117,7 @@ class TestLoadPackedOrders:
 
     def test_entry_without_completed_orders_key_is_skipped(self, tmp_path):
         """The normal case before Task 4 ships -- not an error."""
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {
                 "session_name": "2026-07-26_2",
                 "packing_progress": {
@@ -123,35 +134,69 @@ class TestLoadPackedOrders:
         assert list(df.columns) == ["Order_Number", "Execution_Date"]
 
     def test_entry_without_packing_progress_is_skipped(self, tmp_path):
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {"session_name": "2026-07-26_1", "status": "active"}
         ])
         assert load_packed_orders(pm, "ALMADERM").empty
 
-    def test_missing_index_file_returns_empty(self, tmp_path):
+    def test_missing_client_directory_returns_empty(self, tmp_path):
         assert load_packed_orders(_FakeProfileManager(tmp_path), "NOSUCH").empty
 
-    def test_malformed_json_returns_empty(self, tmp_path):
-        client_dir = tmp_path / "CLIENT_ALMADERM"
-        client_dir.mkdir(parents=True)
-        (client_dir / "session_index.json").write_text("{not json", encoding="utf-8")
+    def test_malformed_index_is_rebuilt_from_the_session_directories(self, tmp_path):
+        pm = _write_sessions(tmp_path, "ALMADERM", [
+            {"session_name": "s", "packing_progress": {
+                "L": {"updated_at": "2026-07-01T10:00:00+00:00",
+                      "completed_orders": ["#A"]}}},
+        ])
+        (tmp_path / "CLIENT_ALMADERM" / "session_index.json").write_text(
+            "{not json", encoding="utf-8"
+        )
 
-        assert load_packed_orders(_FakeProfileManager(tmp_path), "ALMADERM").empty
+        assert set(load_packed_orders(pm, "ALMADERM")["Order_Number"]) == {"#A"}
 
     def test_unparseable_timestamp_is_skipped_without_raising(self, tmp_path):
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {"session_name": "s", "packing_progress": {
                 "L": {"updated_at": "not-a-date", "completed_orders": ["#A"]}}},
         ])
         assert load_packed_orders(pm, "ALMADERM").empty
 
     def test_client_id_is_case_insensitive(self, tmp_path):
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {"session_name": "s", "packing_progress": {
                 "L": {"updated_at": "2026-07-01T10:00:00+00:00",
                       "completed_orders": ["#A"]}}},
         ])
         assert not load_packed_orders(pm, "almaderm").empty
+
+
+class TestStaleIndexIsRefreshed:
+    """The transport this feature rides on.
+
+    Packing Tool only writes session_info.json. It never touches this
+    repo's session_index.json and never changes the session count, so a
+    count-only staleness check leaves the packed orders invisible forever
+    -- silently, which is how this shipped as a draft.
+    """
+
+    def test_packed_orders_written_after_the_index_are_still_seen(self, tmp_path):
+        pm = _write_sessions(tmp_path, "ALMADERM", [
+            {"session_name": "2026-07-01_1", "packing_progress": {
+                "L": {"updated_at": "2026-07-01T10:00:00+00:00",
+                      "completed_orders": ["#A"]}}},
+        ])
+        client_dir = tmp_path / "CLIENT_ALMADERM"
+        # The index as it looked before Packing Tool packed anything: same
+        # session, same count, no packing_progress.
+        index_path = client_dir / "session_index.json"
+        index_path.write_text(
+            json.dumps([{"session_name": "2026-07-01_1", "status": "active"}]),
+            encoding="utf-8",
+        )
+        session_mtime = (client_dir / "2026-07-01_1").stat().st_mtime
+        os.utime(index_path, (session_mtime - 10, session_mtime - 10))
+
+        assert set(load_packed_orders(pm, "ALMADERM")["Order_Number"]) == {"#A"}
 
 
 class TestUnionHistoryWithPacked:
@@ -200,7 +245,7 @@ class TestMalformedCrossToolDataNeverAborts:
     outer handler and fail the whole analysis."""
 
     def _load(self, tmp_path, block):
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {"session_name": "s", "packing_progress": {"ALL": block}}
         ])
         return load_packed_orders(pm, "ALMADERM")
@@ -257,7 +302,7 @@ class TestPackedDateUsesWarehouseLocalDate:
     def test_after_midnight_local_is_not_shifted_to_yesterday(self, tmp_path):
         """utc=True turned 01:00 local (+03:00) into the previous day, which
         flags an order packed this morning as a same-day Repeat."""
-        pm = _write_index(tmp_path, "ALMADERM", [
+        pm = _write_sessions(tmp_path, "ALMADERM", [
             {"session_name": "s", "packing_progress": {"ALL": {
                 "updated_at": "2026-07-02T01:00:00+03:00",
                 "completed_orders": ["#A"],

--- a/tests/test_packed_orders.py
+++ b/tests/test_packed_orders.py
@@ -192,3 +192,76 @@ class TestUnionHistoryWithPacked:
         out = union_history_with_packed(empty, empty)
         assert out.empty
         assert list(out.columns) == ["Order_Number", "Execution_Date"]
+
+
+class TestMalformedCrossToolDataNeverAborts:
+    """The contract is 'never raises'. These shapes all come from a file the
+    OTHER tool writes, and each one used to escape to run_full_analysis's
+    outer handler and fail the whole analysis."""
+
+    def _load(self, tmp_path, block):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "s", "packing_progress": {"ALL": block}}
+        ])
+        return load_packed_orders(pm, "ALMADERM")
+
+    def test_completed_orders_not_a_list(self, tmp_path):
+        out = self._load(tmp_path, {"updated_at": "2026-07-01T10:00:00+03:00",
+                                    "completed_orders": 5})
+        assert out.empty
+
+    def test_completed_orders_is_a_bare_string(self, tmp_path):
+        """A string is iterable: this used to yield one row per character."""
+        out = self._load(tmp_path, {"updated_at": "2026-07-01T10:00:00+03:00",
+                                    "completed_orders": "#A"})
+        assert out.empty
+
+    def test_timestamp_is_a_list(self, tmp_path):
+        out = self._load(tmp_path, {"updated_at": ["2026-07-01", "2026-07-02"],
+                                    "completed_orders": ["#A"]})
+        assert out.empty
+
+    def test_timestamp_is_a_dict(self, tmp_path):
+        out = self._load(tmp_path, {"updated_at": {"a": 1},
+                                    "completed_orders": ["#A"]})
+        assert out.empty
+
+    def test_non_string_order_numbers_are_dropped(self, tmp_path):
+        out = self._load(tmp_path, {"updated_at": "2026-07-01T10:00:00+03:00",
+                                    "completed_orders": ["#A", None, 7, "#B"]})
+        assert set(out["Order_Number"]) == {"#A", "#B"}
+
+
+class TestUnionToleratesLegacyHistory:
+    def test_history_without_execution_date_is_returned_untouched(self):
+        """analysis._detect_repeated_orders has its own branch for this shape.
+        Unioning here raised KeyError and aborted the analysis instead."""
+        history = pd.DataFrame({"Order_Number": ["#A"]})
+        packed = pd.DataFrame({"Order_Number": ["#B"], "Execution_Date": ["2026-07-01"]})
+
+        out = union_history_with_packed(history, packed)
+        assert list(out.columns) == ["Order_Number"]
+        assert set(out["Order_Number"]) == {"#A"}
+
+    def test_legacy_date_format_does_not_win_earliest_by_string_sort(self):
+        """'27/11/2025' sorts after '2026-07-01' lexicographically but is
+        the earlier date."""
+        history = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["27/11/2025"]})
+        packed = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+
+        out = union_history_with_packed(history, packed)
+        assert out.iloc[0]["Execution_Date"] == "27/11/2025"
+
+
+class TestPackedDateUsesWarehouseLocalDate:
+    def test_after_midnight_local_is_not_shifted_to_yesterday(self, tmp_path):
+        """utc=True turned 01:00 local (+03:00) into the previous day, which
+        flags an order packed this morning as a same-day Repeat."""
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "s", "packing_progress": {"ALL": {
+                "updated_at": "2026-07-02T01:00:00+03:00",
+                "completed_orders": ["#A"],
+            }}}
+        ])
+        out = load_packed_orders(pm, "ALMADERM")
+        assert out.iloc[0]["Execution_Date"] == "2026-07-02"

--- a/tests/test_packed_orders.py
+++ b/tests/test_packed_orders.py
@@ -1,0 +1,194 @@
+import json
+
+import pandas as pd
+
+from shopify_tool.packed_orders import load_packed_orders, union_history_with_packed
+
+
+class _FakeProfileManager:
+    """Minimal stand-in exposing only what load_packed_orders uses."""
+
+    def __init__(self, sessions_root):
+        self._sessions_root = sessions_root
+
+    def get_sessions_root(self):
+        return self._sessions_root
+
+
+def _write_index(tmp_path, client_id, entries):
+    client_dir = tmp_path / f"CLIENT_{client_id}"
+    client_dir.mkdir(parents=True, exist_ok=True)
+    (client_dir / "session_index.json").write_text(
+        json.dumps(entries), encoding="utf-8"
+    )
+    return _FakeProfileManager(tmp_path)
+
+
+class TestLoadPackedOrders:
+    def test_reads_completed_orders_with_packing_date(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-26_2",
+                "packing_progress": {
+                    "ALL_ORDERS": {
+                        "started_at": "2026-07-26T18:25:33+00:00",
+                        "updated_at": "2026-07-28T09:10:00+00:00",
+                        "status": "completed",
+                        "completed_orders": ["#11019512", "#11019513"],
+                    }
+                },
+            }
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+
+        assert list(df.columns) == ["Order_Number", "Execution_Date"]
+        assert dict(zip(df["Order_Number"], df["Execution_Date"])) == {
+            "#11019512": "2026-07-28",
+            "#11019513": "2026-07-28",
+        }
+
+    def test_falls_back_to_started_at_when_no_updated_at(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-26_2",
+                "packing_progress": {
+                    "ALL_ORDERS": {
+                        "started_at": "2026-07-26T18:25:33+00:00",
+                        "status": "completed",
+                        "completed_orders": ["#A"],
+                    }
+                },
+            }
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert df.iloc[0]["Execution_Date"] == "2026-07-26"
+
+    def test_collects_across_sessions_and_packing_lists(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-01_1",
+                "packing_progress": {
+                    "LIST_A": {"updated_at": "2026-07-01T10:00:00+00:00",
+                               "completed_orders": ["#A"]},
+                    "LIST_B": {"updated_at": "2026-07-01T11:00:00+00:00",
+                               "completed_orders": ["#B"]},
+                },
+            },
+            {
+                "session_name": "2026-07-02_1",
+                "packing_progress": {
+                    "LIST_C": {"updated_at": "2026-07-02T10:00:00+00:00",
+                               "completed_orders": ["#C"]},
+                },
+            },
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert set(df["Order_Number"]) == {"#A", "#B", "#C"}
+
+    def test_same_order_packed_twice_keeps_earliest(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "2026-07-05_1", "packing_progress": {
+                "L": {"updated_at": "2026-07-05T10:00:00+00:00",
+                      "completed_orders": ["#A"]}}},
+            {"session_name": "2026-07-01_1", "packing_progress": {
+                "L": {"updated_at": "2026-07-01T10:00:00+00:00",
+                      "completed_orders": ["#A"]}}},
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert len(df) == 1
+        assert df.iloc[0]["Execution_Date"] == "2026-07-01"
+
+    # --- degradation: each of these must return empty, not raise ---
+
+    def test_entry_without_completed_orders_key_is_skipped(self, tmp_path):
+        """The normal case before Task 4 ships -- not an error."""
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {
+                "session_name": "2026-07-26_2",
+                "packing_progress": {
+                    "ALL_ORDERS": {
+                        "started_at": "2026-07-26T18:25:33+00:00",
+                        "status": "in_progress",
+                    }
+                },
+            }
+        ])
+
+        df = load_packed_orders(pm, "ALMADERM")
+        assert df.empty
+        assert list(df.columns) == ["Order_Number", "Execution_Date"]
+
+    def test_entry_without_packing_progress_is_skipped(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "2026-07-26_1", "status": "active"}
+        ])
+        assert load_packed_orders(pm, "ALMADERM").empty
+
+    def test_missing_index_file_returns_empty(self, tmp_path):
+        assert load_packed_orders(_FakeProfileManager(tmp_path), "NOSUCH").empty
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        client_dir = tmp_path / "CLIENT_ALMADERM"
+        client_dir.mkdir(parents=True)
+        (client_dir / "session_index.json").write_text("{not json", encoding="utf-8")
+
+        assert load_packed_orders(_FakeProfileManager(tmp_path), "ALMADERM").empty
+
+    def test_unparseable_timestamp_is_skipped_without_raising(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "s", "packing_progress": {
+                "L": {"updated_at": "not-a-date", "completed_orders": ["#A"]}}},
+        ])
+        assert load_packed_orders(pm, "ALMADERM").empty
+
+    def test_client_id_is_case_insensitive(self, tmp_path):
+        pm = _write_index(tmp_path, "ALMADERM", [
+            {"session_name": "s", "packing_progress": {
+                "L": {"updated_at": "2026-07-01T10:00:00+00:00",
+                      "completed_orders": ["#A"]}}},
+        ])
+        assert not load_packed_orders(pm, "almaderm").empty
+
+
+class TestUnionHistoryWithPacked:
+    def test_order_in_both_sources_keeps_earlier_date(self):
+        history = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-10"]})
+        packed = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+
+        out = union_history_with_packed(history, packed)
+        assert len(out) == 1
+        assert out.iloc[0]["Execution_Date"] == "2026-07-01"
+
+    def test_order_in_both_sources_keeps_earlier_date_when_history_is_earlier(self):
+        history = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+        packed = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-10"]})
+
+        out = union_history_with_packed(history, packed)
+        assert len(out) == 1
+        assert out.iloc[0]["Execution_Date"] == "2026-07-01"
+
+    def test_packed_only_order_is_included(self):
+        history = pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+        packed = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+
+        out = union_history_with_packed(history, packed)
+        assert set(out["Order_Number"]) == {"#A"}
+
+    def test_history_only_order_survives_empty_packed(self):
+        """The no-cliff guarantee: the analysis signal keeps working when
+        Packing Tool has contributed nothing yet."""
+        history = pd.DataFrame({"Order_Number": ["#A"], "Execution_Date": ["2026-07-01"]})
+        packed = pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+
+        out = union_history_with_packed(history, packed)
+        assert dict(zip(out["Order_Number"], out["Execution_Date"])) == {"#A": "2026-07-01"}
+
+    def test_both_empty_returns_empty_with_expected_columns(self):
+        empty = pd.DataFrame(columns=["Order_Number", "Execution_Date"])
+        out = union_history_with_packed(empty, empty)
+        assert out.empty
+        assert list(out.columns) == ["Order_Number", "Execution_Date"]

--- a/tests/test_packed_orders.py
+++ b/tests/test_packed_orders.py
@@ -36,7 +36,14 @@ def _write_sessions(tmp_path, client_id, entries):
 
 
 class TestLoadPackedOrders:
-    def test_reads_completed_orders_with_packing_date(self, tmp_path):
+    def test_a_multi_day_list_dates_its_orders_by_started_at(self, tmp_path):
+        """The double-ship regression.
+
+        One updated_at covers the whole block, so dating by it re-dates
+        orders packed on day 1 to the last day the list was touched. On day
+        2 they read as "packed today", miss the Repeat flag, and get picked
+        and shipped a second time.
+        """
         pm = _write_sessions(tmp_path, "ALMADERM", [
             {
                 "session_name": "2026-07-26_2",
@@ -55,17 +62,17 @@ class TestLoadPackedOrders:
 
         assert list(df.columns) == ["Order_Number", "Execution_Date"]
         assert dict(zip(df["Order_Number"], df["Execution_Date"])) == {
-            "#11019512": "2026-07-28",
-            "#11019513": "2026-07-28",
+            "#11019512": "2026-07-26",
+            "#11019513": "2026-07-26",
         }
 
-    def test_falls_back_to_started_at_when_no_updated_at(self, tmp_path):
+    def test_falls_back_to_updated_at_when_no_started_at(self, tmp_path):
         pm = _write_sessions(tmp_path, "ALMADERM", [
             {
                 "session_name": "2026-07-26_2",
                 "packing_progress": {
                     "ALL_ORDERS": {
-                        "started_at": "2026-07-26T18:25:33+00:00",
+                        "updated_at": "2026-07-26T18:25:33+00:00",
                         "status": "completed",
                         "completed_orders": ["#A"],
                     }
@@ -76,16 +83,16 @@ class TestLoadPackedOrders:
         df = load_packed_orders(pm, "ALMADERM")
         assert df.iloc[0]["Execution_Date"] == "2026-07-26"
 
-    def test_falls_back_to_started_at_when_updated_at_is_unparseable(self, tmp_path):
-        """`updated_at or started_at` on the raw values picks the garbage and
+    def test_falls_back_to_updated_at_when_started_at_is_unparseable(self, tmp_path):
+        """`started_at or updated_at` on the raw values picks the garbage and
         drops the whole block; the fallback has to be per-parse."""
         pm = _write_sessions(tmp_path, "ALMADERM", [
             {
                 "session_name": "2026-07-26_2",
                 "packing_progress": {
                     "ALL_ORDERS": {
-                        "started_at": "2026-07-26T18:25:33+00:00",
-                        "updated_at": "not-a-date",
+                        "started_at": "not-a-date",
+                        "updated_at": "2026-07-26T18:25:33+00:00",
                         "completed_orders": ["#A"],
                     }
                 },

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,9 +1,11 @@
 """Session lifecycle & session_info.json accuracy (part of priority 6: app config)."""
 import json
+import os
 from pathlib import Path
 
 import pytest
 
+from shared.atomic_write import atomic_write_json
 from shopify_tool.session_manager import SessionManager, SessionManagerError
 
 
@@ -196,6 +198,44 @@ class TestSessionIndex:
         entries = json.loads(index_path.read_text())
         assert len(entries) == 2
 
+    def test_another_tools_write_to_a_session_is_picked_up(self, session_manager):
+        """Packing Tool writes session_info.json and nothing else. The count
+        is unchanged, so a count-only staleness check served the stale entry
+        forever -- silently."""
+        session_path = Path(session_manager.create_session("M"))
+        client_sessions_dir = session_path.parent
+
+        info = json.loads((session_path / "session_info.json").read_text())
+        info["packing_progress"] = {"ALL": {"completed_orders": ["#A"]}}
+        atomic_write_json(session_path / "session_info.json", info)
+        # The index was written before that; pin the ordering so the test
+        # doesn't depend on filesystem timestamp granularity.
+        index_path = client_sessions_dir / SessionManager.INDEX_FILENAME
+        stamp = session_path.stat().st_mtime - 10
+        os.utime(index_path, (stamp, stamp))
+
+        sessions = session_manager.list_client_sessions("M")
+        assert sessions[0]["packing_progress"] == {"ALL": {"completed_orders": ["#A"]}}
+
+    def test_own_writes_do_not_trigger_a_rebuild(self, session_manager):
+        """The whole point of the index is that the UI doesn't walk the
+        session tree. Every writer here updates the index *after* the
+        session_info.json write it mirrors, so the index stays newer than
+        the directory and the mtime check must stay quiet."""
+        session_manager.create_session("M")
+        session_path = session_manager.create_session("M")
+        session_manager.update_session_status(session_path, "completed")
+        session_manager.update_session_info(session_path, {"comments": "hi"})
+
+        scans = []
+        original_scan = session_manager._scan_sessions
+        session_manager._scan_sessions = lambda d: scans.append(d) or original_scan(d)
+
+        for _ in range(3):
+            session_manager.list_client_sessions("M")
+
+        assert scans == []
+
     def test_rebuild_index_scans_directory_and_writes_index(self, session_manager):
         session_path = Path(session_manager.create_session("M"))
         index_path = session_path.parent / SessionManager.INDEX_FILENAME
@@ -208,10 +248,10 @@ class TestSessionIndex:
     def test_rebuild_holds_index_lock_across_scan_and_write(self, session_manager):
         """A rebuild that only locks the write (not the scan) can capture a
         stale snapshot and then overwrite a concurrent _upsert_index_entry()
-        write with it once the lock is finally taken -- the directory-count
-        staleness guard can't catch that, since an existing session's info
-        changing doesn't change the count. Proven directly: while the scan is
-        in flight, a second lock attempt on the same file must not succeed.
+        write with it once the lock is finally taken -- and the loser's data
+        is gone until something else marks the index stale again. Proven
+        directly: while the scan is in flight, a second lock attempt on the
+        same file must not succeed.
         """
         import fcntl
         import threading


### PR DESCRIPTION
## Summary

Roadmap item: *"Repeat detection: check Packing Tool's processed orders instead of a re-run flag."*

Brainstorming found the item's premise was half wrong. The reported symptom — a repeat flag disappearing on re-analysis — was **not** caused by a fragile re-run flag. It was a one-word bug in this repo. So this ships three things:

1. **A live data-loss fix** (Task 1). Independent of everything else, and losing data on every analysis run today.
2. **Union semantics for repeat detection** (Tasks 2–4). An order is a repeat if it was seen ≥ N days ago in *either* this repo's analysis history *or* Packing Tool's completed orders.
3. **An honest index staleness check** — the transport that makes (2) actually arrive. Was the open design decision on this PR; resolved as **option B** below.

Producer PR (Packing Tool): **https://github.com/cognitiveghost/packing-tool/pull/160** — the other half of the cross-repo change. It needs no changes for option B.

### The bug (Task 1)

`_save_results_and_reports` merged each run's newly-fulfilled orders into `fulfillment_history.csv` with:

```python
pd.concat([history_df, newly_fulfilled]).drop_duplicates(subset=["Order_Number"], keep="last")
```

`newly_fulfilled` is concatenated *after* history and carries **today's** date. So `keep="last"` overwrote every still-Fulfillable order's **original** `Execution_Date` with today, on every single run — permanently, because that CSV is the only record of when an order was first fulfilled. The order's "Repeat" flag silently cleared itself along with it.

One word: `keep="first"`. Extracted into `_merge_fulfillment_history()` because the merge was buried in a 13-argument I/O function with no test seam.

**This does not restore what is already gone.** `fulfillment_history.csv` has lost original fulfilment dates wherever an order was re-analyzed before this fix. Recovering them would mean mining dates out of old session directories — not queued, ask before doing it.

### Union semantics (Tasks 2–4)

- **`shopify_tool/packed_orders.py`** (new): `load_packed_orders()` reads the order numbers Packing Tool completed; `union_history_with_packed()` combines them with analysis history, **earliest date per order wins** (an order is a repeat if it was seen long enough ago in either source, so the earliest sighting is the one that decides).
- **`run_full_analysis`** builds `detection_history_df` and passes it to `_run_analysis_and_rules` **only**. `_save_results_and_reports` still gets the plain `history_df` — the union is a detection-time view and must never be written back into `fulfillment_history.csv`, which stays this repo's own record of what *it* analyzed.
- `_detect_repeated_orders` is **untouched**. It already takes an `[Order_Number, Execution_Date]` frame, so the union needs no new parameter and no second code path. `tests/test_analysis.py::TestRepeatDetection` passes unmodified, which is the proof the analysis path didn't shift.

No new file format was invented: Packing Tool already writes a `packing_progress` block into the session's `session_info.json`. The change is to carry completed order numbers in that same block.

## The transport — was blocking, resolved as option B

Code review found that the packing signal would **normally never arrive**, silently:

`session_index.json` is written only by this repo's own writes (`SessionManager._upsert_index_entry`), and the only other refresh was `_rebuild_index`, triggered from `list_client_sessions` **solely when the session directory count ≠ the index entry count**. Packing Tool writing `completed_orders` into an existing session's `session_info.json` triggers neither: it isn't a write by this repo, and it doesn't change the directory count. The feature would have read an empty `packing_progress` forever, with no error and no warning.

Three options were on the table; **B was chosen** — make this repo's staleness check honest, rather than teaching another repo to write this repo's private cache (A) or bounding the read to the N most recent session directories (C). B is the root-cause fix and repairs a whole *class* of bug: before it, **no** external writer's changes were visible.

### What B does

`SessionManager._index_is_stale()` now rebuilds when **any session directory's mtime is newer than the index**, in addition to the count check. `session_info.json` is written temp-file + rename (`shared.atomic_write` — both repos use it), so an external write bumps its session directory's mtime. It uses `os.scandir`, not `iterdir`: on Windows the directory listing already carries the timestamps, so the mtimes cost no extra round trip on the share.

**The regression risk B carries is that `list_client_sessions` feeds the UI, and more frequent rebuilds would undo the responsiveness work the index exists for. It doesn't rebuild more often**, and that is pinned by a test rather than argued: every writer in `SessionManager` updates the index *after* the `session_info.json` write it mirrors, so this repo's own writes always leave the index newer than the directory. `test_own_writes_do_not_trigger_a_rebuild` creates, updates and re-reads sessions and asserts `_scan_sessions` is never called.

`packed_orders.py` now reads through `list_client_sessions()` instead of reading `session_index.json` directly. This is load-bearing, not stylistic: that method is the only path that runs the staleness check, so a raw index read would have bypassed the fix and stayed empty forever. It also removes `packed_orders.py`'s duplicated `INDEX_FILENAME` and `CLIENT_<id>` convention — `list_client_sessions` is now the only reader of the index in the repo.

The one assumption B makes is that the PCs writing to the share agree on the clock. Skew only costs extra rebuilds (i.e. the pre-index behaviour), never wrong data, and clears itself once the stamps pass; marked in-code with the upgrade path (a per-entry mtime recorded in the index) if it ever shows up on the UNC share.

### The tests that prove it

`tests/test_packed_orders.py` hand-wrote `session_index.json` fixtures — assuming exactly the link that was broken, which is why the suite was green while the feature was unreachable. They now write **real session directories**, so they exercise the transport instead of asserting it.

Both halves are verified necessary by reverting each one alone:

- With the old count-only check: `test_packed_orders_written_after_the_index_are_still_seen` fails (`assert set() == {'#A'}`) — same session, same count, stale entry served.
- With the old raw index read: that test and `test_malformed_index_is_rebuilt_from_the_session_directories` both fail.
- With the old `session_manager`: `test_another_tools_write_to_a_session_is_picked_up` fails with `KeyError: 'packing_progress'`.

## What code review changed

A fresh-context review found three ways malformed data from the *other tool* escaped `packed_orders.py`'s "never raises" contract and aborted the entire analysis through `run_full_analysis`'s outer handler — the exact opposite of the module's stated purpose. All fixed in `07d7c92`, and **all 8 new tests fail against the previous implementation**:

- **The `try` covered only the file read.** The row-building loop and `_to_date` — the parts that actually touch another tool's values — were outside it. A non-list `completed_orders` raised `TypeError`; a list- or dict-valued timestamp raised `ValueError`. The guard now wraps the whole body; a broad `except` is correct here by contract.
- **A bare-string `completed_orders` yielded one row per character.** Now checked with `isinstance(..., list)`.
- **`union_history_with_packed` raised `KeyError` on a legacy history file** with no `Execution_Date` — the exact shape `_detect_repeated_orders` has an explicit backward-compatibility branch for (`analysis.py:817-822`). The union sat *upstream* of that branch and killed the run before it could be reached. It now returns `history_df` untouched.
- **The union sorted `Execution_Date` as strings**, so a legacy `"27/11/2025"` sorted after `"2026-07-01"` and wrongly won "earliest". Sorts on parsed dates now.
- **`_to_date` dropped `utc=True`.** The stamp carries the warehouse's local offset, and `_detect_repeated_orders` compares against a naive local `datetime.now()`. Normalising to UTC dated an order packed at 01:00 local (+03:00) to the *previous* day — flagging a fresh order as a repeat on the same working day, with the default 1-day window.

**Task 3's central invariant had no test at all.** Nothing would have failed if someone passed `detection_history_df` to `_save_results_and_reports` — packed orders would start leaking into `fulfillment_history.csv` and the suite would stay green. Two tests now pin it, verified by injecting the leak and watching both fail. They use real CSV inputs on purpose: `None` file paths put `_save_results_and_reports` in "test mode", which skips the history write-back entirely and would have made the test vacuous.

## Tests

**Gate: `758 passed`** (727 before this branch, 745 after implementation, 755 after review, +3 from the transport fix). `ruff check . --exclude shared` clean.

- `tests/test_core.py` — 3 tests pinning the `keep="first"` merge, 2 pinning the detection-only separation.
- `tests/test_packed_orders.py` — 24 tests: reader behaviour, union semantics, the malformed-data contract, the local-date handling, and the stale-index transport.
- `tests/test_session_manager.py` — 2 new: an external tool's write is picked up, and this repo's own writes still cause no rebuild.

## Known, deliberately not fixed here

- `session_index.json` now grows with **order volume**, not just session count — every completed session adds its full `completed_orders` list, and `_upsert_index_entry` rewrites the whole index on every write. Order of ~1 MB/client/year at one 200-order session per day. Worth knowing for the archive/pruning roadmap item.
- **Version string not bumped.** `gui_main.py:11`, `shopify_tool/__init__.py:7` and `README.md:3` move together at release.
- The design and plan docs in `docs/superpowers/` should be deleted after merge, as with previous items.
